### PR TITLE
support Android 4.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
     buildToolsVersion "24.0.1"
     defaultConfig {
         applicationId "com.kamron.pogoiv"
-        minSdkVersion 21
+        minSdkVersion 19
         targetSdkVersion 24
         versionCode 11
         versionName "1.3.0"


### PR DESCRIPTION
I think there is no reasin supporting lower than 4.4 as pokémon go itself requires android 4.4
https://github.com/farkam135/GoIV/issues/46