### PR TITLE
Load credentials from keystore.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ captures/
 # Keystore files
 *.jks
 **/*.jks
+keystore.properties

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,3 +32,6 @@ You can do so by following these *rules* (taken from this great [article](http:/
 * Use the imperative mood in the subject line
 * Wrap the body at 72 characters
 * Use the body to explain what and why vs. how
+
+## Generating Signed Release Builds
+Follow the instructions under [Sign Your Release Build] (https://developer.android.com/studio/publish/app-signing.html#release-mode) to generate your own keystore.jks file. Place the generated keystore.jks in `<path-to-go-iv>/app`. Make a copy of keystore.properties.sample and rename it to keystore.properties. Change the fields to correspond to your own generated keystore and you should be good to go.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,29 @@ repositories {
 
 apply plugin: 'android-apt'
 
+def keystoreProperties = new Properties()
+
+if (new File('keystore.properties').exists()) {
+    def keystorePropertiesFile = rootProject.file('keystore.properties')
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+else {
+    keystoreProperties.keyAlias = 'your_key_alias'
+    keystoreProperties.keyPassword = 'your_key_password'
+    keystoreProperties.storeFile = 'your_keystore.jks'
+    keystoreProperties.storePassword = 'your_keystore_password'
+}
+
 android {
+
+    signingConfigs {
+        releaseConfig {
+            keyAlias keystoreProperties['keyAlias']
+            keyPassword keystoreProperties['keyPassword']
+            storeFile file(keystoreProperties['storeFile'])
+            storePassword keystoreProperties['storePassword']
+        }
+    }
 
     compileSdkVersion 24
     buildToolsVersion "24.0.1"
@@ -61,6 +83,7 @@ android {
             lintOptions {
                 disable 'MissingTranslation'
             }
+            signingConfig signingConfigs.releaseConfig
         }
     }
 }

--- a/keystore.properties.sample
+++ b/keystore.properties.sample
@@ -1,0 +1,4 @@
+keyAlias=your_key_alias
+keyPassword=your_key_password
+storeFile=your_keystore.jks
+storePassword=your_keystore_password


### PR DESCRIPTION
I don't know how everyone else generates signed release builds, but I thought this might be helpful.

Please let me know if there is a better way.