### PR TITLE
added a basic unit test

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,8 +82,13 @@ dependencies {
     onlineCompile('com.crashlytics.sdk.android:crashlytics:2.6.2@aar') {
         transitive = true;
     }
+
     testCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
-    androidTestCompile 'com.android.support.test:runner:0.5'
+    testCompile 'com.squareup.assertj:assertj-android:1.1.1'
+    testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile 'com.android.support:support-annotations:24.2.0'
+    testCompile 'com.android.support.test:runner:0.5'
+
     androidTestCompile 'com.android.support:support-annotations:24.2.0'
+    androidTestCompile 'com.android.support.test:runner:0.5'
 }

--- a/app/src/test/java/com/kamron/pogoiv/IVCombinationTest.java
+++ b/app/src/test/java/com/kamron/pogoiv/IVCombinationTest.java
@@ -1,0 +1,14 @@
+package com.kamron.pogoiv;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IVCombinationTest {
+
+    @Test
+    public void derivesPerfectPercentage() {
+        IVCombination ivCombination = new IVCombination(40, 50, 60);
+        assertThat(ivCombination.percentPerfect).isEqualTo(333);
+    }
+}


### PR DESCRIPTION
This can be run with `./gradlew testOfflineDebugUnitTest` or `./gradlew testOnlineDebugUnitTest`

`./gradlew test` cannot be used because of the crashlyitcs id needed for online release builds