### PR TITLE
Add Travis-based continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ jdk:
   - oraclejdk8
 
 script:
-   - ./gradlew assembleDebug
+   - ./gradlew assembleDebug testOnlineDebugUnitTest testOfflineDebugUnitTest
      # build  # Would try need the online version, that seems to need fabric IDs.
      # connectedCheck # Would try building the release version, that needs certificates

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@
 language: android
 android:
   components:
+    - tools
+    - platform-tools-24.0.2
     - build-tools-24.0.1
     - android-24
     - extra-android-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ jdk:
   - oraclejdk8
 
 script:
-   #- ./gradlew build connectedCheck # Would try building the release version, that needs keys.
-   - ./gradlew build assembleDebug
+   - ./gradlew assembleDebug
+     # build  # Would try need the online version, that seems to need fabric IDs.
+     # connectedCheck # Would try building the release version, that needs certificates

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@
 language: android
 android:
   components:
-    - tools
-    - platform-tools-24.0.2
     - build-tools-24.0.1
     - android-24
     - extra-android-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ android:
     - platform-tools-24.0.2
     - build-tools-24.0.1
     - android-24
+    - extra-android-m2repository
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+# Based on:
+# https://docs.travis-ci.com/user/languages/android#CI-Environment-for-Android-Projects
+# https://github.com/codepath/android_guides/wiki/Setting-up-Travis-CI
+language: android
+android:
+  components:
+    - tools
+    - platform-tools-24.0.2
+    - build-tools-24.0.1
+    - android-24
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+jdk:
+  - oraclejdk8
+
+script:
+   #- ./gradlew build connectedCheck # Would try building the release version, that needs keys.
+   - ./gradlew build assembleDebug


### PR DESCRIPTION
This PR proposes to add a first form of continuous integration—this ensures that each PR compiles before merging (though doesn't enforce that), both alone and after merging with `master`.

In the future we might also try running some automated tests, but we'd have to add some.

This can only be enabled in Travis by @farkam135 (unless he gives somebody else higher privileges). I've tried out this code in my repository, results are visible in https://travis-ci.org/Blaisorblade/GoIV/builds.

Also, this makes sense if we agree to actually keep the build green.

Fixes #254.