### PR TITLE
Fix alignment issues with the level arc

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -385,11 +385,6 @@ public class MainActivity extends AppCompatActivity {
 
         for (double pokeLevel = 1.0; pokeLevel <= trainerLevel + 1.5; pokeLevel += 0.5) {
             double angleInDegrees = (Data.CpM[(int) (pokeLevel * 2 - 2)] - Data.CpM[0]) * 200.00 / Data.CpM[trainerLevel * 2 - 2];
-            if (angleInDegrees > 1.0 && trainerLevel < 30) {
-                angleInDegrees -= 0.5;
-            } else if (trainerLevel >= 30) {
-                angleInDegrees += 0.5;
-            }
 
             double angleInRadians = (angleInDegrees + 180) * Math.PI / 180.0;
 

--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -384,7 +384,7 @@ public class MainActivity extends AppCompatActivity {
         Data.arcY = new int[indices];
 
         for (double pokeLevel = 1.0; pokeLevel <= trainerLevel + 1.5; pokeLevel += 0.5) {
-            double angleInDegrees = (Data.CpM[(int) (pokeLevel * 2 - 2)] - Data.CpM[0]) * 202.04 / Data.CpM[trainerLevel * 2 - 2];
+            double angleInDegrees = (Data.CpM[(int) (pokeLevel * 2 - 2)] - Data.CpM[0]) * 200.00 / Data.CpM[trainerLevel * 2 - 2];
             if (angleInDegrees > 1.0 && trainerLevel < 30) {
                 angleInDegrees -= 0.5;
             } else if (trainerLevel >= 30) {

--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -383,8 +383,11 @@ public class MainActivity extends AppCompatActivity {
         Data.arcX = new int[indices];
         Data.arcY = new int[indices];
 
+        double maxAngle = 178.4;
+        double levelCoeff = maxAngle * Data.CpM[trainerLevel * 2 - 2] / ( Data.CpM[(int) ( (trainerLevel + 1.5)* 2 - 2 )] - Data.CpM[0] );
+
         for (double pokeLevel = 1.0; pokeLevel <= trainerLevel + 1.5; pokeLevel += 0.5) {
-            double angleInDegrees = (Data.CpM[(int) (pokeLevel * 2 - 2)] - Data.CpM[0]) * 200.00 / Data.CpM[trainerLevel * 2 - 2];
+            double angleInDegrees = (Data.CpM[(int) (pokeLevel * 2 - 2)] - Data.CpM[0]) * levelCoeff / Data.CpM[trainerLevel * 2 - 2];
 
             double angleInRadians = (angleInDegrees + 180) * Math.PI / 180.0;
 


### PR DESCRIPTION
Based on these pictures (http://imgur.com/a/BRNUP), I was able to calculate that the max angle for the position of the white dot on the level arc is approximately 178.4 degrees, not 180. I tried to fix the code to account for that fact - you can see these magnificent calculations here: 
![image](https://cloud.githubusercontent.com/assets/1685446/17901299/135ec5f0-6963-11e6-94d9-5a6e15a5cc62.png)

I replaced 202.04 by 200.00 in the code, deleted these weird -0.5 / +0.5 that were necessary before, and tested it on my phone (Nexus 5, Android 6). It fixed all the alignment problems I had! It probably needs to be tested on more devices, but I'm quite enthusiastic about this change.