### PR TITLE
Makes input smaller so hp is visible

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -144,6 +144,10 @@ public class Pokefly extends Service {
     @BindView(R.id.allPossibilitiesBox)
     LinearLayout allPossibilitiesBox;
 
+
+    @BindView(R.id.appraisalBox)
+    LinearLayout appraisalBox;
+
     // Result data
     @BindView(R.id.resultsMinPercentage)
     TextView resultsMinPercentage;
@@ -193,6 +197,9 @@ public class Pokefly extends Service {
     LinearLayout llMultipleIVMatches;
     @BindView(R.id.refine_by_last_scan)
     LinearLayout refine_by_last_scan;
+
+    @BindView(R.id.inputAppraisalExpandBox)
+    TextView inputAppraisalExpandBox;
 
 
     @BindView(R.id.allPosAtt)
@@ -627,6 +634,16 @@ public class Pokefly extends Service {
         arrowAnimator.start();
     }
 
+
+
+    @OnClick({R.id.inputAppraisalExpandBox})
+    public void toggleAppraisalBox() {
+        if (appraisalBox.getVisibility() == View.VISIBLE) {
+            appraisalBox.setVisibility(View.GONE);
+        } else {
+            appraisalBox.setVisibility(View.VISIBLE);
+        }
+    }
 
     @OnClick(R.id.btnDecrementLevel)
     public void decrementLevel() {

--- a/app/src/main/res/layout/dialog_input.xml
+++ b/app/src/main/res/layout/dialog_input.xml
@@ -39,7 +39,7 @@
         <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
+            android:orientation="horizontal"
             android:gravity="center"
             android:layout_weight="1">
 
@@ -59,6 +59,7 @@
                 android:textColor="@color/colorPrimary"
                 android:text="XX"
                 android:maxLength="4"
+                android:minWidth="80dp"
                 android:textAlignment="center"
                 android:inputType="number"/>
 
@@ -69,7 +70,7 @@
         <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
+            android:orientation="horizontal"
             android:gravity="center"
             android:layout_weight="1">
 
@@ -87,6 +88,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textColor="@color/colorPrimary"
+                android:minWidth="80dp"
                 android:text="XX"
                 android:maxLength="4"
                 android:textAlignment="center"
@@ -96,12 +98,15 @@
 
     </LinearLayout>
 
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="10dp"/>
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/use_the_slider_below_to_align_the_arc"
-        android:textColor="@color/black"
-        android:textSize="18sp"
+        android:textColor="@color/importantText"
+        android:textSize="14sp"
         android:textStyle="bold"
         android:gravity="center"/>
 
@@ -140,67 +145,24 @@
     </LinearLayout>
 
     <TextView
+        android:id="@+id/inputAppraisalExpandBox"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/appraisal_narrowing"
-        android:textColor="@color/importantText"
+        android:textColor="@color/colorPrimary"
         android:layout_marginStart="6sp"
-        android:textAlignment="center"/>
+        android:textAlignment="center"
+        android:clickable="true"
+        android:drawableRight="@drawable/ic_keyboard_arrow_right_blue_18dp" />/>
 
     <Space
         android:layout_width="1dp"
         android:layout_height="15dp"
         />
 
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
 
-        <View
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            />
-        <CheckBox
-            android:id="@+id/attCheckbox"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="@color/importantText"
-            android:text="@string/attack"/>
-        <View
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            />
-        <CheckBox
-            android:id="@+id/defCheckbox"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="@color/importantText"
-            android:text="@string/defense"/>
-        <View
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            />
-        <CheckBox
-            android:id="@+id/staCheckbox"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="@color/importantText"
-            android:text="@string/stamina_hp"/>
+    <include layout="@layout/dialog_input_appraisal"
+        android:visibility="gone"
+        android:id="@+id/appraisalBox"></include>
 
-        <View
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        />
-
-
-    </LinearLayout>
-    <Space
-        android:layout_width="1dp"
-        android:layout_height="15dp"
-        />
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_input_appraisal.xml
+++ b/app/src/main/res/layout/dialog_input_appraisal.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            />
+        <CheckBox
+            android:id="@+id/attCheckbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/importantText"
+            android:text="@string/attack"/>
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            />
+        <CheckBox
+            android:id="@+id/defCheckbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/importantText"
+            android:text="@string/defense"/>
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            />
+        <CheckBox
+            android:id="@+id/staCheckbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/importantText"
+            android:text="@string/stamina_hp"/>
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            />
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="15dp"
+            />
+
+    </LinearLayout>
+</LinearLayout>


### PR DESCRIPTION
Solves that the HP is covered for some screen densities, which makes it hard to confirm that the hp scan is correct.

Known not to work in this pull request:
The arrow for expanding the appraisal info does not change on expand, I haven't looked into how to animate drawables.

EDIT: Fixes #239.
