### PR TITLE
refactor settings so that reads always return the current value

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
+++ b/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
@@ -3,23 +3,9 @@ package com.kamron.pogoiv;
 import android.content.Context;
 import android.content.SharedPreferences;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@AllArgsConstructor
-@Getter
 public class GoIVSettings {
 
-    private boolean launchPokemonGo;
-    private boolean showConfirmationDialog;
-    private boolean manualScreenshotMode;
-    private boolean deleteScreenshots;
-    private boolean copyToClipboard;
-    private boolean sendCrashReports;
-    private boolean autoUpdateEnabled;
-
     public static final String PREFS_GO_IV_SETTINGS = "GoIV_settings";
-
     public static final String LAUNCH_POKEMON_GO = "launchPokemonGo";
     public static final String SHOW_CONFIRMATION_DIALOG = "showConfirmationDialog";
     public static final String MANUAL_SCREENSHOT_MODE = "manualScreenshotMode";
@@ -28,15 +14,46 @@ public class GoIVSettings {
     public static final String SEND_CRASH_REPORTS = "sendCrashReports";
     public static final String AUTO_UPDATE_ENABLED = "autoUpdateEnabled";
 
-    public static GoIVSettings getSettings(Context context) {
-        SharedPreferences settingsPreferences = context.getSharedPreferences(PREFS_GO_IV_SETTINGS, Context.MODE_PRIVATE);
+    private static GoIVSettings instance;
 
-        return new GoIVSettings(settingsPreferences.getBoolean(LAUNCH_POKEMON_GO, true),
-                settingsPreferences.getBoolean(SHOW_CONFIRMATION_DIALOG, true),
-                settingsPreferences.getBoolean(MANUAL_SCREENSHOT_MODE, false),
-                settingsPreferences.getBoolean(DELETE_SCREENSHOTS, true),
-                settingsPreferences.getBoolean(COPY_TO_CLIPBOARD, false),
-                settingsPreferences.getBoolean(SEND_CRASH_REPORTS, true),
-                settingsPreferences.getBoolean(AUTO_UPDATE_ENABLED, true));
+    private final SharedPreferences prefs;
+
+    public static GoIVSettings getInstance(Context context) {
+        if (instance == null) {
+            instance = new GoIVSettings(context.getApplicationContext());
+        }
+        return instance;
+    }
+
+    private GoIVSettings(Context context) {
+        prefs = context.getSharedPreferences(PREFS_GO_IV_SETTINGS, Context.MODE_PRIVATE);
+    }
+
+    public boolean shouldLaunchPokemonGo() {
+        return prefs.getBoolean(LAUNCH_POKEMON_GO, true);
+    }
+
+    public boolean shouldShouldConfirmationDialogs() {
+        return prefs.getBoolean(SHOW_CONFIRMATION_DIALOG, true);
+    }
+
+    public boolean isManualScreenshotModeEnabled() {
+        return prefs.getBoolean(MANUAL_SCREENSHOT_MODE, false);
+    }
+
+    public boolean shouldDeleteScreenshots() {
+        return prefs.getBoolean(DELETE_SCREENSHOTS, true);
+    }
+
+    public boolean shouldCopyToClipboard() {
+        return prefs.getBoolean(COPY_TO_CLIPBOARD, false);
+    }
+
+    public boolean shouldSendCrashReports() {
+        return prefs.getBoolean(SEND_CRASH_REPORTS, true);
+    }
+
+    public boolean isAutoUpdateEnabled() {
+        return prefs.getBoolean(AUTO_UPDATE_ENABLED, true);
     }
 }

--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -143,8 +143,8 @@ public class MainActivity extends AppCompatActivity {
 
         mContext = MainActivity.this;
 
-        settings = GoIVSettings.getSettings(MainActivity.this);
-        if (BuildConfig.isInternetAvailable && settings.getAutoUpdateEnabled())
+        settings = GoIVSettings.getInstance(this);
+        if (BuildConfig.isInternetAvailable && settings.isAutoUpdateEnabled())
             new AppUpdateLoader().start();
 
         setContentView(R.layout.activity_main);
@@ -161,7 +161,7 @@ public class MainActivity extends AppCompatActivity {
         trainerLevel = sharedPref.getInt(PREF_LEVEL, 1);
         screenshotDir = sharedPref.getString(PREF_SCREENSHOT_DIR, "");
         screenshotUri = Uri.parse(sharedPref.getString(PREF_SCREENSHOT_URI, ""));
-        batterySaver = settings.getManualScreenshotMode();
+        batterySaver = settings.isManualScreenshotModeEnabled();
 
         final EditText etTrainerLevel = (EditText) findViewById(R.id.trainerLevel);
         etTrainerLevel.setText(String.valueOf(trainerLevel));
@@ -181,7 +181,7 @@ public class MainActivity extends AppCompatActivity {
                         ActivityCompat.requestPermissions(MainActivity.this, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, WRITE_STORAGE_REQ_CODE);
                     }
                 } else if (((Button) v).getText().toString().equals(getString(R.string.main_start))) {
-                    batterySaver = settings.getManualScreenshotMode();
+                    batterySaver = settings.isManualScreenshotModeEnabled();
                     Rect rectangle = new Rect();
                     Window window = getWindow();
                     window.getDecorView().getWindowVisibleDisplayFrame(rectangle);
@@ -340,13 +340,6 @@ public class MainActivity extends AppCompatActivity {
         super.onStop();
     }
 
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        settings = GoIVSettings.getSettings(MainActivity.this);
-    }
-
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onAppUpdateEvent(AppUpdateEvent event) {
         switch (event.getStatus()) {
@@ -397,8 +390,9 @@ public class MainActivity extends AppCompatActivity {
 
         pokeFlyRunning = true;
 
-        if (settings.getLaunchPokemonGo())
+        if (settings.shouldLaunchPokemonGo()) {
             openPokemonGoApp();
+        }
     }
 
     private boolean isNumeric(String str) {

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -583,7 +583,7 @@ public class Pokefly extends Service {
         }
 
         if (batterySaver && !screenshotDir.isEmpty()) {
-            if (GoIVSettings.getSettings(getBaseContext()).getDeleteScreenshots()) {
+            if (GoIVSettings.getInstance(getBaseContext()).shouldDeleteScreenshots()) {
                 getContentResolver().delete(screenshotUri, MediaStore.Files.FileColumns.DATA + "=?", new String[]{screenshotDir});
             }
         }
@@ -628,8 +628,7 @@ public class Pokefly extends Service {
      * Adds the iv range of the pokemon to the clipboard if the clipboard setting is on
      */
     private void addToRangeToClipboardIfSettingOn(IVScanResult ivScanResult) {
-        GoIVSettings settings = GoIVSettings.getSettings(getApplicationContext());
-        if (settings.getCopyToClipboard()) {
+        if (GoIVSettings.getInstance(getApplicationContext()).shouldCopyToClipboard()) {
             String clipText = ivScanResult.getLowestIVCombination().percentPerfect + "-" + ivScanResult.getHighestIVCombination().percentPerfect;
             ClipData clip = ClipData.newPlainText(clipText, clipText);
             clipboard.setPrimaryClip(clip);
@@ -950,8 +949,9 @@ public class Pokefly extends Service {
                 infoShownReceived = false;
             }
 
-            if (!GoIVSettings.getSettings(getBaseContext()).getShowConfirmationDialog())
+            if (!GoIVSettings.getInstance(getBaseContext()).shouldShouldConfirmationDialogs()) {
                 checkIv();
+            }
         }
     }
 


### PR DESCRIPTION
Before: getting the settings object would give you a snapshot of settings at that moment in time that did not reflect changes a user would make.

Now the settings object is just a wrapper around shared preferences and will read the most up to date value every time it's requested. The accessor names read a little better now too I think

I made it a singleton because there don't really need to be more than one instances floating about since it's just a read wrapper and it made the refactoring smaller (MainActivity kept a reference to a settings object). I've no strong feelings on if this is nicer than not having an object and using static methods like `GoIvSettings.isAutoUpdateEnabled(context)` wherever you want to check a setting. 