### PR TITLE
Fix input dialog and expanded results box, V3

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -629,41 +629,31 @@ public class Pokefly extends Service {
 
     }
 
-
-    @OnClick({R.id.resultsMoreInformationText})
-    public void toggleMoreResultsBox() {
+    private void toggleVisibility(TextView expanderText, LinearLayout expandedBox) {
         int boxVisibility;
         Drawable arrowDrawable;
-        if (expandedResultsBox.getVisibility() == View.VISIBLE) {
+        if (expandedBox.getVisibility() == View.VISIBLE) {
             boxVisibility = View.GONE;
             arrowDrawable = getResources().getDrawable(R.drawable.arrow_collapse);
         } else {
             boxVisibility = View.VISIBLE;
             arrowDrawable = getResources().getDrawable(R.drawable.arrow_expand);
         }
-        resultsMoreInformationText.setCompoundDrawablesWithIntrinsicBounds(null, null, arrowDrawable, null);
+        expanderText.setCompoundDrawablesWithIntrinsicBounds(null, null, arrowDrawable, null);
         arrowAnimator = ObjectAnimator.ofInt(arrowDrawable, "level", 0, 10000).setDuration(100);
         arrowAnimator.start();
-        expandedResultsBox.setVisibility(boxVisibility);
+        expandedBox.setVisibility(boxVisibility);
     }
 
 
+    @OnClick({R.id.resultsMoreInformationText})
+    public void toggleMoreResultsBox() {
+        toggleVisibility(resultsMoreInformationText, expandedResultsBox);
+    }
 
     @OnClick({R.id.inputAppraisalExpandBox})
     public void toggleAppraisalBox() {
-        int boxVisibility;
-        Drawable arrowDrawable;
-        if (appraisalBox.getVisibility() == View.VISIBLE) {
-            boxVisibility = View.GONE;
-            arrowDrawable = getResources().getDrawable(R.drawable.arrow_collapse);
-        } else {
-            boxVisibility = View.VISIBLE;
-            arrowDrawable = getResources().getDrawable(R.drawable.arrow_expand);
-        }
-        inputAppraisalExpandBox.setCompoundDrawablesWithIntrinsicBounds(null, null, arrowDrawable, null);
-        arrowAnimator = ObjectAnimator.ofInt(arrowDrawable, "level", 0, 10000).setDuration(100);
-        arrowAnimator.start();
-        appraisalBox.setVisibility(boxVisibility);
+        toggleVisibility(inputAppraisalExpandBox, appraisalBox);
     }
 
     @OnClick(R.id.btnDecrementLevel)

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -127,8 +127,6 @@ public class Pokefly extends Service {
     private PokeInfoCalculator pokeCalculator = null;
 
     private Animator arrowAnimator;
-    private Drawable inputAppraisalExpandBoxArrowDrawable;
-    private Drawable resultsMoreInformationArrowDrawable;
 
     @BindView(R.id.tvSeeAllPossibilities)
     TextView seeAllPossibilities;
@@ -634,36 +632,38 @@ public class Pokefly extends Service {
 
     @OnClick({R.id.resultsMoreInformationText})
     public void toggleMoreResultsBox() {
-        int expandedResultsBoxVisibility;
+        int boxVisibility;
+        Drawable arrowDrawable;
         if (expandedResultsBox.getVisibility() == View.VISIBLE) {
-            expandedResultsBoxVisibility = View.GONE;
-            resultsMoreInformationArrowDrawable = getResources().getDrawable(R.drawable.arrow_collapse);
+            boxVisibility = View.GONE;
+            arrowDrawable = getResources().getDrawable(R.drawable.arrow_collapse);
         } else {
-            expandedResultsBoxVisibility = View.VISIBLE;
-            resultsMoreInformationArrowDrawable = getResources().getDrawable(R.drawable.arrow_expand);
+            boxVisibility = View.VISIBLE;
+            arrowDrawable = getResources().getDrawable(R.drawable.arrow_expand);
         }
-        resultsMoreInformationText.setCompoundDrawablesWithIntrinsicBounds(null, null, resultsMoreInformationArrowDrawable, null);
-        arrowAnimator = ObjectAnimator.ofInt(resultsMoreInformationArrowDrawable, "level", 0, 10000).setDuration(100);
+        resultsMoreInformationText.setCompoundDrawablesWithIntrinsicBounds(null, null, arrowDrawable, null);
+        arrowAnimator = ObjectAnimator.ofInt(arrowDrawable, "level", 0, 10000).setDuration(100);
         arrowAnimator.start();
-        expandedResultsBox.setVisibility(expandedResultsBoxVisibility);
+        expandedResultsBox.setVisibility(boxVisibility);
     }
 
 
 
     @OnClick({R.id.inputAppraisalExpandBox})
     public void toggleAppraisalBox() {
-        int appraisalBoxVisibility;
+        int boxVisibility;
+        Drawable arrowDrawable;
         if (appraisalBox.getVisibility() == View.VISIBLE) {
-            appraisalBoxVisibility = View.GONE;
-            inputAppraisalExpandBoxArrowDrawable = getResources().getDrawable(R.drawable.arrow_collapse);
+            boxVisibility = View.GONE;
+            arrowDrawable = getResources().getDrawable(R.drawable.arrow_collapse);
         } else {
-            appraisalBoxVisibility = View.VISIBLE;
-            inputAppraisalExpandBoxArrowDrawable = getResources().getDrawable(R.drawable.arrow_expand);
+            boxVisibility = View.VISIBLE;
+            arrowDrawable = getResources().getDrawable(R.drawable.arrow_expand);
         }
-        inputAppraisalExpandBox.setCompoundDrawablesWithIntrinsicBounds(null, null, inputAppraisalExpandBoxArrowDrawable, null);
-        arrowAnimator = ObjectAnimator.ofInt(inputAppraisalExpandBoxArrowDrawable, "level", 0, 10000).setDuration(100);
+        inputAppraisalExpandBox.setCompoundDrawablesWithIntrinsicBounds(null, null, arrowDrawable, null);
+        arrowAnimator = ObjectAnimator.ofInt(arrowDrawable, "level", 0, 10000).setDuration(100);
         arrowAnimator.start();
-        appraisalBox.setVisibility(appraisalBoxVisibility);
+        appraisalBox.setVisibility(boxVisibility);
     }
 
     @OnClick(R.id.btnDecrementLevel)

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -116,8 +116,9 @@ public class Pokefly extends Service {
 
     private PokeInfoCalculator pokeCalculator = null;
 
-    private Drawable arrowDrawable;
     private Animator arrowAnimator;
+    private Drawable inputAppraisalExpandBoxArrowDrawable;
+    private Drawable resultsMoreInformationArrowDrawable;
 
     @BindView(R.id.tvSeeAllPossibilities)
     TextView seeAllPossibilities;
@@ -622,27 +623,36 @@ public class Pokefly extends Service {
 
     @OnClick({R.id.resultsMoreInformationText})
     public void toggleMoreResultsBox() {
+        int expandedResultsBoxVisibility;
         if (expandedResultsBox.getVisibility() == View.VISIBLE) {
-            expandedResultsBox.setVisibility(View.GONE);
-            arrowDrawable = getResources().getDrawable(R.drawable.arrow_collapse);
+            expandedResultsBoxVisibility = View.GONE;
+            resultsMoreInformationArrowDrawable = getResources().getDrawable(R.drawable.arrow_collapse);
         } else {
-            expandedResultsBox.setVisibility(View.VISIBLE);
-            arrowDrawable = getResources().getDrawable(R.drawable.arrow_expand);
+            expandedResultsBoxVisibility = View.VISIBLE;
+            resultsMoreInformationArrowDrawable = getResources().getDrawable(R.drawable.arrow_expand);
         }
-        resultsMoreInformationText.setCompoundDrawablesWithIntrinsicBounds(null, null, arrowDrawable, null);
-        arrowAnimator = ObjectAnimator.ofInt(arrowDrawable, "level", 0, 10000).setDuration(200);
+        resultsMoreInformationText.setCompoundDrawablesWithIntrinsicBounds(null, null, resultsMoreInformationArrowDrawable, null);
+        arrowAnimator = ObjectAnimator.ofInt(resultsMoreInformationArrowDrawable, "level", 0, 10000).setDuration(100);
         arrowAnimator.start();
+        expandedResultsBox.setVisibility(expandedResultsBoxVisibility);
     }
 
 
 
     @OnClick({R.id.inputAppraisalExpandBox})
     public void toggleAppraisalBox() {
+        int appraisalBoxVisibility;
         if (appraisalBox.getVisibility() == View.VISIBLE) {
-            appraisalBox.setVisibility(View.GONE);
+            appraisalBoxVisibility = View.GONE;
+            inputAppraisalExpandBoxArrowDrawable = getResources().getDrawable(R.drawable.arrow_collapse);
         } else {
-            appraisalBox.setVisibility(View.VISIBLE);
+            appraisalBoxVisibility = View.VISIBLE;
+            inputAppraisalExpandBoxArrowDrawable = getResources().getDrawable(R.drawable.arrow_expand);
         }
+        inputAppraisalExpandBox.setCompoundDrawablesWithIntrinsicBounds(null, null, inputAppraisalExpandBoxArrowDrawable, null);
+        arrowAnimator = ObjectAnimator.ofInt(inputAppraisalExpandBoxArrowDrawable, "level", 0, 10000).setDuration(100);
+        arrowAnimator.start();
+        appraisalBox.setVisibility(appraisalBoxVisibility);
     }
 
     @OnClick(R.id.btnDecrementLevel)
@@ -923,10 +933,20 @@ public class Pokefly extends Service {
 
         extendedEvolutionSpinner.setEnabled(extendedEvolutionSpinner.getCount() > 1);
 
-        CPRange expectedRange = pokeCalculator.getCpRangeAtLevel(selectedPokemon, ivScanResult.lowAttack, ivScanResult.lowDefense, ivScanResult.lowStamina, ivScanResult.highAttack, ivScanResult.highDefense, ivScanResult.highStamina, goalLevel);
+        CPRange expectedRange = pokeCalculator.getCpRangeAtLevel(selectedPokemon,
+                ivScanResult.lowAttack, ivScanResult.lowDefense, ivScanResult.lowStamina,
+                ivScanResult.highAttack, ivScanResult.highDefense, ivScanResult.highStamina,goalLevel);
         int realCP = ivScanResult.scannedCP;
         int expectedAverage = (expectedRange.high + expectedRange.low) / 2;
-        exResultCP.setText(String.valueOf(expectedAverage) + " (+" + (expectedAverage - realCP) + ")");
+        String exResultCPStr = String.valueOf(expectedAverage);
+
+        int diffCP = expectedAverage - realCP;
+        if (diffCP >= 0) {
+            exResultCPStr += " (+" + diffCP + ")";
+        } else {
+            exResultCPStr += " (" + diffCP + ")";
+        }
+        exResultCP.setText(exResultCPStr);
 
         UpgradeCost cost = pokeCalculator.getUpgradeCost(goalLevel, estimatedPokemonLevel);
         int evolutionCandyCost = pokeCalculator.getCandyCostForEvolution(ivScanResult.pokemon, selectedPokemon);

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -144,6 +144,10 @@ public class Pokefly extends Service {
     @BindView(R.id.allPossibilitiesBox)
     LinearLayout allPossibilitiesBox;
 
+
+    @BindView(R.id.appraisalBox)
+    LinearLayout appraisalBox;
+
     // Result data
     @BindView(R.id.resultsMinPercentage)
     TextView resultsMinPercentage;
@@ -193,6 +197,9 @@ public class Pokefly extends Service {
     LinearLayout llMultipleIVMatches;
     @BindView(R.id.refine_by_last_scan)
     LinearLayout refine_by_last_scan;
+
+    @BindView(R.id.inputAppraisalExpandBox)
+    TextView inputAppraisalExpandBox;
 
 
     @BindView(R.id.allPosAtt)
@@ -627,6 +634,16 @@ public class Pokefly extends Service {
         arrowAnimator.start();
     }
 
+
+
+    @OnClick({R.id.inputAppraisalExpandBox})
+    public void toggleAppraisalBox() {
+        if (appraisalBox.getVisibility() == View.VISIBLE) {
+            appraisalBox.setVisibility(View.GONE);
+        } else {
+            appraisalBox.setVisibility(View.VISIBLE);
+        }
+    }
 
     @OnClick(R.id.btnDecrementLevel)
     public void decrementLevel() {

--- a/app/src/main/res/layout/dialog_input.xml
+++ b/app/src/main/res/layout/dialog_input.xml
@@ -39,7 +39,7 @@
         <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
+            android:orientation="horizontal"
             android:gravity="center"
             android:layout_weight="1">
 
@@ -59,6 +59,7 @@
                 android:textColor="@color/colorPrimary"
                 android:text="XX"
                 android:maxLength="4"
+                android:minWidth="80dp"
                 android:textAlignment="center"
                 android:inputType="number"/>
 
@@ -69,7 +70,7 @@
         <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
+            android:orientation="horizontal"
             android:gravity="center"
             android:layout_weight="1">
 
@@ -87,6 +88,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textColor="@color/colorPrimary"
+                android:minWidth="80dp"
                 android:text="XX"
                 android:maxLength="4"
                 android:textAlignment="center"
@@ -96,12 +98,15 @@
 
     </LinearLayout>
 
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="10dp"/>
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/use_the_slider_below_to_align_the_arc"
-        android:textColor="@color/black"
-        android:textSize="18sp"
+        android:textColor="@color/importantText"
+        android:textSize="14sp"
         android:textStyle="bold"
         android:gravity="center"/>
 
@@ -140,67 +145,24 @@
     </LinearLayout>
 
     <TextView
+        android:id="@+id/inputAppraisalExpandBox"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/appraisal_narrowing"
-        android:textColor="@color/importantText"
+        android:textColor="@color/colorPrimary"
         android:layout_marginStart="6sp"
-        android:textAlignment="center"/>
+        android:textAlignment="center"
+        android:clickable="true"
+        android:drawableRight="@drawable/ic_keyboard_arrow_right_blue_18dp" />/>
 
     <Space
         android:layout_width="1dp"
         android:layout_height="15dp"
         />
 
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
 
-        <View
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            />
-        <CheckBox
-            android:id="@+id/attCheckbox"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="@color/importantText"
-            android:text="@string/attack"/>
-        <View
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            />
-        <CheckBox
-            android:id="@+id/defCheckbox"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="@color/importantText"
-            android:text="@string/defense"/>
-        <View
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            />
-        <CheckBox
-            android:id="@+id/staCheckbox"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="@color/importantText"
-            android:text="@string/stamina_hp"/>
+    <include layout="@layout/dialog_input_appraisal"
+        android:visibility="gone"
+        android:id="@+id/appraisalBox"></include>
 
-        <View
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        />
-
-
-    </LinearLayout>
-    <Space
-        android:layout_width="1dp"
-        android:layout_height="15dp"
-        />
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_input.xml
+++ b/app/src/main/res/layout/dialog_input.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    tools:showIn="@layout/dialog_info_window">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -144,22 +146,36 @@
 
     </LinearLayout>
 
-    <TextView
-        android:id="@+id/inputAppraisalExpandBox"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/appraisal_narrowing"
-        android:textColor="@color/colorPrimary"
-        android:layout_marginStart="6sp"
-        android:textAlignment="center"
-        android:clickable="true"
-        android:drawableRight="@drawable/ic_keyboard_arrow_right_blue_18dp" />/>
+        android:padding="12sp">
 
-    <Space
-        android:layout_width="1dp"
-        android:layout_height="15dp"
-        />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
+            <TextView
+                android:id="@+id/inputAppraisalExpandBox"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/appraisal_refining"
+                android:textColor="@color/colorPrimary"
+                android:clickable="true"
+                android:drawableRight="@drawable/ic_keyboard_arrow_right_blue_18dp"
+                android:textSize="18sp"
+                android:layout_gravity="center" />
+        </LinearLayout>
+    </LinearLayout><![CDATA[
+
+    />
+
+
+
+
+    ]]>
 
     <include layout="@layout/dialog_input_appraisal"
         android:visibility="gone"

--- a/app/src/main/res/layout/dialog_input_appraisal.xml
+++ b/app/src/main/res/layout/dialog_input_appraisal.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            />
+        <CheckBox
+            android:id="@+id/attCheckbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/importantText"
+            android:text="@string/attack"/>
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            />
+        <CheckBox
+            android:id="@+id/defCheckbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/importantText"
+            android:text="@string/defense"/>
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            />
+        <CheckBox
+            android:id="@+id/staCheckbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/importantText"
+            android:text="@string/stamina_hp"/>
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            />
+
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="15dp"
+            />
+
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/expanded_results_box.xml
+++ b/app/src/main/res/layout/expanded_results_box.xml
@@ -119,10 +119,7 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:popupBackground="#FFF"
-            android:gravity="right"
-            android:layout_marginRight="-8sp"
-            android:layout_marginTop="-8sp"
-            android:layout_marginBottom="-8sp" />
+            android:gravity="right" />
 
     </LinearLayout>
     <LinearLayout

--- a/app/src/main/res/layout/expanded_results_box.xml
+++ b/app/src/main/res/layout/expanded_results_box.xml
@@ -119,7 +119,10 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:popupBackground="#FFF"
-            android:gravity="right"/>
+            android:gravity="right"
+            android:layout_marginRight="-8sp"
+            android:layout_marginTop="-8sp"
+            android:layout_marginBottom="-8sp" />
 
     </LinearLayout>
     <LinearLayout

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -52,7 +52,7 @@
     <string name="possible_iv_combinations">"%1$d Možné kombinace IV"</string>
     <string name="too_many_iv_combinations">Příliš mnoho kombinací IV</string>
     <string name="refining_instructions">Zlepši přesnost výpočtu IV powerupováním a porovnáním dvou načtení stejného Pokémona</string>
-    <string name="appraisal_narrowing">Zpřesnění díky Appraisal (volitelné)</string>
+    <string name="appraisal_refining">Zpřesnění díky Appraisal </string>
     <string name="attack">Útok</string>
     <string name="defense">Obrana</string>
     <string name="stamina_hp">HP</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -53,7 +53,7 @@
     <string name="see_all">Ver Todas</string>
     <string name="stardust_cost">Costo en Polvoestalar</string>
     <string name="refining_instructions">Refine la predicción de IV mejorando un Pokémon y comparando los resultados obtenidos</string>
-    <string name="appraisal_narrowing">Refinamiento por valoración (opcional)</string>
+    <string name="appraisal_refining">Refinamiento por valoración </string>
     <string name="attack">Ataque</string>
     <string name="defense">Defensa</string>
     <string name="stamina_hp">PS</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -58,7 +58,7 @@
     <string name="possible_iv_combinations">"%1$d combi. d\'IV possibles"</string>
     <string name="too_many_iv_combinations">Trop de combinaisons d\'IV</string>
     <string name="refining_instructions">Améliorer la précision du calcul d\'IV en rechargeant le Pokémon puis en comparant deux scans</string>
-    <string name="appraisal_narrowing">Raffiner via \'Évaluer\' (optionnel)</string>
+    <string name="appraisal_refining">Raffiner via \'Évaluer\' </string>
     <string name="attack">Attaque</string>
     <string name="defense">Défense</string>
     <string name="stamina_hp">PV</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -58,7 +58,7 @@
     <string name="possible_iv_combinations">"%1$d combinazioni di IV"</string>
     <string name="too_many_iv_combinations">Troppe combinazioni di IV</string>
     <string name="refining_instructions">Affina la precisione del calcolo IV potenziando e comparando due scansioni dello stesso Pokémon</string>
-    <string name="appraisal_narrowing">Affinamento con \'Valuta\' (opzionale)</string>
+    <string name="appraisal_refining">Affinamento con \'Valuta\'</string>
     <string name="attack">Attacco</string>
     <string name="defense">Difesa</string>
     <string name="stamina_hp">PS</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,7 +62,7 @@
     <string name="possible_iv_combinations">"%1$d Possible IV combinations"</string>
     <string name="too_many_iv_combinations">Too many IV combinations</string>
     <string name="refining_instructions">Increase IV calculation precision by leveling up and comparing two scans of the same Pokémon</string>
-    <string name="appraisal_narrowing">Appraisal narrowing (optional)</string>
+    <string name="appraisal_refining">Appraisal Refining</string>
     <string name="attack">Attack</string>
     <string name="defense">Defense</string>
     <string name="stamina_hp">HP</string>


### PR DESCRIPTION
I took #304, merged conflicts, and did a couple refactorings on the new code to reduce copy-pasting. Credits to @nahojjjen and @DJCrapsody for most of the work.

----
Quoting from #304:
As this changes were based on @nahojjjen's fixInfoDialogHeight branch, this PR should supersede https://github.com/farkam135/GoIV/pull/294.

Additional things done:
* Rename "Appraisal narrowing" to "Appraisal Refining"
* Remove "(optional)" as refining is closed by default now
* Fix layout of Appraisal Refining
* Add rotating animation to appraisal refining box arrow
* Change rotating animation to happen before dialog shows/hides
* <s>Fix alignment of Evolution spinner using negative margins</s> (I removed that)
* Fix devolution CP text by checking if result CP is negative

Fixes #272 and fixes #293.