### PR TITLE
Refactor Unused Strings

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -11,16 +11,7 @@
     <string name="main_invalide_trainerlvl">Neplatný level trenéra!</string>
     <string name="notification_title">GoIV běží - Level %1$s</string>
     <string name="notification_text">Klikni pro otevření</string>
-	<string name="ivtext_title">Tvůj lvl %1$s, CP %2$s, HP %3$s %4$s může být:</string>
-    <string name="ivtext_possibilities">%1$s více možností...</string>
     <string name="ivtext_no_possibilities">Žádné možnosti, prosím zkontroluj znova své staty!</string>
-    <string name="ivtext_iv">Min: %1$s%% Průměr: %2$s%% Max: %3$s%%\n</string>
-    <string name="ivtext_evolve">Se může vyvinout na %1$s:\n</string>
-    <string name="ivtext_evolve_further">Se může dále vyvinout na %1$s:</string>
-    <string name="ivtext_many_possibilities">Příliš mnoho možností pro tohoto Pokémona. Zkus power up!</string>
-    <string name="ivtext_max_lvl_cost">Cena pro dosažení levelu %1$s:</string>
-    <string name="main_battery_saver">Spořič baterky (Screenshot pro načtení)</string>
-    <string name="ivtext_cp_lvl">CP na lvl %1$s: %2$s - %3$s</string>
     <string name="ivtext_stats">Útok: %1$02d Obrana: %2$02d Stamina: %3$02d — %4$3d%%</string>
     <string name="close">Zavřít</string>
 	<string name="main_permission">Udělit povolení</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -13,17 +13,7 @@
     <string name="main_invalide_trainerlvl">Niveau de dresseur invalide!</string>
     <string name="notification_title">GoIV Actif - Niveau %1$s</string>
     <string name="notification_text">Appuyer pour ouvrir</string>
-    <string name="ivtext_title">Votre niveau %1$s, PC %2$s, PV %3$s %4$s peut être:</string>
-    <string name="ivtext_possibilities">%1$s autres possibilités...</string>
     <string name="ivtext_no_possibilities">Aucune possibilitié, SVP vérifier stats!</string>
-    <string name="ivtext_iv">Min: %1$s%% Moyenne: %2$s%% Max: %3$s%%\n</string>
-    <string name="ivtext_evolve">Peut évoluer en %1$s:\n</string>
-    <string name="ivtext_evolve_further">Peut ensuite évoluer en %1$s:</string>
-    <string name="ivtext_many_possibilities">Il y a trop de possibilités pour ce Pokémon. Restaurer avec bonbons et réessayer!</string>
-    <string name="ivtext_max_lvl_cost">Coût pour atteindre %1$s:</string>
-    <string name="ivtext_max_lvl_cost2">Bonbon: %1$s Poussière: %2$s</string>
-    <string name="main_battery_saver">Économisateur pile (Capture d\'écran pour scanner)</string>
-    <string name="ivtext_cp_lvl">PC au niveau %1$s: %2$s - %3$s</string>
     <string name="ivtext_stats">Atq: %1$02d Déf: %2$02d Vig: %3$02d — %4$3d%%</string>
     <string name="close">Fermer</string>
     <string name="main_permission">Obtenir permissions</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -14,17 +14,7 @@
     <string name="main_invalide_trainerlvl">Nível de treinador inválido!</string>
     <string name="notification_title">GoIV funcionando - Nível %1$s</string>
     <string name="notification_text">Toque para abrir</string>
-    <string name="ivtext_title">O teu nível %1$s, CP %2$s, HP %3$s %4$s pode ser:</string>
-    <string name="ivtext_possibilities">%1$s mais possibilidades...</string>
     <string name="ivtext_no_possibilities">Não há possibilides, por favor verifique os dados!</string>
-    <string name="ivtext_iv">Min: %1$s%% Média: %2$s%% Max: %3$s%%\n</string>
-    <string name="ivtext_evolve">Pode evoluir para %1$s:\n</string>
-    <string name="ivtext_evolve_further">Pode ser ainda mais evoluído para %1$s:</string>
-    <string name="ivtext_many_possibilities">Há muitas possibilidades para este Pokémon. Tente usar o POWER UP!</string>
-    <string name="ivtext_max_lvl_cost">Custo para chegar ao nível %1$s:</string>
-    <string name="ivtext_max_lvl_cost2">Candy: %1$s Stardust: %2$s</string>
-    <string name="main_battery_saver">Poupança de bateria (Pesquiza por captura de ecrã)</string>
-    <string name="ivtext_cp_lvl">CP ao nivél %1$s: %2$s - %3$s</string>
     <string name="ivtext_stats">Atk: %1$02d Def: %2$02d Sta: %3$02d — %4$3d%%</string>
     <string name="close">Fechar</string>
     <string name="main_permission">Grantir Permições</string>


### PR DESCRIPTION
Removes unnecessary strings from pre-UI overhaul
Note: Check before doing a refactor, some strings are still being used (Nidoran, screen capture and scan failed strings are used in MainActivity)