### PR TITLE
Change team picker colors + shorten appraisal (fr)

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/widgets/PlayerTeamAdapter.java
+++ b/app/src/main/java/com/kamron/pogoiv/widgets/PlayerTeamAdapter.java
@@ -26,9 +26,9 @@ public class PlayerTeamAdapter extends BaseAdapter implements SpinnerAdapter {
     public PlayerTeamAdapter(Context context) {
         this.context = context;
         colors = new ArrayList<>();
-        colors.add(Color.rgb(30, 30, 250));
-        colors.add(Color.rgb(250, 30, 30));
-        colors.add(Color.rgb(225, 225, 30));
+        colors.add(Color.rgb(61, 159, 255));
+        colors.add(Color.rgb(238, 91, 91));
+        colors.add(Color.rgb(255, 196, 50));
     }
 
     @Override

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -14,50 +14,50 @@
 
     <string-array name="mystic_percentage">
         <item name="mplace1">@string/place1</item>
-        <item name="mystic80_100">"Est une merveille. Un Pokémon captivant !"</item>
-        <item name="mystic67_79">"A retenu toute mon attention."</item>
-        <item name="mystic51_66">"Est supérieur à la moyenne."</item>
-        <item name="mystic0_50">"N'ira pas très loin au combat."</item>
+        <item name="mystic80_100">"Est une merveille&#8230; captivant !"</item>
+        <item name="mystic67_79">&#8230;toute mon attention."</item>
+        <item name="mystic51_66">"&#8230;supérieur à la moyenne."</item>
+        <item name="mystic0_50">"N'ira pas très loin&#8230;"</item>
     </string-array>
 
     <string-array name="mystic_ivrange">
         <item name="mplace2">@string/place2</item>
-        <item name="mysticiv15">"Dépassent tous mes calculs, c'est incroyable !"</item>
-        <item name="mysticiv13_14">"Je suis impressionnée par ses stats."</item>
+        <item name="mysticiv15">"Dépassent tous mes calculs&#8230; !"</item>
+        <item name="mysticiv13_14">"Je suis impressionnée&#8230;"</item>
         <item name="mysticiv8_12">"S'améliorent à vue d'œil."</item>
         <item name="mysticiv0_7">"N'ont rien d'anormal."</item>
     </string-array>
 
-    <string-array name="instinct_percentage">
-        <item name="iplace1">@string/place1</item>
-        <item name="instinct80_100">"Semble capable de tenir tête aux meilleurs."</item>
-        <item name="instinct67_79">"Est vraiment fort."</item>
-        <item name="instinct51_66">"Est plutôt bien."</item>
-        <item name="instinct0_50">"Peut devenir un meilleur combattant."</item>
-    </string-array>
-
-    <string-array name="instinct_ivrange">
-        <item name="iplace2">@string/place2</item>
-        <item name="instinctiv15">"Sont les meilleures que j'ai jamais vues !"</item>
-        <item name="instinctiv13_14">"Sont super élevées. Impressionnant !"</item>
-        <item name="instinctiv8_12">"Il a quelques bonnes stats."</item>
-        <item name="instinctiv0_7">"Ne sont pas mal, mais un peu basiques."</item>
-    </string-array>
-
     <string-array name="valor_percentage">
         <item name="vplace1">@string/place1</item>
-        <item name="valor80_100">"M'étonne beaucoup, il peut tout faire."</item>
-        <item name="valor67_79">"Est très fort, tu dois être fier."</item>
-        <item name="valor51_66">"Est un Pokémon solide."</item>
-        <item name="valor0_50">"N'est pas un combattant."</item>
+        <item name="valor80_100">"M'étonne beaucoup&#8230; tout faire."</item>
+        <item name="valor67_79">"&#8230;très fort, &#8230;être fier."</item>
+        <item name="valor51_66">"&#8230;un Pokémon solide."</item>
+        <item name="valor0_50">"&#8230;pas un combattant."</item>
     </string-array>
 
     <string-array name="valor_ivrange">
         <item name="vplace2">@string/place2</item>
-        <item name="valoriv15">"Sont excellentes ! C'est super !"</item>
-        <item name="valoriv13_14">"Je suis estomaquée par ses stats. Bravo !"</item>
-        <item name="valoriv8_12">"Indiquent qu'il va faire des dégâts au combat."</item>
-        <item name="valoriv0_7">"Ne t'aideront pas beaucoup au combat."</item>
+        <item name="valoriv15">"Sont excellentes ! &#8230;super !"</item>
+        <item name="valoriv13_14">"&#8230;estomaquée&#8230; Bravo !"</item>
+        <item name="valoriv8_12">"&#8230;va faire des dégâts au combat."</item>
+        <item name="valoriv0_7">"Ne t'aideront pas beaucoup&#8230;"</item>
+    </string-array>
+
+    <string-array name="instinct_percentage">
+        <item name="iplace1">@string/place1</item>
+        <item name="instinct80_100">"&#8230;tenir tête aux meilleurs."</item>
+        <item name="instinct67_79">"&#8230;vraiment fort."</item>
+        <item name="instinct51_66">"&#8230;plutôt bien."</item>
+        <item name="instinct0_50">"Peut devenir&#8230; meilleur&#8230;"</item>
+    </string-array>
+
+    <string-array name="instinct_ivrange">
+        <item name="iplace2">@string/place2</item>
+        <item name="instinctiv15">"&#8230;meilleures que j'ai jamais vues !"</item>
+        <item name="instinctiv13_14">"&#8230;super élevées. Impressionnant !"</item>
+        <item name="instinctiv8_12">"&#8230;quelques bonnes stats."</item>
+        <item name="instinctiv0_7">"&#8230;un peu basiques."</item>
     </string-array>
     
     <string name="pokemon_name">Nom du Pokémon :</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -9,9 +9,11 @@
         <item name="valor">"Bravoure"</item>
         <item name="instinct">"Intuition"</item>
     </string-array>
+    <string name="place1">"Dans l\'ensemble, ton Pokémon&#8230;"</string>
+    <string name="place2">"Ses stats&#8230;"</string>
 
     <string-array name="mystic_percentage">
-        <item name="mplace1">"(Optionnel)"</item>
+        <item name="mplace1">@string/place1</item>
         <item name="mystic80_100">"Est une merveille. Un Pokémon captivant !"</item>
         <item name="mystic67_79">"A retenu toute mon attention."</item>
         <item name="mystic51_66">"Est supérieur à la moyenne."</item>
@@ -19,16 +21,15 @@
     </string-array>
 
     <string-array name="mystic_ivrange">
-        <item name="mplace2">"(Optionnel)"</item>
+        <item name="mplace2">@string/place2</item>
         <item name="mysticiv15">"Dépassent tous mes calculs, c'est incroyable !"</item>
         <item name="mysticiv13_14">"Je suis impressionnée par ses stats."</item>
         <item name="mysticiv8_12">"S'améliorent à vue d'œil."</item>
         <item name="mysticiv0_7">"N'ont rien d'anormal."</item>
     </string-array>
 
-
     <string-array name="instinct_percentage">
-        <item name="iplace1">"(Optionnel)"</item>
+        <item name="iplace1">@string/place1</item>
         <item name="instinct80_100">"Semble capable de tenir tête aux meilleurs."</item>
         <item name="instinct67_79">"Est vraiment fort."</item>
         <item name="instinct51_66">"Est plutôt bien."</item>
@@ -36,7 +37,7 @@
     </string-array>
 
     <string-array name="instinct_ivrange">
-        <item name="iplace2">"(Optionnel)"</item>
+        <item name="iplace2">@string/place2</item>
         <item name="instinctiv15">"Sont les meilleures que j'ai jamais vues !"</item>
         <item name="instinctiv13_14">"Sont super élevées. Impressionnant !"</item>
         <item name="instinctiv8_12">"Il a quelques bonnes stats."</item>
@@ -44,7 +45,7 @@
     </string-array>
 
     <string-array name="valor_percentage">
-        <item name="vplace1">"(Optionnel)"</item>
+        <item name="vplace1">@string/place1</item>
         <item name="valor80_100">"M'étonne beaucoup, il peut tout faire."</item>
         <item name="valor67_79">"Est très fort, tu dois être fier."</item>
         <item name="valor51_66">"Est un Pokémon solide."</item>
@@ -52,7 +53,7 @@
     </string-array>
 
     <string-array name="valor_ivrange">
-        <item name="vplace2">"(Optionnel)"</item>
+        <item name="vplace2">@string/place2</item>
         <item name="valoriv15">"Sont excellentes ! C'est super !"</item>
         <item name="valoriv13_14">"Je suis estomaquée par ses stats. Bravo !"</item>
         <item name="valoriv8_12">"Indiquent qu'il va faire des dégâts au combat."</item>
@@ -130,7 +131,4 @@
     <string name="atk">ATQ</string>
     <string name="def">DÉF</string>
     <string name="sta">PV</string>
-    <string name="iv_range_phrase">Ses stats&#8230;</string>
-    <string name="percent_phrase">Dans l\'ensemble, ton Pokémon&#8230;</string>
-    <string name="higher_values">Ses meilleurs atouts sont&#8230;</string>
 </resources>


### PR DESCRIPTION
I changed the colors of the team picker to match the colors used in the Pokémon Go app, because the Instinct color looked a bit green/weird to me.

I also updated the French localization, following the recent changes made to appraisal in #379. And I moved the Instinct strings below the Valor ones, to match the order of the team picker, because I kept reversing them while editing and testing the translation. It makes the "files changed" tab a bit confusing.