### PR TITLE
Revert "Added resources across languages for future translations."

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -155,11 +155,10 @@
     <string name="welcome_message">Willkommen bei GoIV!\n\nAnleitung:\n1. Geben Sie Ihr Trainer Level unter ein\n2. Drücken Sie die Start-Taste und akzeptieren Sie die Berechtigungen\n3. Schauen Sie sich Ihr Pokémon in \'Pokémon Go\' an\n4. Tippen Sie auf die IV Taste, um das Pokémon zu scannen\n5. Passen Sie die gescannten Daten bei Bedarf an\n6. Überprüfen Sie die IV!</string>
     <string name="goiv_is_open_source">GoIV ist open source!\ngithub.com/farkam135/GoIV\nreddit.com/r/GoIV</string>
     <string name="cancel">Abbrechen</string>
-    <string name="trainer_level">Trainer-Level</string>
-
     <string name="check_iv">Berechne IV</string>
     <string name="cp">WP</string>
     <string name="hp">KP</string>
     <string name="pokemon_name">Pokémon Name:</string>
+    <string name="trainer_level">Trainer-Level</string>
     <string name="use_the_slider_below_to_align_the_arc">Verwenden Sie den Schieberegler um den roten Punkt ausrichten</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -151,15 +151,4 @@
     <string name="pokemon149">Dracolosse</string>
     <string name="pokemon150">Mewtwo</string>
     <string name="pokemon151">Mew</string>
-
-    <string name="welcome_message">Welcome to GoIV!\n\nInstructions:\n1. Enter your trainer level below\n2. Press the start button and allow screen capture\n3. Open up your desired Pokémon in \'Pokémon Go\'\n4. Tap the IV Button to scan the Pokémon\n5. Adjust the scanned data if necessary\n6. Check IV!</string>
-    <string name="goiv_is_open_source">GoIV is open source!\ngithub.com/farkam135/GoIV\nreddit.com/r/GoIV</string>
-    <string name="trainer_level">Trainer Level</string>
-
-    <string name="pokemon_name">Pokémon name:</string>
-    <string name="cp">CP</string>
-    <string name="hp">HP</string>
-    <string name="use_the_slider_below_to_align_the_arc">Use the slider below to align the arc</string>
-    <string name="cancel">Cancel</string>
-    <string name="check_iv">Check IV</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -151,15 +151,4 @@
     <string name="pokemon149">カイリュー</string>
     <string name="pokemon150">ミュウツー</string>
     <string name="pokemon151">ミュウ</string>
-
-    <string name="welcome_message">Welcome to GoIV!\n\nInstructions:\n1. Enter your trainer level below\n2. Press the start button and allow screen capture\n3. Open up your desired Pokémon in \'Pokémon Go\'\n4. Tap the IV Button to scan the Pokémon\n5. Adjust the scanned data if necessary\n6. Check IV!</string>
-    <string name="goiv_is_open_source">GoIV is open source!\ngithub.com/farkam135/GoIV\nreddit.com/r/GoIV</string>
-    <string name="trainer_level">Trainer Level</string>
-
-    <string name="pokemon_name">Pokémon name:</string>
-    <string name="cp">CP</string>
-    <string name="hp">HP</string>
-    <string name="use_the_slider_below_to_align_the_arc">Use the slider below to align the arc</string>
-    <string name="cancel">Cancel</string>
-    <string name="check_iv">Check IV</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1,4 +1,7 @@
 <resources>
+    <string name="drawer_open">Abrir gaveta de navegação</string>
+    <string name="drawer_close">Fechar gaveta de navegação</string>
+
     <string name="pokemon001">Bulbasaur</string>
     <string name="pokemon002">Ivysaur</string>
     <string name="pokemon003">Venusaur</string>
@@ -154,11 +157,4 @@
     <string name="welcome_message">Bem-vindo ao GoIV!\n\nInstruções:\n1. Insere o nível de treinador em baixo\n2. Carrega em START e permite a captura de ecrã\n3. Abre o teu Pokemon na aplicação \'Pokémon Go\'\n4. Carrega no botão IV para iniciar o exame\n5. Ajusta os dados se necessário\n6. Observa o IV!</string>
     <string name="goiv_is_open_source">GoIV é agora em código aberto!\ngithub.com/farkam135/GoIV\nreddit.com/r/GoIV</string>
     <string name="trainer_level">Nível de Treinador</string>
-
-    <string name="pokemon_name">Pokémon name:</string>
-    <string name="cp">CP</string>
-    <string name="hp">HP</string>
-    <string name="use_the_slider_below_to_align_the_arc">Use the slider below to align the arc</string>
-    <string name="cancel">Cancel</string>
-    <string name="check_iv">Check IV</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -151,15 +151,4 @@
     <string name="pokemon149">Драгонайт</string>
     <string name="pokemon150">Мьюту</string>
     <string name="pokemon151">Мью</string>
