### PR TITLE
Use Optional for scan failures in HP/CP, avoid defaulting to 10

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -132,6 +132,7 @@ dependencies {
     compile 'com.jakewharton:butterknife:8.4.0'
     compile 'com.jakewharton.timber:timber:4.3.0'
     compile 'com.rmtheis:tess-two:6.0.4'
+    compile 'com.google.guava:guava:19.0'
     onlineCompile 'com.squareup.okhttp3:okhttp:3.4.1'
     onlineCompile 'com.squareup.okio:okio:1.10.0'
     compile 'io.apptik.widget:multislider:1.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -133,6 +133,9 @@ dependencies {
     compile 'com.jakewharton.timber:timber:4.3.0'
     compile 'com.rmtheis:tess-two:6.0.4'
     compile 'com.google.guava:guava:19.0'
+    //jsr305 is needed by Guava in release builds.
+    compile 'com.google.code.findbugs:jsr305:3.0.1'
+
     onlineCompile 'com.squareup.okhttp3:okhttp:3.4.1'
     onlineCompile 'com.squareup.okio:okio:1.10.0'
     compile 'io.apptik.widget:multislider:1.2'

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -23,3 +23,9 @@
 -keep class org.** { *; }
 -keep class com.** {*;}
 -dontwarn okio.**
+
+# For Guava
+-dontwarn sun.misc.Unsafe
+-dontwarn com.google.j2objc.annotations.Weak
+-dontwarn java.lang.ClassValue
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement

--- a/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
@@ -261,12 +261,8 @@ public class OcrHelper {
         if (candyName == null) {
             candy = replaceColors(candy, 68, 105, 108, Color.WHITE, 200, true);
             tesseract.setImage(candy);
-            try {
-                candyName = fixOcrNumsToLetters(
-                        removeFirstOrLastWord(tesseract.getUTF8Text().trim().replace("-", " "), candyWordFirst));
-            } catch (StringIndexOutOfBoundsException e) {
-                candyName = "";
-            }
+            candyName = fixOcrNumsToLetters(
+                    removeFirstOrLastWord(tesseract.getUTF8Text().trim().replace("-", " "), candyWordFirst));
             candy.recycle();
             ocrCache.put(hash, candyName);
         }

--- a/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
@@ -287,9 +287,9 @@ public class OcrHelper {
             hp = replaceColors(hp, 55, 66, 61, Color.WHITE, 200, true);
             tesseract.setImage(hp);
             pokemonHPStr = tesseract.getUTF8Text();
-            hp.recycle();
             ocrCache.put(hash, pokemonHPStr);
         }
+        hp.recycle();
 
         if (pokemonHPStr.contains("/")) {
             try {

--- a/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
@@ -276,7 +276,6 @@ public class OcrHelper {
      * @return an integer of the interpreted pokemon name, 10 if scan failed
      */
     private int getPokemonHPFromImg(Bitmap pokemonImage) {
-        int pokemonHP = 10;
         Bitmap hp = Bitmap.createBitmap(pokemonImage, (int) Math.round(widthPixels / 2.8),
                 (int) Math.round(heightPixels / 1.8962963), (int) Math.round(widthPixels / 3.5),
                 (int) Math.round(heightPixels / 34.13333333));
@@ -300,12 +299,12 @@ public class OcrHelper {
                                 ? hpParts[1]
                                 : hpParts[0];
 
-                pokemonHP = Integer.parseInt(fixOcrLettersToNums(hpStr).replaceAll("[^0-9]", ""));
+                return Integer.parseInt(fixOcrLettersToNums(hpStr).replaceAll("[^0-9]", ""));
             } catch (NumberFormatException e) {
-                pokemonHP = 10;
+                //Fall-through to default.
             }
         }
-        return pokemonHP;
+        return 10;
     }
 
     /**
@@ -315,23 +314,22 @@ public class OcrHelper {
      * @return a CP of the pokemon, 10 if scan failed
      */
     private int getPokemonCPFromImg(Bitmap pokemonImage) {
-        int pokemonCP;
         Bitmap cp = Bitmap.createBitmap(pokemonImage, (int) Math.round(widthPixels / 3.0),
                 (int) Math.round(heightPixels / 15.5151515), (int) Math.round(widthPixels / 3.84),
                 (int) Math.round(heightPixels / 21.333333333));
         cp = replaceColors(cp, 255, 255, 255, Color.BLACK, 30, false);
         tesseract.setImage(cp);
         String cpText = fixOcrLettersToNums(tesseract.getUTF8Text());
+        cp.recycle();
+
         if (cpText.length() >= 2) { //gastly can block the "cp" text, so its not visible...
             cpText = cpText.substring(2);
         }
         try {
-            pokemonCP = Integer.parseInt(cpText);
+            return Integer.parseInt(cpText);
         } catch (NumberFormatException e) {
-            pokemonCP = 10;
+            return 10;
         }
-        cp.recycle();
-        return pokemonCP;
     }
 
     /**

--- a/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
@@ -5,6 +5,7 @@ import android.graphics.Color;
 import android.support.annotation.NonNull;
 import android.util.LruCache;
 
+import com.google.common.base.Optional;
 import com.googlecode.tesseract.android.TessBaseAPI;
 import com.kamron.pogoiv.logic.Data;
 import com.kamron.pogoiv.logic.ScanResult;
@@ -275,7 +276,7 @@ public class OcrHelper {
      * @param pokemonImage the image of the whole screen
      * @return an integer of the interpreted pokemon name, 10 if scan failed
      */
-    private int getPokemonHPFromImg(Bitmap pokemonImage) {
+    private Optional<Integer> getPokemonHPFromImg(Bitmap pokemonImage) {
         Bitmap hp = Bitmap.createBitmap(pokemonImage, (int) Math.round(widthPixels / 2.8),
                 (int) Math.round(heightPixels / 1.8962963), (int) Math.round(widthPixels / 3.5),
                 (int) Math.round(heightPixels / 34.13333333));
@@ -299,12 +300,13 @@ public class OcrHelper {
                                 ? hpParts[1]
                                 : hpParts[0];
 
-                return Integer.parseInt(fixOcrLettersToNums(hpStr).replaceAll("[^0-9]", ""));
+                return Optional.of(Integer.parseInt(fixOcrLettersToNums(hpStr).replaceAll("[^0-9]", "")));
             } catch (NumberFormatException e) {
                 //Fall-through to default.
             }
         }
-        return 10;
+
+        return Optional.absent();
     }
 
     /**
@@ -313,7 +315,7 @@ public class OcrHelper {
      * @param pokemonImage the image of the whole pokemon screen
      * @return a CP of the pokemon, 10 if scan failed
      */
-    private int getPokemonCPFromImg(Bitmap pokemonImage) {
+    private Optional<Integer>  getPokemonCPFromImg(Bitmap pokemonImage) {
         Bitmap cp = Bitmap.createBitmap(pokemonImage, (int) Math.round(widthPixels / 3.0),
                 (int) Math.round(heightPixels / 15.5151515), (int) Math.round(widthPixels / 3.84),
                 (int) Math.round(heightPixels / 21.333333333));
@@ -326,9 +328,9 @@ public class OcrHelper {
             cpText = cpText.substring(2);
         }
         try {
-            return Integer.parseInt(cpText);
+            return Optional.of(Integer.parseInt(cpText));
         } catch (NumberFormatException e) {
-            return 10;
+            return Optional.absent();
         }
     }
 
@@ -344,8 +346,8 @@ public class OcrHelper {
         double estimatedPokemonLevel = getPokemonLevelFromImg(pokemonImage, trainerLevel);
         String pokemonName = getPokemonNameFromImg(pokemonImage);
         String candyName = getCandyNameFromImg(pokemonImage);
-        int pokemonHP = getPokemonHPFromImg(pokemonImage);
-        int pokemonCP = getPokemonCPFromImg(pokemonImage);
+        Optional<Integer> pokemonHP = getPokemonHPFromImg(pokemonImage);
+        Optional<Integer> pokemonCP = getPokemonCPFromImg(pokemonImage);
 
         return new ScanResult(estimatedPokemonLevel, pokemonName, candyName, pokemonHP, pokemonCP);
     }

--- a/app/src/main/java/com/kamron/pogoiv/logic/ScanResult.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/ScanResult.java
@@ -1,5 +1,7 @@
 package com.kamron.pogoiv.logic;
 
+import com.google.common.base.Optional;
+
 /**
  * A ScanResult represents the result of an OCR scan.
  * Created by pgiarrusso on 3/9/2016.
@@ -10,11 +12,11 @@ public class ScanResult {
     private double estimatedPokemonLevel;
     private String pokemonName;
     private String candyName;
-    private int pokemonHP;
-    private int pokemonCP;
+    private Optional<Integer> pokemonHP;
+    private Optional<Integer> pokemonCP;
 
-    public ScanResult(double estimatedPokemonLevel, String pokemonName, String candyName, int pokemonHP,
-                      int pokemonCP) {
+    public ScanResult(double estimatedPokemonLevel, String pokemonName, String candyName, Optional<Integer> pokemonHP,
+                      Optional<Integer> pokemonCP) {
         this.estimatedPokemonLevel = estimatedPokemonLevel;
         this.pokemonName = pokemonName;
         this.candyName = candyName;
@@ -34,17 +36,17 @@ public class ScanResult {
         return candyName;
     }
 
-    public int getPokemonHP() {
+    public Optional<Integer> getPokemonHP() {
         return pokemonHP;
     }
 
-    public int getPokemonCP() {
+    public Optional<Integer> getPokemonCP() {
         return pokemonCP;
     }
 
     public boolean isFailed() {
         //XXX replace by proper logic.
         //the default values for a failed scan, if all three fail, then probably scrolled down.
-        return candyName.equals("") && pokemonHP == 10 && pokemonCP == 10;
+        return candyName.equals("") && !pokemonHP.isPresent() && !pokemonCP.isPresent();
     }
 }

--- a/app/src/main/java/com/kamron/pogoiv/logic/ScanResult.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/ScanResult.java
@@ -44,9 +44,12 @@ public class ScanResult {
         return pokemonCP;
     }
 
+    /**
+     * Test whether this ScanResult represents a failed scan.
+     * @return a boolean representing whether this scan failed.
+     */
     public boolean isFailed() {
-        //XXX replace by proper logic.
-        //the default values for a failed scan, if all three fail, then probably scrolled down.
-        return candyName.equals("") && !pokemonHP.isPresent() && !pokemonCP.isPresent();
+        //If both scans failed, then probably scrolled down.
+        return !pokemonHP.isPresent() && !pokemonCP.isPresent();
     }
 }


### PR DESCRIPTION
Fix #374.

I'm not done on failures for candy recognition though: it seems that code can't fail, so I dropped the current catch block for it as dead code. There's other code depending on that.