### PR TITLE
fix absent clasess warnings for okio

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -18,3 +18,4 @@
 -keep class javax.** { *; }
 -keep class org.** { *; }
 -keep class com.** {*;}
+-dontwarn okio.**


### PR DESCRIPTION
Removed warnings from okio (see this: http://stackoverflow.com/questions/36010942/getting-warnings-with-proguard-with-external-libraries). Those mess with release build and pro guard - I could not make a release version without this fix.