### PR TITLE
Quick fix for the Pokedex spinner and MainActivity numberpicker display issues

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/GUIUtil.java
+++ b/app/src/main/java/com/kamron/pogoiv/GUIUtil.java
@@ -1,6 +1,8 @@
 package com.kamron.pogoiv;
 
+import android.content.Context;
 import android.graphics.Color;
+import android.util.TypedValue;
 import android.widget.TextView;
 
 /**
@@ -22,5 +24,15 @@ public class GUIUtil {
         } else {
             text.setTextColor(Color.parseColor("#8A0808")); //dark red
         }
+    }
+
+    /**
+     * Converts dp units to pixels
+     *
+     * @param dp the dp ammount you want to return as pixels
+     * @param context the context
+     */
+    public static int dpToPixels(int dp, Context context) {
+        return (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, context.getResources().getDisplayMetrics());
     }
 }

--- a/app/src/main/java/com/kamron/pogoiv/PokemonSpinnerAdapter.java
+++ b/app/src/main/java/com/kamron/pogoiv/PokemonSpinnerAdapter.java
@@ -57,6 +57,11 @@ public class PokemonSpinnerAdapter extends ArrayAdapter<Pokemon> {
         TextView row = (TextView) inflater.inflate(mTextViewResourceId, parent, false);
         Pokemon pokemon = pokemons.get(position);
         String text = String.format("#%d %s", pokemon.number + 1, pokemon.name);
+
+        int padding = GUIUtil.dpToPixels(5, mContext);
+        row.setPadding(padding, 0, 0, padding);
+        row.setTextAlignment(View.TEXT_ALIGNMENT_CENTER);
+        row.setGravity(View.TEXT_ALIGNMENT_CENTER);
         row.setText(text);
 
         return row;

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -31,7 +31,7 @@
         <NumberPicker
             android:id="@+id/trainerLevel"
             android:layout_width="75dp"
-            android:layout_height="wrap_content"
+            android:layout_height="100dp"
             android:gravity="end"
             android:inputType="number"
             android:textAlignment="center"/>

--- a/app/src/main/res/layout/spinner_evolution.xml
+++ b/app/src/main/res/layout/spinner_evolution.xml
@@ -6,5 +6,4 @@
     android:textSize="20sp"
     android:gravity="right"
     android:textColor="@drawable/spinner_color_set"
-    android:backgroundTint="#FFFFFF"
-    android:padding="5dip" />
+    android:backgroundTint="#FFFFFF"/>


### PR DESCRIPTION
Fixes #312.
NINJA EDIT: This PR also reduces main activity numberpicker height as discussed in #273.

I'm summoning @DJCrapsody and @nahojjjen to the discussion.

I gave a look to the code of our spinners and it turns out that we are inflating a single textbox in the adapter. Currently it's the same xml resource that we use to show the selected Pokémon, so they share their settings.

What I do here as a quick fix is to leave the TextView without margins and padding (so it aligns nicely to the right on the advanced information panel) and provide the inflated TextView instance that we use to display as each item in the dropdown with some new properties (padding, text align, gravity), so it shows its contents at the center.

Now, this works, but I'd like to make a sencond pass later and maybe rework this small layouts and adapter. To maybe display two columns of data as a means to make it easier to the eyes to quickly scan the information. That would be a column for the 'mon Pokédex number, another for the name (we can discuss how to align the texts) and maybe use a striped pattern like the results screen.

I'd like to hear what you guys think. 
Also, feel free to merge this change in the meantime because I'm a little constrained with my times lately and I would hate to not make it in time for the next release, so I'll be at peace if at least this small fix is working.