### PR TITLE
stop keeping a static reference to context in hte crashlytics wrapper

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/PoGoApplication.java
+++ b/app/src/main/java/com/kamron/pogoiv/PoGoApplication.java
@@ -17,7 +17,7 @@ public class PoGoApplication extends Application {
         if (BuildConfig.DEBUG) {
             Timber.plant(new Timber.DebugTree());
         } else {
-            Timber.plant(new CrashlyticsWrapper.CrashReportingTree());
+            Timber.plant(new CrashlyticsWrapper.CrashReportingTree(this));
         }
 
         // Fonts overriding application wide

--- a/app/src/offline/java/com/kamron/pogoiv/CrashlyticsWrapper.java
+++ b/app/src/offline/java/com/kamron/pogoiv/CrashlyticsWrapper.java
@@ -6,11 +6,13 @@ import timber.log.Timber;
 
 public class CrashlyticsWrapper {
 
-    public static void init(Context context){
+    public static void init(Context context) {
         // there is no crashlytics in offline builds
     }
 
     public static class CrashReportingTree extends Timber.Tree {
+
+        public CrashReportingTree(Context context) { }
 
         @Override protected void log(int priority, String tag, String message, Throwable t) {
             // there is no logging of crash reports in offline builds

--- a/app/src/online/java/com/kamron/pogoiv/CrashlyticsWrapper.java
+++ b/app/src/online/java/com/kamron/pogoiv/CrashlyticsWrapper.java
@@ -11,12 +11,8 @@ import timber.log.Timber;
 
 public class CrashlyticsWrapper {
 
-    private static Context mContext;
-
     public static void init(Context context) {
-
-        mContext = context;
-        if (BuildConfig.isInternetAvailable && GoIVSettings.getSettings(mContext).getSendCrashReports()) {
+        if (BuildConfig.isInternetAvailable && GoIVSettings.getSettings(context).getSendCrashReports()) {
             // Set up Crashlytics, disabled for debug builds
             Crashlytics crashlyticsKit = new Crashlytics.Builder()
                     .core(new CrashlyticsCore.Builder()
@@ -30,10 +26,16 @@ public class CrashlyticsWrapper {
 
     public static class CrashReportingTree extends Timber.Tree {
 
+        public final Context context;
+
+        public CrashReportingTree(Context context) {
+            this.context = context;
+        }
+
         @Override
         protected void log(int priority, String tag, String message, Throwable t) {
 
-            if (BuildConfig.isInternetAvailable && GoIVSettings.getSettings(mContext).getSendCrashReports()) {
+            if (BuildConfig.isInternetAvailable && GoIVSettings.getSettings(context).getSendCrashReports()) {
                 if (t != null) {
                     Crashlytics.logException(t);
                 } else if (!TextUtils.isEmpty(message)) {


### PR DESCRIPTION
Static references to context often cause memory leaks. This one was fine but it's better to just not have them (people copy code patterns they see, the next time it mightn't be the application context that's kept around)