### PR TITLE
Remove unnecessary SharedPrefs writes from settings

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
+++ b/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
@@ -5,7 +5,6 @@ import android.content.SharedPreferences;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 
 @AllArgsConstructor
 @Getter
@@ -19,6 +18,8 @@ public class GoIVSettings {
     private boolean sendCrashReports;
     private boolean autoUpdateEnabled;
 
+    public static final String PREFS_GO_IV_SETTINGS = "GoIV_settings";
+
     public static final String LAUNCH_POKEMON_GO = "launchPokemonGo";
     public static final String SHOW_CONFIRMATION_DIALOG = "showConfirmationDialog";
     public static final String MANUAL_SCREENSHOT_MODE = "manualScreenshotMode";
@@ -27,23 +28,8 @@ public class GoIVSettings {
     public static final String SEND_CRASH_REPORTS = "sendCrashReports";
     public static final String AUTO_UPDATE_ENABLED = "autoUpdateEnabled";
 
-    public static void saveSettings(Context context, GoIVSettings newSettings) {
-        SharedPreferences settingsPreferences = context.getSharedPreferences("GoIV_settings", Context.MODE_PRIVATE);
-        SharedPreferences.Editor settingsEditor = settingsPreferences.edit();
-
-        settingsEditor.putBoolean(LAUNCH_POKEMON_GO, newSettings.getLaunchPokemonGo());
-        settingsEditor.putBoolean(SHOW_CONFIRMATION_DIALOG, newSettings.getShowConfirmationDialog());
-        settingsEditor.putBoolean(MANUAL_SCREENSHOT_MODE, newSettings.getManualScreenshotMode());
-        settingsEditor.putBoolean(DELETE_SCREENSHOTS, newSettings.getDeleteScreenshots());
-        settingsEditor.putBoolean(COPY_TO_CLIPBOARD, newSettings.getCopyToClipboard());
-        settingsEditor.putBoolean(SEND_CRASH_REPORTS, newSettings.getSendCrashReports());
-        settingsEditor.putBoolean(AUTO_UPDATE_ENABLED, newSettings.getAutoUpdateEnabled());
-
-        settingsEditor.apply();
-    }
-
     public static GoIVSettings getSettings(Context context) {
-        SharedPreferences settingsPreferences = context.getSharedPreferences("GoIV_settings", Context.MODE_PRIVATE);
+        SharedPreferences settingsPreferences = context.getSharedPreferences(PREFS_GO_IV_SETTINGS, Context.MODE_PRIVATE);
 
         return new GoIVSettings(settingsPreferences.getBoolean(LAUNCH_POKEMON_GO, true),
                 settingsPreferences.getBoolean(SHOW_CONFIRMATION_DIALOG, true),

--- a/app/src/main/java/com/kamron/pogoiv/SettingsActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/SettingsActivity.java
@@ -1,11 +1,9 @@
 package com.kamron.pogoiv;
 
-import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
-import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
 import android.preference.SwitchPreference;
 import android.support.v7.app.AlertDialog;
@@ -20,27 +18,13 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
-public class SettingsActivity extends AppCompatActivity implements SharedPreferences.OnSharedPreferenceChangeListener {
+public class SettingsActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         getFragmentManager().beginTransaction().replace(android.R.id.content, new SettingsFragment()).commit();
         getSupportActionBar().setTitle(getResources().getString(R.string.settings_page_title));
-
-        SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(this);
-        sharedPref.registerOnSharedPreferenceChangeListener(this);
-    }
-
-    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-        GoIVSettings.saveSettings(this, new GoIVSettings(
-                sharedPreferences.getBoolean(GoIVSettings.LAUNCH_POKEMON_GO, true),
-                sharedPreferences.getBoolean(GoIVSettings.SHOW_CONFIRMATION_DIALOG, true),
-                sharedPreferences.getBoolean(GoIVSettings.MANUAL_SCREENSHOT_MODE, false),
-                sharedPreferences.getBoolean(GoIVSettings.DELETE_SCREENSHOTS, true),
-                sharedPreferences.getBoolean(GoIVSettings.COPY_TO_CLIPBOARD, false),
-                sharedPreferences.getBoolean(GoIVSettings.SEND_CRASH_REPORTS, true),
-                sharedPreferences.getBoolean(GoIVSettings.AUTO_UPDATE_ENABLED, true)));
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
@@ -64,6 +48,7 @@ public class SettingsActivity extends AppCompatActivity implements SharedPrefere
         @Override
         public void onCreate(Bundle savedInstanceState) {
             super.onCreate(savedInstanceState);
+            getPreferenceManager().setSharedPreferencesName(GoIVSettings.PREFS_GO_IV_SETTINGS);
             addPreferencesFromResource(R.xml.settings);
             PreferenceScreen preferenceScreen = getPreferenceScreen();
 


### PR DESCRIPTION
the `PreferenceFragment` can do all the saving for us

this can be merged independent of any changes to how settings are accessed