### PR TITLE
Clean up screen handling code and intent flow

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -595,9 +595,10 @@ public class MainActivity extends AppCompatActivity {
                 if (readyForNewScreenshot && file != null) {
                     readyForNewScreenshot = false;
                     File pokemonScreenshot = new File(screenshotDir + File.separator + file);
-                    Bitmap bmp = BitmapFactory.decodeFile(pokemonScreenshot.getAbsolutePath());
-                    scanPokemon(bmp, pokemonScreenshot.getAbsolutePath());
-                    bmp.recycle();
+                    String filepath = pokemonScreenshot.getAbsolutePath();
+                    Bitmap bmp = BitmapFactory.decodeFile(filepath);
+                    Intent newintent = MainActivity.createProcessBitmapIntent(bmp, filepath);
+                    LocalBroadcastManager.getInstance(MainActivity.this).sendBroadcast(newintent);
                 }
             }
         };

--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -86,6 +86,7 @@ public class MainActivity extends AppCompatActivity {
     private static final String ACTION_PROCESS_BITMAP = "process-bitmap";
 
     private static final String KEY_BITMAP = "bitmap";
+    private static final String KEY_SS_FILE = "ss-file";
 
     private ScreenGrabber screen;
     private ContentObserver screenShotObserver;
@@ -121,9 +122,10 @@ public class MainActivity extends AppCompatActivity {
         return new Intent(ACTION_RESET_SCREENSHOT);
     }
 
-    public static Intent createProcessBitmapIntent(Bitmap bitmap) {
+    public static Intent createProcessBitmapIntent(Bitmap bitmap, String file) {
         Intent intent = new Intent(ACTION_PROCESS_BITMAP);
         intent.putExtra(KEY_BITMAP, bitmap);
+        intent.putExtra(KEY_SS_FILE, file);
         return intent;
     }
 
@@ -643,7 +645,11 @@ public class MainActivity extends AppCompatActivity {
         public void onReceive(Context context, Intent intent) {
             if (readyForNewScreenshot) {
                 Bitmap bitmap = (Bitmap) intent.getParcelableExtra(KEY_BITMAP);
-                scanPokemon(bitmap, "");
+                String ss_file = intent.getStringExtra(KEY_SS_FILE);
+                if (ss_file == null) {
+                    ss_file = "";
+                }
+                scanPokemon(bitmap, ss_file);
                 bitmap.recycle();
                 readyForNewScreenshot = false;
             }

--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -64,8 +64,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Timer;
-import java.util.TimerTask;
 
 import timber.log.Timber;
 
@@ -108,10 +106,6 @@ public class MainActivity extends AppCompatActivity {
     private boolean pokeFlyRunning = false;
     private int trainerLevel;
 
-    private int areaX1;
-    private int areaY1;
-    private int areaX2;
-    private int areaY2;
     private int statusBarHeight;
     private int arcCenter;
     private int arcInitialY;
@@ -246,11 +240,6 @@ public class MainActivity extends AppCompatActivity {
         rawDisplayMetrics = new DisplayMetrics();
         Display disp = windowManager.getDefaultDisplay();
         disp.getRealMetrics(rawDisplayMetrics);
-
-        areaX1 = Math.round(displayMetrics.widthPixels / 24);  // these values used to get "white" left of "power up"
-        areaY1 = (int) Math.round(displayMetrics.heightPixels / 1.24271845);
-        areaX2 = (int) Math.round(displayMetrics.widthPixels / 1.15942029);  // these values used to get greenish color in transfer button
-        areaY2 = (int) Math.round(displayMetrics.heightPixels / 1.11062907);
 
         LocalBroadcastManager.getInstance(this).registerReceiver(resetScreenshot, new IntentFilter(ACTION_RESET_SCREENSHOT));
         LocalBroadcastManager.getInstance(this).registerReceiver(takeScreenshot, new IntentFilter(ACTION_SCREENSHOT));
@@ -487,23 +476,6 @@ public class MainActivity extends AppCompatActivity {
 
                 startPokeFly();
                 //showNotification();
-                final Handler handler = new Handler();
-                final Timer timer = new Timer();
-                TimerTask doAsynchronousTask = new TimerTask() {
-                    @Override
-                    public void run() {
-                        handler.post(new Runnable() {
-                            public void run() {
-                                if (pokeFlyRunning) {
-                                    scanPokemonScreen();
-                                } else {
-                                    timer.cancel();
-                                }
-                            }
-                        });
-                    }
-                };
-                timer.schedule(doAsynchronousTask, 0, 750);
             } else {
                 ((Button) findViewById(R.id.start)).setText(getString(R.string.main_start));
             }
@@ -570,26 +542,6 @@ public class MainActivity extends AppCompatActivity {
             }
         }
 
-    }
-
-    /**
-     * scanPokemonScreen
-     * Scans the device screen to check area1 for the white and area2 for the transfer button.
-     * If both exist then the user is on the pokemon screen.
-     */
-    private void scanPokemonScreen() {
-        Bitmap bmp = screen.grabScreen();
-        if (bmp == null) {
-            return;
-        }
-
-        if (bmp.getHeight() > bmp.getWidth()) {
-            boolean shouldShow = bmp.getPixel(areaX1, areaY1) == Color.rgb(250, 250, 250) && bmp.getPixel(areaX2, areaY2) == Color.rgb(28, 135, 150);
-            Intent showIVButtonIntent = Pokefly.createIVButtonIntent(shouldShow);
-            LocalBroadcastManager.getInstance(MainActivity.this).sendBroadcast(showIVButtonIntent);
-            //SaveImage(bmp,"everything");
-        }
-        bmp.recycle();
     }
 
     /**

--- a/app/src/main/java/com/kamron/pogoiv/OCRHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/OCRHelper.java
@@ -64,6 +64,7 @@ public class OCRHelper {
             tesseract.stop();
             tesseract.end();
             tesseract = null;
+            instance = null;
         } else {
             Timber.e("Avoided NPE on OCRHelper.exit()");
             //The exception is to ensure we get a stack trace. It's not thrown.

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -382,7 +382,7 @@ public class Pokefly extends Service {
             timer.cancel();
         }
         super.onDestroy();
-        if (IVButton != null && IVButtonShown) windowManager.removeView(IVButton);
+        setIVButtonDisplay(false);
         hideInfoLayoutArcPointer();
         stopForeground(true);
         LocalBroadcastManager.getInstance(this).unregisterReceiver(displayInfo);
@@ -519,8 +519,7 @@ public class Pokefly extends Service {
             public boolean onTouch(View v, MotionEvent event) {
                 switch (event.getAction()) {
                     case MotionEvent.ACTION_UP:
-                        windowManager.removeView(IVButton);
-                        IVButtonShown = false;
+                        setIVButtonDisplay(false);
                         Intent intent = MainActivity.createScreenshotIntent();
                         LocalBroadcastManager.getInstance(Pokefly.this).sendBroadcast(intent);
                         receivedInfo = false;
@@ -948,10 +947,6 @@ public class Pokefly extends Service {
      */
     public void cancelInfoDialog() {
         hideInfoLayoutArcPointer();
-        if (!batterySaver) {
-            windowManager.addView(IVButton, IVButonParams);
-            IVButtonShown = true;
-        }
         attCheckbox.setChecked(false);
         defCheckbox.setChecked(false);
         staCheckbox.setChecked(false);
@@ -964,6 +959,9 @@ public class Pokefly extends Service {
 
         resetPokeflyStateMachine();
         resetInfoDialogue();
+        if (!batterySaver) {
+            setIVButtonDisplay(true);
+        }
     }
 
     /**

--- a/app/src/main/java/com/kamron/pogoiv/ScreenGrabber.java
+++ b/app/src/main/java/com/kamron/pogoiv/ScreenGrabber.java
@@ -1,0 +1,91 @@
+package com.kamron.pogoiv;
+
+import android.annotation.TargetApi;
+import android.graphics.Bitmap;
+import android.graphics.PixelFormat;
+import android.hardware.display.DisplayManager;
+import android.media.Image;
+import android.media.ImageReader;
+import android.media.projection.MediaProjection;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.widget.Toast;
+
+import java.nio.ByteBuffer;
+
+import timber.log.Timber;
+
+/**
+ * Created by Sarav on 8/27/2016.
+ */
+public class ScreenGrabber {
+
+    private static ScreenGrabber instance = null;
+    private ImageReader mImageReader;
+    private MediaProjection mProjection = null;
+    private DisplayMetrics rawDisplayMetrics;
+    private DisplayMetrics displayMetrics;
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private ScreenGrabber(MediaProjection mediaProjection, DisplayMetrics raw, DisplayMetrics display) {
+        rawDisplayMetrics = raw;
+        displayMetrics = display;
+        mProjection = mediaProjection;
+        mImageReader = ImageReader.newInstance(rawDisplayMetrics.widthPixels, rawDisplayMetrics.heightPixels, PixelFormat.RGBA_8888, 2);
+        mProjection.createVirtualDisplay("screen-mirror", rawDisplayMetrics.widthPixels, rawDisplayMetrics.heightPixels, rawDisplayMetrics.densityDpi, DisplayManager.VIRTUAL_DISPLAY_FLAG_PUBLIC, mImageReader.getSurface(), null, null);
+    }
+
+    public static ScreenGrabber init(MediaProjection mediaProjection, DisplayMetrics raw, DisplayMetrics display) {
+        if (instance == null) {
+            instance = new ScreenGrabber(mediaProjection, raw, display);
+        }
+        return instance;
+    }
+
+    public void exit() {
+        if (mProjection != null) {
+            mImageReader = null;
+            mProjection.stop();
+            mProjection = null;
+            rawDisplayMetrics = null;
+            displayMetrics = null;
+            instance = null;
+        }
+    }
+
+    private Bitmap getBitmap(ByteBuffer buffer, int pixelStride, int rowPadding) {
+        Bitmap bmp = Bitmap.createBitmap(rawDisplayMetrics.widthPixels + rowPadding / pixelStride, displayMetrics.heightPixels, Bitmap.Config.ARGB_8888);
+        bmp.copyPixelsFromBuffer(buffer);
+        return bmp;
+    }
+
+    public Bitmap grabScreen() {
+        Image image = null;
+        Bitmap bmp = null;
+
+        try {
+            image = mImageReader.acquireLatestImage();
+        } catch (Exception exception) {
+            Timber.e("Error thrown in grabScreen() - acquireLatestImage()");
+            Timber.e(exception);
+        }
+
+        if (image != null) {
+            final Image.Plane[] planes = image.getPlanes();
+            final ByteBuffer buffer = planes[0].getBuffer();
+            int pixelStride = planes[0].getPixelStride();
+            int rowStride = planes[0].getRowStride();
+            int rowPadding = rowStride - pixelStride * rawDisplayMetrics.widthPixels;
+            image.close();
+
+            try {
+                bmp = getBitmap(buffer, pixelStride, rowPadding);
+            } catch (Exception exception) {
+                Timber.e("Exception thrown in grabScreen() - when creating bitmap");
+                Timber.e(exception);
+            }
+        }
+
+        return bmp;
+    }
+}

--- a/app/src/main/java/com/kamron/pogoiv/ShareHandlerActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/ShareHandlerActivity.java
@@ -26,7 +26,7 @@ public class ShareHandlerActivity extends Activity {
             Uri imageUri = (Uri) intent.getParcelableExtra(Intent.EXTRA_STREAM);
             try {
                 Bitmap bitmap = MediaStore.Images.Media.getBitmap(this.getContentResolver(), imageUri);
-                Intent newintent = MainActivity.createProcessBitmapIntent(bitmap);
+                Intent newintent = MainActivity.createProcessBitmapIntent(bitmap, null);
                 LocalBroadcastManager.getInstance(ShareHandlerActivity.this).sendBroadcast(newintent);
             } catch (IOException e) {
                 e.printStackTrace();

--- a/app/src/main/java/com/kamron/pogoiv/ShareHandlerActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/ShareHandlerActivity.java
@@ -26,7 +26,7 @@ public class ShareHandlerActivity extends Activity {
             Uri imageUri = (Uri) intent.getParcelableExtra(Intent.EXTRA_STREAM);
             try {
                 Bitmap bitmap = MediaStore.Images.Media.getBitmap(this.getContentResolver(), imageUri);
-                Intent newintent = MainActivity.createProcessBitmapIntent(bitmap, null);
+                Intent newintent = Pokefly.createProcessBitmapIntent(bitmap, null);
                 LocalBroadcastManager.getInstance(ShareHandlerActivity.this).sendBroadcast(newintent);
             } catch (IOException e) {
                 e.printStackTrace();


### PR DESCRIPTION
PR is not yet complete. Making a request so people can see the progress and make comments. There are tiny hacks (accessing public variables, making unnecessary dependencies, etc) to keep each commit small enough to review. When the PR is done, most of those hacks should go away.

- [x] Move the screen capture code out of MainActivity
- [x] Move the periodic scan of the screen into the service
- [x] Remove unnecessary Intent passing to take a screenshot and process it.

I'm stuck at the last one because I can't (yet) find the code that makes the (IV) button disappear.

Did some quick tests and it works so far.

This should address #203 -- you can already see how the timer stopping isn't times to some public variable. So, we should at least not get any timer races.
EDIT (by @Blaisorblade): fixes #203 and fixes #234.