### PR TITLE
Improve efficiency of evolution tracking

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/PokeInfoCalculator.java
@@ -37,37 +37,19 @@ public class PokeInfoCalculator {
         pokedex = new ArrayList<>();
         int pokeListSize = names.length;
         for (int i = 0; i <= pokeListSize - 1; i++) {
-            pokedex.add(new Pokemon(names[i], i, attack[i], defense[i], stamina[i], devolution[i]));
+            Pokemon p = new Pokemon(names[i], i, attack[i], defense[i], stamina[i], devolution[i]);
+            /* Add the pokemon to the devolution's evolution list */
+            if (devolution[i] != -1) {
+                Pokemon devo = pokedex.get(devolution[i]);
+                devo.evolutions.add(p);
+                sortPokedex(devo.evolutions);
+            }
+            pokedex.add(p);
         }
 
         sortPokedex(pokedex);
-        setEvolutions(pokedex);
-
     }
 
-
-    /**
-     * Goes through all pokemon in the pokemon list, checks what devlutions they have registered,
-     * and uses that information to populate each pokemon object evolutions list.
-     * <p/>
-     * So for example, Vaporeon can devolve into eevee, so eevee get vaporeon added to its evolution list. (and jolteon, and flareon)
-     *
-     * @param pokedex
-     */
-    private void setEvolutions(ArrayList<Pokemon> pokedex) {
-        int devolNumber = -1;
-        for (int i = 0; i <= pokedex.size() - 1; i++) { //for each pokemon get devolution number
-            devolNumber = pokedex.get(i).devolNumber;
-            if (devolNumber >= 0) { //if devolution is given, index >= 0
-                for (int j = 0; j <= pokedex.size() - 1; j++) { //check for devolution index in all pokemon
-                    if (pokedex.get(j).number == devolNumber) {
-                        pokedex.get(j).evolutions.add(i); // if found add sorted index of evolution (i) to devolution and break
-                        break;
-                    }
-                }
-            }
-        }
-    }
 
     /**
      * Sorts the pokemon in the pokedex by alphabetical order
@@ -184,7 +166,7 @@ public class PokeInfoCalculator {
      * <p/>
      * Returns a string on the form of "\n CP at lvl X: A - B" where x is the pokemon level, A is minCP and B is maxCP
      *
-     * @param pokemonIndex the index of the pokemon species within the pokemon list (sorted)
+     * @param pokemon the index of the pokemon species within the pokemon list (sorted)
      * @param lowAttack    attack IV of the lowest combination
      * @param lowDefense   defense IV of the lowest combination
      * @param lowStamina   stamina IV of the lowest combination
@@ -194,10 +176,10 @@ public class PokeInfoCalculator {
      * @param level        pokemon level for CP calculation
      * @return String containing the CP range including the specified level.
      */
