### PR TITLE
added offline flavour that doesn't use the internet permission

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,6 +40,14 @@ android {
             }
         }
     }
+
+    productFlavors {
+        offline {
+            ext.enableCrashlytics = false
+        }
+
+        online {}
+    }
 }
 
 dependencies {
@@ -47,13 +55,17 @@ dependencies {
     compile 'com.android.support:appcompat-v7:24.0.0'
     compile 'com.android.support.constraint:constraint-layout:1.0.0-alpha1'
     compile 'com.rmtheis:tess-two:6.0.3'
+    compile 'com.jakewharton.timber:timber:4.3.0'
     compile 'com.jakewharton:butterknife:8.1.0'
     apt 'com.jakewharton:butterknife-compiler:8.1.0'
+
+    // only include crashlytics in the online build
+    onlineCompile('com.crashlytics.sdk.android:crashlytics:2.6.2@aar') {
+        transitive = true;
+    }
+
     testCompile 'junit:junit:4.12'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
     androidTestCompile 'com.android.support.test:runner:0.5'
     androidTestCompile 'com.android.support:support-annotations:24.0.0'
-    compile('com.crashlytics.sdk.android:crashlytics:2.6.2@aar') {
-        transitive = true;
-    }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.kamron.pogoiv" >
+          package="com.kamron.pogoiv">
 
-    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
@@ -37,7 +36,9 @@
         <screen android:screenSize="xlarge" android:screenDensity="480"  />
         <screen android:screenSize="xlarge" android:screenDensity="560"  />
     </compatible-screens>
+
     <application
+        android:name=".PoGoApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -49,8 +49,6 @@ import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.crashlytics.android.Crashlytics;
-import com.crashlytics.android.core.CrashlyticsCore;
 import com.googlecode.tesseract.android.TessBaseAPI;
 
 import java.io.File;
@@ -62,9 +60,8 @@ import java.nio.ByteBuffer;
 import java.util.Locale;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.stream.IntStream;
 
-import io.fabric.sdk.android.Fabric;
+import timber.log.Timber;
 
 
 public class MainActivity extends AppCompatActivity {
@@ -114,14 +111,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        // Set up Crashlytics, disabled for debug builds
-        Crashlytics crashlyticsKit = new Crashlytics.Builder()
-                .core(new CrashlyticsCore.Builder()
-                .disabled(BuildConfig.DEBUG).build())
-                .build();
-
-        // Initialize Fabric with the debug-disabled crashlytics.
-        Fabric.with(this, crashlyticsKit);
+        Timber.tag(TAG);
 
         setContentView(R.layout.activity_main);
 
@@ -356,8 +346,8 @@ public class MainActivity extends AppCompatActivity {
         try {
             return getPackageManager().getPackageInfo(getPackageName(), 0).versionName;
         } catch (PackageManager.NameNotFoundException e) {
-            Crashlytics.log("Exception thrown while getting version name");
-            Crashlytics.logException(e);
+            Timber.e("Exception thrown while getting version name");
+            Timber.e(e);
             Log.e(TAG, "Error while getting version name", e);
         }
         return "Error while getting version name";
@@ -496,10 +486,9 @@ public class MainActivity extends AppCompatActivity {
         Image image = null;
         try {
             image = mImageReader.acquireLatestImage();
-        } catch (Exception e) {
-            Crashlytics.log("Error thrown in takeScreenshot() - acquireLatestImage()");
-            Crashlytics.logException(e);
-            Log.e(TAG, "Error while Scanning!", e);
+        } catch (Exception exception) {
+            Timber.e("Error thrown in takeScreenshot() - acquireLatestImage()");
+            Timber.e(exception);
             Toast.makeText(MainActivity.this, "Error Scanning! Please try again later!", Toast.LENGTH_SHORT).show();
         }
 
@@ -516,9 +505,9 @@ public class MainActivity extends AppCompatActivity {
                 Bitmap bmp = getBitmap(buffer, pixelStride, rowPadding);
                 scanPokemon(bmp,"");
                 //SaveImage(bmp,"Search");
-            } catch (Exception e) {
-                Crashlytics.log("Exception thrown in takeScreenshot() - when creating bitmap");
-                Crashlytics.logException(e);
+            } catch (Exception exception) {
+                Timber.e("Exception thrown in takeScreenshot() - when creating bitmap");
+                Timber.e(exception);
                 image.close();
             }
 
@@ -736,10 +725,10 @@ public class MainActivity extends AppCompatActivity {
             out.flush();
             out.close();
 
-        } catch (Exception e) {
-            Crashlytics.log("Exception thrown in saveImage()");
-            Crashlytics.logException(e);
-            Log.e(TAG, "Error while saving the image.", e);
+        } catch (Exception exception) {
+            Timber.e("Exception thrown in saveImage()");
+            Timber.e(exception);
+            Log.e(TAG, "Error while saving the image.", exception);
         }
     }
 
@@ -851,10 +840,10 @@ public class MainActivity extends AppCompatActivity {
 
         try {
             files = assetManager.list(fromAssetPath);
-        } catch (IOException e) {
-            Crashlytics.log("Exception thrown in copyAssetFolder()");
-            Crashlytics.logException(e);
-            Log.e(TAG, "Error while loading filenames.", e);
+        } catch (IOException exception) {
+            Timber.e("Exception thrown in copyAssetFolder()");
+            Timber.e(exception);
+            Log.e(TAG, "Error while loading filenames.", exception);
         }
         new File(toPath).mkdirs();
         boolean res = true;
@@ -878,10 +867,10 @@ public class MainActivity extends AppCompatActivity {
             out.flush();
             out.close();
             return true;
-        } catch (IOException e) {
-            Crashlytics.log("Exception thrown in copyAsset()");
-            Crashlytics.logException(e);
-            Log.e(TAG, "Error while copying assets.", e);
+        } catch (IOException exception) {
+            Timber.e("Exception thrown in copyAsset()");
+            Timber.e(exception);
+            Log.e(TAG, "Error while copying assets.", exception);
             return false;
         }
     }

--- a/app/src/main/java/com/kamron/pogoiv/PoGoApplication.java
+++ b/app/src/main/java/com/kamron/pogoiv/PoGoApplication.java
@@ -1,0 +1,20 @@
+package com.kamron.pogoiv;
+
+import android.app.Application;
+
+import timber.log.Timber;
+
+public class PoGoApplication extends Application {
+
+    @Override public void onCreate() {
+        super.onCreate();
+
+        CrashlyticsWrapper.init(getApplicationContext());
+
+        if (BuildConfig.DEBUG) {
+            Timber.plant(new Timber.DebugTree());
+        } else {
+            Timber.plant(new CrashlyticsWrapper.CrashReportingTree());
+        }
+    }
+}

--- a/app/src/offline/java/com/kamron/pogoiv/CrashlyticsWrapper.java
+++ b/app/src/offline/java/com/kamron/pogoiv/CrashlyticsWrapper.java
@@ -1,0 +1,19 @@
+package com.kamron.pogoiv;
+
+import android.content.Context;
+
+import timber.log.Timber;
+
+public class CrashlyticsWrapper {
+
+    public static void init(Context context){
+        // there is no crashlytics in offline builds
+    }
+
+    public static class CrashReportingTree extends Timber.Tree {
+
+        @Override protected void log(int priority, String tag, String message, Throwable t) {
+            // there is no logging of crash reports in offline builds
+        }
+    }
+}

--- a/app/src/online/AndroidManifest.xml
+++ b/app/src/online/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET"/>
+
+</manifest>

--- a/app/src/online/java/com/kamron/pogoiv/CrashlyticsWrapper.java
+++ b/app/src/online/java/com/kamron/pogoiv/CrashlyticsWrapper.java
@@ -1,0 +1,35 @@
+package com.kamron.pogoiv;
+
+import android.content.Context;
+import android.text.TextUtils;
+
+import com.crashlytics.android.Crashlytics;
+import com.crashlytics.android.core.CrashlyticsCore;
+
+import io.fabric.sdk.android.Fabric;
+import timber.log.Timber;
+
+public class CrashlyticsWrapper {
+
+    public static void init(Context context) {
+        // Set up Crashlytics, disabled for debug builds
+        Crashlytics crashlyticsKit = new Crashlytics.Builder()
+                .core(new CrashlyticsCore.Builder()
+                        .disabled(BuildConfig.DEBUG).build())
+                .build();
+
+        // Initialize Fabric with the debug-disabled crashlytics.
+        Fabric.with(context, crashlyticsKit);
+    }
+
+    public static class CrashReportingTree extends Timber.Tree {
+
+        @Override protected void log(int priority, String tag, String message, Throwable t) {
+            if (t != null) {
+                Crashlytics.logException(t);
+            } else if (!TextUtils.isEmpty(message)) {
+                Crashlytics.log(message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
For those of us that don't like that internet permission 😺 

This PR will also change logging somewhat. All logging should be done through [Timber](https://github.com/JakeWharton/timber) now. The API is very similar to `Log`, you have `Timber.e` and so on. For debug builds all logs go to logcat. For the offline release builds all logs are swallowed. For the online release build all logs go to Crashlytics.

From Android Studio you can choose what variant to build by clicking the 'build variants' tab in the lower left of the IDE and using the dropdown

![image](https://cloud.githubusercontent.com/assets/3344901/17832980/e199bc74-6709-11e6-8242-6868927858ca.png)

Not sure how you go about making the `.apk`s for release. I use the command line, doing a `./gradlew clean build` (or `./gradlew clean assembleOnlineRelease assembleOfflineRelease`) will make both `.apk` files. I haven't built a project through Android Studio in forever, I think you'll need to select the `onlineRelease` variant and build that then repeat for `offlineRelease`

This also introduces new code sourcesets for code specific to online or offline builds, `app/src/online` and `app/src/offline`. The docs for this are [here](https://developer.android.com/studio/build/build-variants.html)