### PR TITLE
Recycle bitmaps where possible

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -518,6 +518,7 @@ public class MainActivity extends AppCompatActivity {
                 image.close();
                 Bitmap bmp = getBitmap(buffer, pixelStride, rowPadding);
                 scanPokemon(bmp,"");
+                bmp.recycle();
                 //SaveImage(bmp,"Search");
             } catch (Exception exception) {
                 Timber.e("Exception thrown in takeScreenshot() - when creating bitmap");
@@ -772,7 +773,9 @@ public class MainActivity extends AppCompatActivity {
                     if (readyForNewScreenshot && file != null) {
                         readyForNewScreenshot = false;
                         File pokemonScreenshot = new File(screenshotDir + File.separator + file);
-                        scanPokemon(BitmapFactory.decodeFile(pokemonScreenshot.getAbsolutePath()),pokemonScreenshot.getAbsolutePath());
+                        Bitmap bmp = BitmapFactory.decodeFile(pokemonScreenshot.getAbsolutePath());
+                        scanPokemon(bmp, pokemonScreenshot.getAbsolutePath());
+                        bmp.recycle();
                     }
             }
         };
@@ -821,6 +824,7 @@ public class MainActivity extends AppCompatActivity {
             if (readyForNewScreenshot) {
                 Bitmap bitmap = (Bitmap) intent.getParcelableExtra("bitmap");
                 scanPokemon(bitmap, "");
+                bitmap.recycle();
                 readyForNewScreenshot = false;
             }
         }


### PR DESCRIPTION
Some of the bitmaps weren't recycled once we are done using them.
Recycle them. The benefits of recycle isn't clear for an app that
targets Android 4.4 and higher, but going with the existing convention
in this project.

Btw, based on what's in [this link](https://developer.android.com/training/displaying-bitmaps/manage-memory.html#inBitmap), looks like calling recycle() might not have any major benefit and using BitmapFactory might be a better option.