### PR TITLE
Tweak tess to do single-line scan instead

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/OCRHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/OCRHelper.java
@@ -38,6 +38,7 @@ public class OCRHelper {
     private OCRHelper(String dataPath, int widthPixels, int heightPixels) {
         tesseract = new TessBaseAPI();
         tesseract.init(dataPath, "eng");
+        tesseract.setPageSegMode(TessBaseAPI.PageSegMode.PSM_SINGLE_LINE);
         tesseract.setVariable(TessBaseAPI.VAR_CHAR_WHITELIST, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789/♀♂");
         this.heightPixels = heightPixels;
         this.widthPixels = widthPixels;


### PR DESCRIPTION
Tesseract allows single-line scan to improve quality. [See wiki] (https://github.com/tesseract-ocr/tesseract/wiki/ImproveQuality)
Reference issue [#180] (https://github.com/farkam135/GoIV/issues/180)