-
-    <string name="welcome_message">Welcome to GoIV!\n\nInstructions:\n1. Enter your trainer level below\n2. Press the start button and allow screen capture\n3. Open up your desired Pokémon in \'Pokémon Go\'\n4. Tap the IV Button to scan the Pokémon\n5. Adjust the scanned data if necessary\n6. Check IV!</string>
-    <string name="goiv_is_open_source">GoIV is open source!\ngithub.com/farkam135/GoIV\nreddit.com/r/GoIV</string>
-    <string name="trainer_level">Trainer Level</string>
-
-    <string name="pokemon_name">Pokémon name:</string>
-    <string name="cp">CP</string>
-    <string name="hp">HP</string>
-    <string name="use_the_slider_below_to_align_the_arc">Use the slider below to align the arc</string>
-    <string name="cancel">Cancel</string>
-    <string name="check_iv">Check IV</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -151,15 +151,4 @@
     <string name="pokemon149">快龙</string>
     <string name="pokemon150">超梦</string>
     <string name="pokemon151">梦幻</string>
-
-    <string name="welcome_message">Welcome to GoIV!\n\nInstructions:\n1. Enter your trainer level below\n2. Press the start button and allow screen capture\n3. Open up your desired Pokémon in \'Pokémon Go\'\n4. Tap the IV Button to scan the Pokémon\n5. Adjust the scanned data if necessary\n6. Check IV!</string>
-    <string name="goiv_is_open_source">GoIV is open source!\ngithub.com/farkam135/GoIV\nreddit.com/r/GoIV</string>
-    <string name="trainer_level">Trainer Level</string>
-
-    <string name="pokemon_name">Pokémon name:</string>
-    <string name="cp">CP</string>
-    <string name="hp">HP</string>
-    <string name="use_the_slider_below_to_align_the_arc">Use the slider below to align the arc</string>
-    <string name="cancel">Cancel</string>
-    <string name="check_iv">Check IV</string>
 </resources>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -151,15 +151,4 @@
     <string name="pokemon149">啟暴龍</string>
     <string name="pokemon150">超夢夢</string>
     <string name="pokemon151">夢夢</string>
-
-    <string name="welcome_message">Welcome to GoIV!\n\nInstructions:\n1. Enter your trainer level below\n2. Press the start button and allow screen capture\n3. Open up your desired Pokémon in \'Pokémon Go\'\n4. Tap the IV Button to scan the Pokémon\n5. Adjust the scanned data if necessary\n6. Check IV!</string>
-    <string name="goiv_is_open_source">GoIV is open source!\ngithub.com/farkam135/GoIV\nreddit.com/r/GoIV</string>
-    <string name="trainer_level">Trainer Level</string>
-
-    <string name="pokemon_name">Pokémon name:</string>
-    <string name="cp">CP</string>
-    <string name="hp">HP</string>
-    <string name="use_the_slider_below_to_align_the_arc">Use the slider below to align the arc</string>
-    <string name="cancel">Cancel</string>
-    <string name="check_iv">Check IV</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -151,15 +151,4 @@
     <string name="pokemon149">快龍</string>
     <string name="pokemon150">超夢</string>
     <string name="pokemon151">夢幻</string>
-
-    <string name="welcome_message">Welcome to GoIV!\n\nInstructions:\n1. Enter your trainer level below\n2. Press the start button and allow screen capture\n3. Open up your desired Pokémon in \'Pokémon Go\'\n4. Tap the IV Button to scan the Pokémon\n5. Adjust the scanned data if necessary\n6. Check IV!</string>
-    <string name="goiv_is_open_source">GoIV is open source!\ngithub.com/farkam135/GoIV\nreddit.com/r/GoIV</string>
-    <string name="trainer_level">Trainer Level</string>
-
-    <string name="pokemon_name">Pokémon name:</string>
-    <string name="cp">CP</string>
-    <string name="hp">HP</string>
-    <string name="use_the_slider_below_to_align_the_arc">Use the slider below to align the arc</string>
-    <string name="cancel">Cancel</string>
-    <string name="check_iv">Check IV</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <resources>
     <string name="app_name" translatable="false">GoIV</string>
+    <string name="drawer_open">Open navigation drawer</string>
+    <string name="drawer_close">Close navigation drawer</string>
 
     <string name="pokemon001">Bulbasaur</string>
     <string name="pokemon002">Ivysaur</string>


### PR DESCRIPTION
This reverts commit [88e93a959b991cd841e086e4e97035ee416830c1](https://github.com/farkam135/GoIV/commit/88e93a959b991cd841e086e4e97035ee416830c1).

> please revert this. It is unnecessary, Android pulls the information from string.xml if e.g. strings-de.xml does not contain the element.
> 
> Also there is a nice translation view where you can see all elements in every language.
> http://tools.android.com/_/rsrc/1408658785758/recent/androidstudio087released/translations4.png