### PR TITLE
Swap the Close and Back button in the info dialog

### DIFF
--- a/app/src/main/res/layout/dialog_info_window.xml
+++ b/app/src/main/res/layout/dialog_info_window.xml
@@ -184,17 +184,17 @@
         android:orientation="horizontal">
 
         <Button
-            android:id="@+id/btnCloseInfo"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="@string/close"
-            android:layout_weight="1"/>
-
-        <Button
             android:id="@+id/btnBackInfo"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/back"
+            android:layout_weight="1"/>
+
+        <Button
+            android:id="@+id/btnCloseInfo"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/close"
             android:layout_weight="1"/>
 
     </LinearLayout>


### PR DESCRIPTION
1. Consistent with the navigation back button being on the left
2. Doesn't break the muscle memory for right handed people expecting the
   close button on the right side.