### PR TITLE
Release builds: move Fabric keys out of manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ captures/
 *.jks
 **/*.jks
 keystore.properties
+fabric.properties

--- a/app/fabric.properties
+++ b/app/fabric.properties
@@ -1,3 +1,0 @@
-#Contains API Secret used to validate your application. Commit to internal source control; avoid making secret public.
-#Wed Aug 17 11:50:17 IST 2016
-apiSecret=PLACEHOLDER

--- a/app/fabric.properties.sample
+++ b/app/fabric.properties.sample
@@ -1,0 +1,8 @@
+# Contains API Secret used to validate your application. Avoid committing to
+# source control to avoid making secret public.
+#
+# For release builds, copy this file as app/fabric.properties and replace by
+# your key/secret, that you can gather from
+# https://www.fabric.io/settings/organizations.
+apiKey=0000000000000000000000000000000000000000
+apiSecret=0000000000000000000000000000000000000000000000000000000000000000

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -78,10 +78,6 @@
         <service android:name=".updater.DownloadUpdateService"
             android:exported="false" />
 
-        <meta-data
-            android:name="io.fabric.ApiKey"
-            android:value="PLACEHOLDER" />
-
     </application>
 
 </manifest>


### PR DESCRIPTION
This way, adding a fabric key will not require editing the manifest.
@farkam135 I'll merge this soon, you'll have to adapt before next release.

Next step: allow release builds on Travis.