### PR TITLE
Send non-Crashlytics logs to logcat at least in releases

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/CommonLogger.java
+++ b/app/src/main/java/com/kamron/pogoiv/CommonLogger.java
@@ -1,0 +1,19 @@
+package com.kamron.pogoiv;
+
+import android.util.Log;
+
+/**
+ * Created by pgiarrusso on 30/8/2016.
+ */
+public class CommonLogger {
+    /**
+     * Wraooer around android.util.Log.println.
+     * @param priority Logging priority, using android.util.Log constants
+     * @param tag
+     * @param message
+     * @param tr
+     */
+    public static void log(int priority, String tag, String message, Throwable tr) {
+        Log.println(priority, tag, message + '\n' + Log.getStackTraceString(tr));
+    }
+}

--- a/app/src/offline/java/com/kamron/pogoiv/CrashlyticsWrapper.java
+++ b/app/src/offline/java/com/kamron/pogoiv/CrashlyticsWrapper.java
@@ -18,9 +18,8 @@ public class CrashlyticsWrapper {
 
         @Override
         protected void log(int priority, String tag, String message, Throwable t) {
-            // there is no logging of crash reports in offline builds
-            // XXX we use error level but should look at the priority.
-            Log.e(tag, message, t);
+            // there is no online logging of crash reports in offline builds
+            CommonLogger.log(priority, tag, message, t);
         }
     }
 }

--- a/app/src/offline/java/com/kamron/pogoiv/CrashlyticsWrapper.java
+++ b/app/src/offline/java/com/kamron/pogoiv/CrashlyticsWrapper.java
@@ -1,6 +1,7 @@
 package com.kamron.pogoiv;
 
 import android.content.Context;
+import android.util.Log;
 
 import timber.log.Timber;
 
@@ -18,6 +19,8 @@ public class CrashlyticsWrapper {
         @Override
         protected void log(int priority, String tag, String message, Throwable t) {
             // there is no logging of crash reports in offline builds
+            // XXX we use error level but should look at the priority.
+            Log.e(tag, message, t);
         }
     }
 }

--- a/app/src/online/java/com/kamron/pogoiv/CrashlyticsWrapper.java
+++ b/app/src/online/java/com/kamron/pogoiv/CrashlyticsWrapper.java
@@ -2,6 +2,7 @@ package com.kamron.pogoiv;
 
 import android.content.Context;
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.crashlytics.android.Crashlytics;
 import com.crashlytics.android.core.CrashlyticsCore;
@@ -42,6 +43,9 @@ public class CrashlyticsWrapper {
                 } else if (!TextUtils.isEmpty(message)) {
                     Crashlytics.log(message);
                 }
+            } else {
+                // XXX we use error level but should look at the priority.
+                Log.e(tag, message, t);
             }
 
         }

--- a/app/src/online/java/com/kamron/pogoiv/CrashlyticsWrapper.java
+++ b/app/src/online/java/com/kamron/pogoiv/CrashlyticsWrapper.java
@@ -43,11 +43,9 @@ public class CrashlyticsWrapper {
                 } else if (!TextUtils.isEmpty(message)) {
                     Crashlytics.log(message);
                 }
-            } else {
-                // XXX we use error level but should look at the priority.
-                Log.e(tag, message, t);
             }
 
+            CommonLogger.log(priority, tag, message, t);
         }
     }
 }


### PR DESCRIPTION
This could be helpful to users of offline versions that have problems and try to use logcat on it. @harkin thought this was worth of discussion (and I misunderstood the logic when originally committing), so here's a PR to discuss.