### PR TITLE
Quickfix manual screenshot mode

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
+++ b/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
@@ -40,7 +40,7 @@ public class GoIVSettings {
 
     public boolean isManualScreenshotModeEnabled() {
         //XXX unify with code in SettingsActivity.java
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT_WATCH) {
             return true;
         } else {
             return prefs.getBoolean(MANUAL_SCREENSHOT_MODE, false);

--- a/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
+++ b/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
@@ -2,6 +2,7 @@ package com.kamron.pogoiv;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 
 public class GoIVSettings {
 
@@ -38,7 +39,12 @@ public class GoIVSettings {
     }
 
     public boolean isManualScreenshotModeEnabled() {
-        return prefs.getBoolean(MANUAL_SCREENSHOT_MODE, false);
+        //XXX unify with code in SettingsActivity.java
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+            return true;
+        } else {
+            return prefs.getBoolean(MANUAL_SCREENSHOT_MODE, false);
+        }
     }
 
     public boolean shouldDeleteScreenshots() {

--- a/app/src/main/java/com/kamron/pogoiv/SettingsActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/SettingsActivity.java
@@ -85,7 +85,7 @@ public class SettingsActivity extends AppCompatActivity {
                 preferenceScreen.removePreference(checkForUpdatePreference);
             }
 
-            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT_WATCH) {
                 SwitchPreference manualScreenshotModePreference = (SwitchPreference) getPreferenceManager().findPreference(GoIVSettings.MANUAL_SCREENSHOT_MODE);
                 manualScreenshotModePreference.setDefaultValue(true);
                 manualScreenshotModePreference.setChecked(true);


### PR DESCRIPTION
Fix #315. A bit hacky, but I'm not sure how to change settings from
elsewhere, and where, and we're in a hurry.

And force screenshot mode also for API level 20.

Nobody should be running GoIV on Android Wear IMHO, but there are
unexpected crashes on Android 5 with NoClassDefFoundError for the
MediaProjectionManager API, so let's rule that out more clearly.