### PR TITLE
Allow processing pokemon without HP=CP=10 (#235)

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/PokeInfoCalculator.java
@@ -144,7 +144,8 @@ public class PokeInfoCalculator {
         //IV vars for lower and upper end cp ranges
 
 
-        if (pokemonHP != 10 && pokemonCP != 10) {
+        //It's safe to proceed if *one* is not 10, though it takes a bit longer.
+        if (pokemonHP != 10 || pokemonCP != 10) {
             IVScanResult returner = new IVScanResult(get(selectedPokemon), estimatedPokemonLevel);
             for (int staminaIV = 0; staminaIV < 16; staminaIV++) {
                 int hp = (int) Math.max(Math.floor((baseStamina + staminaIV) * lvlScalar), 10);


### PR DESCRIPTION
The code flipped back and forth. @farkam135 suggested using `||`, I changed it, and @nahojjjen changed it back in cf8ab33a5b7a69693be631137a2c58b5c4d7f9b7. GoIV can give useful info here, especially with narrowing—and even without there's a delay but I find it acceptable.

What do you think?