### PR TITLE
Make more strings translatable and update French translation

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -806,7 +806,7 @@ public class Pokefly extends Service {
      */
     private void populateResultsHeader(IVScanResult ivScanResult) {
         resultsPokemonName.setText(ivScanResult.pokemon.name);
-        resultsPokemonLevel.setText(getString(R.string.level) + ": " + ivScanResult.estimatedPokemonLevel);
+        resultsPokemonLevel.setText(getString(R.string.level) + " " + ivScanResult.estimatedPokemonLevel);
     }
 
     /**
@@ -819,7 +819,7 @@ public class Pokefly extends Service {
         llMinIV.setVisibility(View.VISIBLE);
         llSingleMatch.setVisibility(View.GONE);
         llMultipleIVMatches.setVisibility(View.VISIBLE);
-        tvAvgIV.setText("AVG");
+        tvAvgIV.setText(getString(R.string.avg));
         if (ivScanResult.tooManyPossibilities) {
             resultsCombinations.setText(getString(R.string.too_many_iv_combinations));
         } else {

--- a/app/src/main/res/layout/dialog_results.xml
+++ b/app/src/main/res/layout/dialog_results.xml
@@ -74,7 +74,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="ATK"
+                    android:text="@string/atk"
                     android:layout_margin="0dp"
                     android:textSize="12sp"
                     android:gravity="center"
@@ -108,7 +108,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="DEF"
+                    android:text="@string/def"
                     android:textSize="12sp"
                     android:layout_margin="0dp"
                     android:textColor="#222"/>
@@ -142,7 +142,7 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="STA"
+                    android:text="@string/sta"
                     android:textSize="12sp"
                     android:layout_margin="0dp"
                     android:textColor="#222"/>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -58,10 +58,19 @@
     <string name="possible_iv_combinations">"%1$d combi. d\'IV possibles"</string>
     <string name="too_many_iv_combinations">Trop de combinaisons d\'IV</string>
     <string name="refining_instructions">Améliorer la précision du calcul d\'IV en rechargeant le Pokémon puis en comparant deux scans</string>
-    <string name="appraisal_refining">Raffiner via \'Évaluer\' </string>
+    <string name="appraisal_refining">Raffiner via \'Évaluer\'</string>
     <string name="attack">Attaque</string>
     <string name="defense">Défense</string>
     <string name="stamina_hp">PV</string>
     <string name="missing_inputs">Données manquantes. Veuillez remplir les champs PC et PV.</string>
     <string name="ivtext_no_possibilities">Aucune combinaison d\'IV possible pour ces données. Veuillez vérifier les informations.</string>
+    <string name="checking_for_update">Recherche de mise à jour&#8230;</string>
+    <string name="ongoing_update">Une mise à jour de GoIV est déjà en cours de téléchargement</string>
+    <string name="up_to_date">L\'appli est à jour</string>
+    <string name="update_check_failed">Erreur pendant la recherche de mise à jour. Veuillez vérifier votre connexion internet</string>
+    <string name="iv_perfect">% Parfait</string>
+    <string name="avg">MOY</string>
+    <string name="atk">ATQ</string>
+    <string name="def">DÉF</string>
+    <string name="sta">PV</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,4 +73,10 @@
     <string name="checking_for_update">Checking for update...</string>
     <string name="ongoing_update">An update for GoIV is already being downloaded</string>
     <string name="iv_perfect">% Perfect</string>
+    <string name="min">MIN</string>
+    <string name="max">MAX</string>
+    <string name="avg">AVG</string>
+    <string name="atk">ATK</string>
+    <string name="def">DEF</string>
+    <string name="sta">STA</string>
 </resources>


### PR DESCRIPTION
The ATK, DEF, STA and MIN, AVG, MAX strings couldn't be translated, so I tried to change that. Here's how it looks on my phone now, in French: http://imgur.com/a/MNWYf