### PR TITLE
Prevent checkstyle violations through Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ jdk:
   - oraclejdk8
 
 script:
-   - ./gradlew assembleDebug testOnlineDebugUnitTest testOfflineDebugUnitTest
+   - ./gradlew assembleDebug testOnlineDebugUnitTest testOfflineDebugUnitTest checkstyle
      # build  # Would try need the online version, that seems to need fabric IDs.
      # connectedCheck # Would try building the release version, that needs certificates

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,7 +8,7 @@
 
 ## Project Set-up for GoIV (Required)
 * [Fork GoIV Repo] (https://help.github.com/articles/fork-a-repo/)
-* Copy GoIVCodeStyle.xml into the codestyles folder under the Android Studio preferences folder *(create codestyles folder if it does not exist)*
+* Copy `GoIVCodeStyle.xml` into the codestyles folder under the Android Studio preferences folder *(create codestyles folder if it does not exist)*
  *  Windows: `\%USERPROFILE%\.{ANDROID_STUDIO_FOLDER}\config\codestyles\`
  *  OS X: `~/Library/Preferences/{ANDROID_STUDIO_FOLDER}/codestyles/`
  *  Linux: `./.{ANDROID_STUDIO_FOLDER}/config/codestyles/`
@@ -16,6 +16,9 @@
 * Select Code Style Scheme (`File > Settings > Editor > Code Style > Scheme > Select 'GoIVCodeStyle'`)
 
 *__{ANDROID_STUDIO_FOLDER}__ varies on the Android Studio version installed. Read more [here](http://tools.android.com/tech-docs/configuration).*
+
+## Updating Codestyle Definition
+If `GoIVCodeStyle.xml` has changed, close Android Studio, copy our file over the copy in Android Studio settings as above, and reopen Android Studio. The new setting should be loaded.
 
 ## Optional Set-up
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,6 +19,13 @@
 
 ## Optional Set-up
 
+### CheckStyle Plugin
+This plugin checks the codebase for violations of coding style.
+* Install CheckStyle Plugin (`Configure > Plugins > Browse Repositories > Search 'CheckStyle-IDEA' > Install`)
+* Restart Android Studio if requested.
+
+This is especially important to send pull requests.
+
 ### Lombok Plugin
 GoIV project uses Lombok Plugin to automatically generate various methods (i.e. Getter, Setters). Without this plugin, `Unable to resolve method` errors will show, but code will compile and build as per normal.
 * Close the Project *(required to enable annotation processing)*
@@ -34,6 +41,9 @@ Set-up Git on Android Studio to automate Git commands. For developers who are *l
 [Syncing your fork] (https://help.github.com/articles/syncing-a-fork/) will keep it up to date with the latest commits on the main repo. This will also reduce the chances of getting merge conflicts. Always sync your fork before working on it!
 
 ## Contributing with Pull Requests
+
+### Ensure Commits Follow Coding Style
+Use Android Studio autoformatting and check with CheckStyle that your PR does not add coding style violations.
 
 ### Splitting Pull Requests
 Please open separate PR's for separate bug fixes or features. It helps us to review your PR's.

--- a/GoIVCodeStyle.xml
+++ b/GoIVCodeStyle.xml
@@ -27,6 +27,8 @@
     </value>
   </option>
   <option name="RIGHT_MARGIN" value="100" />
+  <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
+  <option name="JD_KEEP_EMPTY_RETURN" value="false" />
   <AndroidXmlCodeStyleSettings>
     <option name="USE_CUSTOM_SETTINGS" value="true" />
   </AndroidXmlCodeStyleSettings>
@@ -66,7 +68,10 @@
   </XML>
   <codeStyleSettings language="JAVA">
     <option name="RIGHT_MARGIN" value="120" />
+    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+    <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
     <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="PREFER_PARAMETERS_WRAP" value="true" />
     <option name="METHOD_PARAMETERS_WRAP" value="1" />
     <option name="RESOURCE_LIST_WRAP" value="1" />
     <option name="EXTENDS_LIST_WRAP" value="1" />
@@ -75,12 +80,19 @@
     <option name="THROWS_KEYWORD_WRAP" value="1" />
     <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
     <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
     <option name="TERNARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
     <option name="FOR_STATEMENT_WRAP" value="1" />
     <option name="ARRAY_INITIALIZER_WRAP" value="1" />
-    <option name="ASSIGNMENT_WRAP" value="1" />
+    <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
     <option name="ASSERT_STATEMENT_WRAP" value="1" />
+    <option name="IF_BRACE_FORCE" value="1" />
+    <option name="DOWHILE_BRACE_FORCE" value="1" />
+    <option name="WHILE_BRACE_FORCE" value="1" />
+    <option name="FOR_BRACE_FORCE" value="1" />
     <option name="WRAP_LONG_LINES" value="true" />
+    <option name="METHOD_ANNOTATION_WRAP" value="1" />
     <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
     <option name="VARIABLE_ANNOTATION_WRAP" value="1" />
     <option name="ENUM_CONSTANTS_WRAP" value="1" />

--- a/checkstyle/checkstyle-rules.xml
+++ b/checkstyle/checkstyle-rules.xml
@@ -18,7 +18,7 @@
 <module name = "Checker">
     <property name="charset" value="UTF-8"/>
 
-    <property name="severity" value="warning"/>
+    <property name="severity" value="error"/>
 
     <property name="fileExtensions" value="java, properties, xml"/>
     <!-- Checks for whitespace                               -->


### PR DESCRIPTION
Now that I fixed all violations, enable checkstyle on Travis.

* Turn Checkstyle violations into errors.
* Run Checkstyle on Travis.
* Update the uploaded style for Android Studio.