### PR TITLE
Prevent scanPokemon from hanging the app (#284)

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1158,20 +1158,15 @@ public class Pokefly extends Service {
     private void scanPokemon(Bitmap pokemonImage, String filePath) {
         //WARNING: this method *must* always send an intent at the end, no matter what, to avoid the application hanging.
         Intent info = Pokefly.createNoInfoIntent();
-        if (ocr == null) {
-            Toast.makeText(Pokefly.this, "Screen analysis module not initialized", Toast.LENGTH_LONG).show();
-        } else {
-            try {
-                ocr.scanPokemon(pokemonImage, trainerLevel);
-                if (ocr.candyName.equals("") && ocr.pokemonHP == 10 && ocr.pokemonCP == 10) { //the default values for a failed scan, if all three fail, then probably scrolled down.
-                    Toast.makeText(Pokefly.this, getString(R.string.scan_pokemon_failed), Toast.LENGTH_SHORT).show();
-                }
-                Pokefly.populateInfoIntent(info, ocr.pokemonName, ocr.candyName, ocr.pokemonHP, ocr.pokemonCP, ocr.estimatedPokemonLevel, filePath);
-            } finally {
-                LocalBroadcastManager.getInstance(Pokefly.this).sendBroadcast(info);
+        try {
+            ocr.scanPokemon(pokemonImage, trainerLevel);
+            if (ocr.candyName.equals("") && ocr.pokemonHP == 10 && ocr.pokemonCP == 10) { //the default values for a failed scan, if all three fail, then probably scrolled down.
+                Toast.makeText(Pokefly.this, getString(R.string.scan_pokemon_failed), Toast.LENGTH_SHORT).show();
             }
+            Pokefly.populateInfoIntent(info, ocr.pokemonName, ocr.candyName, ocr.pokemonHP, ocr.pokemonCP, ocr.estimatedPokemonLevel, filePath);
+        } finally {
+            LocalBroadcastManager.getInstance(Pokefly.this).sendBroadcast(info);
         }
-
     }
 
     /**


### PR DESCRIPTION
Revert "Warning toast in case of error case or ocr slow
init" (9ac1355ba784d1b85700d110edfd775c8421c377). As discussed in #284,
this null check should be unnecessary; if it is necessary, crashing
might be better than mitigating the bug and hang.

Fix #284.
Don't merge yet since we're apparently still debugging it. Ping @sarav.