-    public CPRange getCpRangeAtLevel(int pokemonIndex, int lowAttack, int lowDefense, int lowStamina, int highAttack, int highDefense, int highStamina, double level) {
-        int baseAttack = pokedex.get(pokemonIndex).baseAttack;
-        int baseDefense = pokedex.get(pokemonIndex).baseDefense;
-        int baseStamina = pokedex.get(pokemonIndex).baseStamina;
+    public CPRange getCpRangeAtLevel(Pokemon pokemon, int lowAttack, int lowDefense, int lowStamina, int highAttack, int highDefense, int highStamina, double level) {
+        int baseAttack = pokemon.baseAttack;
+        int baseDefense = pokemon.baseDefense;
+        int baseStamina = pokemon.baseStamina;
         double lvlScalar = Data.CpM[(int) (level * 2 - 2)];
         int cpMin = (int) Math.floor((baseAttack + lowAttack) * Math.sqrt(baseDefense + lowDefense) * Math.sqrt(baseStamina + lowStamina) * Math.pow(lvlScalar, 2) * 0.1);
         int cpMax = (int) Math.floor((baseAttack + highAttack) * Math.sqrt(baseDefense + highDefense) * Math.sqrt(baseStamina + highStamina) * Math.pow(lvlScalar, 2) * 0.1);

--- a/app/src/main/java/com/kamron/pogoiv/Pokemon.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokemon.java
@@ -13,7 +13,7 @@ public class Pokemon {
     public int baseDefense;
     public int baseStamina;
     public int devolNumber; //indexnumber in ressources of devolution, pokedexnumber - 1
-    public ArrayList<Integer> evolutions; //evolutions sorted collection index, populated after sort
+    public ArrayList<Pokemon> evolutions; //evolutions sorted collection index, populated after sort
 
     public Pokemon(String name, int number, int baseAttack, int baseDefense, int baseStamina, int devolNumber) {
         this.name = name;
@@ -22,7 +22,7 @@ public class Pokemon {
         this.baseDefense = baseDefense;
         this.baseStamina = baseStamina;
         this.devolNumber = devolNumber;
-        this.evolutions = new ArrayList<Integer>();
+        this.evolutions = new ArrayList<Pokemon>();
     }
 
     @Override

--- a/app/src/main/java/com/kamron/pogoiv/pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokefly.java
@@ -440,7 +440,8 @@ public class pokefly extends Service {
      */
     private String getIVText() {
         int selectedPokemon = pokemonList.getSelectedItemPosition();
-        String returnVal = String.format(getString(R.string.ivtext_title), estimatedPokemonLevel, pokeCalculator.get(selectedPokemon).name);
+        Pokemon pokemon = pokeCalculator.get(selectedPokemon);
+        String returnVal = String.format(getString(R.string.ivtext_title), estimatedPokemonLevel, pokemon.name);
         IVScanResult ivScanResult = pokeCalculator.getIVPossibilities(selectedPokemon,estimatedPokemonLevel, pokemonHP, pokemonCP);
 
         int counter = 0;
@@ -464,33 +465,27 @@ public class pokefly extends Service {
 
             // for trainer level cp cap, if estimatedPokemonLevel is at cap do not print
             if (estimatedPokemonLevel < trainerLevel + 1.5) {
-
-
-                CPRange range = pokeCalculator.getCpRangeAtLevel(pokemonList.getSelectedItemPosition(), ivScanResult.lowAttack, ivScanResult.lowDefense, ivScanResult.lowStamina, ivScanResult.highAttack, ivScanResult.highDefense, ivScanResult.highStamina, Math.min(trainerLevel + 1.5, 40.0));
+                CPRange range = pokeCalculator.getCpRangeAtLevel(pokemon, ivScanResult.lowAttack, ivScanResult.lowDefense, ivScanResult.lowStamina, ivScanResult.highAttack, ivScanResult.highDefense, ivScanResult.highStamina, Math.min(trainerLevel + 1.5, 40.0));
                 returnVal += "\n" + String.format(getString(R.string.ivtext_cp_lvl), range.level, range.low, range.high);
                 returnVal += "\n" + String.format(getString(R.string.ivtext_max_lvl_cost), trainerLevel + 1.5);
                 UpgradeCost cost = pokeCalculator.getMaxReqText(trainerLevel, estimatedPokemonLevel);
                 returnVal += "\n" + String.format( getString(R.string.ivtext_max_lvl_cost2), cost.candy, NumberFormat.getInstance().format(cost.dust) + "\n");
             }
 
-            ArrayList<Integer> evolutions = pokeCalculator.get(pokemonList.getSelectedItemPosition()).evolutions;
+            ArrayList<Pokemon> evolutions = pokemon.evolutions;
             //for each evolution of next stage (example, eevees three evolutions jolteon, vaporeon and flareon)
-            for(int i = evolutions.size()-1; i>=0; i--){
-                pokemonName = pokeCalculator.get(evolutions.get(i)).name;
+            for(Pokemon evolution: evolutions){
+                pokemonName = evolution.name;
                 returnVal += "\n" + String.format(getString(R.string.ivtext_evolve), pokemonName);
 
-                CPRange range = pokeCalculator.getCpRangeAtLevel(evolutions.get(i), ivScanResult.lowAttack, ivScanResult.lowDefense, ivScanResult.lowStamina, ivScanResult.highAttack, ivScanResult.highDefense, ivScanResult.highStamina, Math.min(trainerLevel + 1.5, 40.0));
+                CPRange range = pokeCalculator.getCpRangeAtLevel(evolution, ivScanResult.lowAttack, ivScanResult.lowDefense, ivScanResult.lowStamina, ivScanResult.highAttack, ivScanResult.highDefense, ivScanResult.highStamina, Math.min(trainerLevel + 1.5, 40.0));
                 returnVal +=  String.format(getString(R.string.ivtext_cp_lvl), range.level, range.low, range.high);
                 //for following stage evolution (example, dratini - dragonair - dragonite)
-                int nextEvolutionNbr = evolutions.get(i);
                 //if the current evolution has another evolution calculate its range and break
-                if (pokeCalculator.get(nextEvolutionNbr).evolutions.size() != 0) {
-                    int nextEvoStage = pokeCalculator.get(nextEvolutionNbr).evolutions.get(0);
-                    pokemonName = pokeCalculator.get(nextEvoStage).name;
+                for(Pokemon nextEvo: evolution.evolutions) {
+                    pokemonName = nextEvo.name;
                     returnVal += "\n" + String.format(getString(R.string.ivtext_evolve_further), pokemonName);
-
-
-                    CPRange range2 = pokeCalculator.getCpRangeAtLevel(nextEvoStage, ivScanResult.lowAttack, ivScanResult.lowDefense, ivScanResult.lowStamina, ivScanResult.highAttack, ivScanResult.highDefense, ivScanResult.highStamina, Math.min(trainerLevel + 1.5, 40.0));
+                    CPRange range2 = pokeCalculator.getCpRangeAtLevel(nextEvo, ivScanResult.lowAttack, ivScanResult.lowDefense, ivScanResult.lowStamina, ivScanResult.highAttack, ivScanResult.highDefense, ivScanResult.highStamina, Math.min(trainerLevel + 1.5, 40.0));
                     returnVal += "\n" + String.format(getString(R.string.ivtext_cp_lvl), range2.level, range2.low, range2.high);
                     break;
                 }


### PR DESCRIPTION
Associating a pokemon and its evolutions was using an O(n^2) algorithm.
For 151 pokemon, that's 22801 iterations! Changing it into O(n)
algorithm. So, the pokemon list population should take less than 1% of
the previous time.

Since every evolution comes after the pokemon in the pokedex, we can
immediately associate the evolved pokemon to its devolution. To do this
the evolution list had to be converted into a Pokemon list. This has
some cascading code change impact, but those make the code more readable
and efficient too (removes a lot of unnecessary int to Pokemon lookups).