### PR TITLE
Single match layout behaviour

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -152,7 +152,24 @@ public class Pokefly extends Service {
     SeekBar expandedLevelSeekbar;
     @BindView(R.id.extendedEvolutionSpinner)
     Spinner extendedEvolutionSpinner;
+    @BindView(R.id.llSingleMatch)
+    LinearLayout llSingleMatch;
+    @BindView(R.id.tvAvgIV)
+    TextView tvAvgIV;
+    @BindView(R.id.resultsAttack)
+    TextView resultsAttack;
+    @BindView(R.id.resultsDefense)
+    TextView resultsDefense;
+    @BindView(R.id.resultsHP)
+    TextView resultsHP;
+    @BindView(R.id.llMaxIV)
+    LinearLayout llMaxIV;
+    @BindView(R.id.llMinIV)
+    LinearLayout llMinIV;
+    @BindView(R.id.llMultipleIVMatches)
+    LinearLayout llMultipleIVMatches;
 
+    // Refine by appraisal
     @BindView(R.id.attCheckbox)
     CheckBox attCheckbox;
     @BindView(R.id.defCheckbox)
@@ -619,19 +636,36 @@ public class Pokefly extends Service {
     private void populateResultsBox(IVScanResult ivScanResult) {
 
         resultsPokemonName.setText(ivScanResult.pokemon.name);
-        if (ivScanResult.tooManyPossibilities) {
-            resultsCombinations.setText(getString(R.string.too_many_iv_combinations));
-        } else {
-            resultsCombinations.setText(String.format(getString(R.string.possible_iv_combinations), ivScanResult.iVCombinations.size()));
-        }
 
-
-        //TODO: Populate ivText in a better way.
-        String allIvs = "";
-        for (IVCombination ivItem : ivScanResult.iVCombinations) {
-            allIvs += String.format(getString(R.string.ivtext_stats), ivItem.att, ivItem.def, ivItem.sta, ivItem.percentPerfect) + "\n";
+        // Single match
+        // Todo: Refactor this bit to make it cleaner.
+        if (ivScanResult.getCount()==1){
+            llMaxIV.setVisibility(View.GONE);
+            llMinIV.setVisibility(View.GONE);
+            tvAvgIV.setText("IV");
+            resultsAttack.setText(String.valueOf(ivScanResult.iVCombinations.get(0).att));
+            resultsDefense.setText(String.valueOf(ivScanResult.iVCombinations.get(0).def));
+            resultsHP.setText(String.valueOf(ivScanResult.iVCombinations.get(0).sta));
+            llSingleMatch.setVisibility(View.VISIBLE);
+            llMultipleIVMatches.setVisibility(View.GONE);
+        }else { // More than a match
+            llMaxIV.setVisibility(View.VISIBLE);
+            llMinIV.setVisibility(View.VISIBLE);
+            llSingleMatch.setVisibility(View.GONE);
+            llMultipleIVMatches.setVisibility(View.VISIBLE);
+            tvAvgIV.setText("AVG");
+            if (ivScanResult.tooManyPossibilities) {
+                resultsCombinations.setText(getString(R.string.too_many_iv_combinations));
+            } else {
+                resultsCombinations.setText(String.format(getString(R.string.possible_iv_combinations), ivScanResult.iVCombinations.size()));
+            }
+            //TODO: Populate ivText in a better way.
+            String allIvs = "";
+            for (IVCombination ivItem : ivScanResult.iVCombinations) {
+                allIvs += String.format(getString(R.string.ivtext_stats), ivItem.att, ivItem.def, ivItem.sta, ivItem.percentPerfect) + "\n";
+            }
+            ivText.setText(allIvs);
         }
-        ivText.setText(allIvs);
 
         resultsPokemonLevel.setText(getString(R.string.level) + ": " + ivScanResult.estimatedPokemonLevel);
         setResultScreenPercentageRange(ivScanResult);

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -646,6 +646,11 @@ public class Pokefly extends Service {
             resultsAttack.setText(String.valueOf(ivScanResult.iVCombinations.get(0).att));
             resultsDefense.setText(String.valueOf(ivScanResult.iVCombinations.get(0).def));
             resultsHP.setText(String.valueOf(ivScanResult.iVCombinations.get(0).sta));
+
+            setTextColorbyPercentage(resultsAttack, (int) Math.round(ivScanResult.iVCombinations.get(0).att*100.0/15));
+            setTextColorbyPercentage(resultsDefense, (int) Math.round(ivScanResult.iVCombinations.get(0).def*100.0/15));
+            setTextColorbyPercentage(resultsHP, (int) Math.round(ivScanResult.iVCombinations.get(0).sta*100.0/15));
+
             llSingleMatch.setVisibility(View.VISIBLE);
             llMultipleIVMatches.setVisibility(View.GONE);
         }else { // More than a match

--- a/app/src/main/res/layout/dialog_results.xml
+++ b/app/src/main/res/layout/dialog_results.xml
@@ -142,7 +142,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/stamina_hp"
+                    android:text="STA"
                     android:textSize="12sp"
                     android:layout_margin="0dp"
                     android:textColor="#222"/>

--- a/app/src/main/res/layout/dialog_results.xml
+++ b/app/src/main/res/layout/dialog_results.xml
@@ -40,6 +40,119 @@
         android:layout_gravity="center">
 
         <LinearLayout
+
+            android:id="@+id/llSingleMatch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            android:layout_gravity="center">
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:background="@drawable/skin_iv_linearlayout"
+                android:paddingLeft="12sp"
+                android:paddingRight="12sp"
+                android:paddingTop="6sp"
+                android:paddingBottom="6sp"
+                android:layout_margin="6sp"
+                android:gravity="center"
+                android:layout_gravity="center">
+
+                <TextView
+                    android:id="@+id/resultsAttack"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="24sp"
+                    android:textStyle="bold"
+                    android:text="15"
+                    android:textColor="#222"
+                    />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="ATK"
+                    android:layout_margin="0dp"
+                    android:textSize="12sp"
+                    android:gravity="center"
+                    android:textColor="#222"/>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:background="@drawable/skin_iv_linearlayout"
+                android:paddingLeft="12sp"
+                android:paddingRight="12sp"
+                android:paddingTop="6sp"
+                android:paddingBottom="6sp"
+                android:layout_margin="6sp"
+                android:gravity="center"
+                android:layout_gravity="center">
+
+                <TextView
+                    android:id="@+id/resultsDefense"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="24sp"
+                    android:textStyle="bold"
+                    android:textColor="#222"
+                    android:text="15"
+                    />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="DEF"
+                    android:textSize="12sp"
+                    android:layout_margin="0dp"
+                    android:textColor="#222"/>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:background="@drawable/skin_iv_linearlayout"
+                android:paddingLeft="12sp"
+                android:paddingRight="12sp"
+                android:paddingTop="6sp"
+                android:paddingBottom="6sp"
+                android:layout_margin="6sp"
+                android:gravity="center"
+                android:layout_gravity="center">
+
+                <TextView
+
+                    android:id="@+id/resultsHP"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="24sp"
+                    android:textStyle="bold"
+                    android:textColor="#222"
+                    android:text="15"
+                    />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/stamina_hp"
+                    android:textSize="12sp"
+                    android:layout_margin="0dp"
+                    android:textColor="#222"/>
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/llMinIV"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
@@ -75,6 +188,7 @@
         </LinearLayout>
 
         <LinearLayout
+            android:id="@+id/llAvgIV"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
@@ -99,6 +213,7 @@
                 />
 
             <TextView
+                android:id="@+id/tvAvgIV"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="AVG"
@@ -110,6 +225,7 @@
         </LinearLayout>
 
         <LinearLayout
+            android:id="@+id/llMaxIV"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
@@ -219,15 +335,16 @@
             android:layout_marginTop="5dp"
             android:layout_gravity="center"/>
 
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginLeft="12sp"
-            android:layout_marginRight="12sp"
-            android:background="@android:color/darker_gray"/>
-
     </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="5dp"
+        android:layout_marginLeft="12sp"
+        android:layout_marginRight="12sp"
+        android:background="@android:color/darker_gray"/>
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION
Added new UI elements to address the single match scenario. This was partially discussed on Issue #217.
The rationale behind it is that if there's a single match there is no need for further refinement, and its just a hassle for the user to tap "See all" to see the one result.

Result values are color coded with the same ratios as the percentages from the IV calculations.

Here's an example of how it looks like:
![screenshot_2016-08-28-04-22-51](https://cloud.githubusercontent.com/assets/10285769/18032285/30362c6e-6cd7-11e6-82ba-cbd51244e442.png)
