### PR TITLE
Add build instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,9 @@
+# Build instructions
+
+- Download and install Android studio (https://github.com/farkam135/GoIV/issues/60).
+
+- Install the SDK for the relevant android versions from within android studio (press the SDK manager button in the toolbar, an android face above a box with a down arrow)
+
+- Open the project
+
+- If you get errors because modules are not found, use the SDK manager to add the missing modules.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -7,3 +7,8 @@
 - Open the project
 
 - If you get errors because modules are not found, use the SDK manager to add the missing modules.
+
+## Command-line build tool
+
+Android Studio uses the Gradle build tool. It's recommended you invoke it through the `gradlew` wrapper which is part of the project.
+You can do, for instance, `./gradlew clean build`.

--- a/README.md
+++ b/README.md
@@ -104,3 +104,7 @@ GoIV would not have been possible without the help and support of the following 
  - Stuart Dorff  
  - Kevin Do  
  - Tommy Tran  
+
+# Development
+
+For info on developing GoIV, see [DEVELOPMENT.md](DEVELOPMENT.md).


### PR DESCRIPTION
Fix #60. Build instructions should be in the project, somewhere where they are easy to find.