### PR TITLE
Remove deadlock we had

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1239,8 +1239,8 @@ public class Pokefly extends Service {
         @Override
         public void onReceive(Context context, Intent intent) {
             if (!receivedInfo) {
-                receivedInfo = true;
                 if (intent.hasExtra(KEY_SEND_INFO_NAME) && intent.hasExtra(KEY_SEND_INFO_CP) && intent.hasExtra(KEY_SEND_INFO_HP) && intent.hasExtra(KEY_SEND_INFO_LEVEL)) {
+                    receivedInfo = true;
                     pokemonName = intent.getStringExtra(KEY_SEND_INFO_NAME);
                     candyName = intent.getStringExtra(KEY_SEND_INFO_CANDY);
                     pokemonCP = intent.getIntExtra(KEY_SEND_INFO_CP, 0);


### PR DESCRIPTION
Here's a potentail deadlock: If scanning fails we produce and send an
empty intent. Right now if we receive that, we set `receivedInfo` even
though we received no info, so the next button press will be ignored.
Usually the flag would be cleared by closing the input/result
dialogs—but since we're showing none, that's not possible!

IIRC I introduced this, sorry. But finally I found it (I think).

Testing.