### PR TITLE
Speedup screen check by grabbing only needed pixels, v2

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -16,6 +16,7 @@ import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.PixelFormat;
+import android.graphics.Point;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
@@ -119,11 +120,8 @@ public class Pokefly extends Service {
     private OcrHelper ocr;
 
     private Timer timer;
-    private int areaX1;
-    private int areaY1;
-    private int areaX2;
-    private int areaY2;
-
+    private Point area1 = new Point();
+    private Point area2 = new Point();
 
     private boolean infoShownSent = false;
     private boolean infoShownReceived = false;
@@ -376,11 +374,11 @@ public class Pokefly extends Service {
     }
 
     private void startPeriodicScreenScan() {
-        areaX1 = Math.round(displayMetrics.widthPixels / 24);  // these values used to get "white" left of "power up"
-        areaY1 = (int) Math.round(displayMetrics.heightPixels / 1.24271845);
-        areaX2 = (int) Math.round(
+        area1.x = Math.round(displayMetrics.widthPixels / 24);  // these values used to get "white" left of "power up"
+        area1.y = (int) Math.round(displayMetrics.heightPixels / 1.24271845);
+        area2.x = (int) Math.round(
                 displayMetrics.widthPixels / 1.15942029);  // these values used to get greenish color in transfer button
-        areaY2 = (int) Math.round(displayMetrics.heightPixels / 1.11062907);
+        area2.y = (int) Math.round(displayMetrics.heightPixels / 1.11062907);
         final Handler handler = new Handler();
         timer = new Timer();
         TimerTask doAsynchronousTask = new TimerTask() {
@@ -408,8 +406,8 @@ public class Pokefly extends Service {
         }
 
         if (bmp.getHeight() > bmp.getWidth()) {
-            boolean shouldShow = bmp.getPixel(areaX1, areaY1) == Color.rgb(250, 250, 250)
-                    && bmp.getPixel(areaX2, areaY2) == Color.rgb(28, 135, 150);
+            boolean shouldShow = bmp.getPixel(area1.x, area1.y) == Color.rgb(250, 250, 250)
+                    && bmp.getPixel(area2.x, area2.y) == Color.rgb(28, 135, 150);
             setIVButtonDisplay(shouldShow);
         }
         bmp.recycle();

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -400,17 +400,13 @@ public class Pokefly extends Service {
      * If both exist then the user is on the pokemon screen.
      */
     private void scanPokemonScreen() {
-        Bitmap bmp = screen.grabScreen();
-        if (bmp == null) {
-            return;
-        }
+        @ColorInt int[] pixels = screen.grabPixels(area);
 
-        if (bmp.getHeight() > bmp.getWidth()) {
-            boolean shouldShow = bmp.getPixel(area[0].x, area[0].y) == Color.rgb(250, 250, 250)
-                    && bmp.getPixel(area[1].x, area[1].y) == Color.rgb(28, 135, 150);
+        if (pixels != null) {
+            boolean shouldShow =
+                    pixels[0] == Color.rgb(250, 250, 250) && pixels[1] == Color.rgb(28, 135, 150);
             setIVButtonDisplay(shouldShow);
         }
-        bmp.recycle();
     }
 
     private boolean infoLayoutArcPointerVisible = false;

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -120,8 +120,7 @@ public class Pokefly extends Service {
     private OcrHelper ocr;
 
     private Timer timer;
-    private Point area1 = new Point();
-    private Point area2 = new Point();
+    private Point[] area = new Point[2];
 
     private boolean infoShownSent = false;
     private boolean infoShownReceived = false;
@@ -374,11 +373,12 @@ public class Pokefly extends Service {
     }
 
     private void startPeriodicScreenScan() {
-        area1.x = Math.round(displayMetrics.widthPixels / 24);  // these values used to get "white" left of "power up"
-        area1.y = (int) Math.round(displayMetrics.heightPixels / 1.24271845);
-        area2.x = (int) Math.round(
-                displayMetrics.widthPixels / 1.15942029);  // these values used to get greenish color in transfer button
-        area2.y = (int) Math.round(displayMetrics.heightPixels / 1.11062907);
+        area[0] = new Point(                // these values used to get "white" left of "power up"
+                Math.round(displayMetrics.widthPixels / 24),
+                (int) Math.round(displayMetrics.heightPixels / 1.24271845));
+        area[1] = new Point(                // these values used to get greenish color in transfer button
+                (int) Math.round(displayMetrics.widthPixels / 1.15942029),
+                (int) Math.round(displayMetrics.heightPixels / 1.11062907));
         final Handler handler = new Handler();
         timer = new Timer();
         TimerTask doAsynchronousTask = new TimerTask() {
@@ -396,7 +396,7 @@ public class Pokefly extends Service {
 
     /**
      * scanPokemonScreen
-     * Scans the device screen to check area1 for the white and area2 for the transfer button.
+     * Scans the device screen to check area[0] for the white and area[1] for the transfer button.
      * If both exist then the user is on the pokemon screen.
      */
     private void scanPokemonScreen() {
@@ -406,8 +406,8 @@ public class Pokefly extends Service {
         }
 
         if (bmp.getHeight() > bmp.getWidth()) {
-            boolean shouldShow = bmp.getPixel(area1.x, area1.y) == Color.rgb(250, 250, 250)
-                    && bmp.getPixel(area2.x, area2.y) == Color.rgb(28, 135, 150);
+            boolean shouldShow = bmp.getPixel(area[0].x, area[0].y) == Color.rgb(250, 250, 250)
+                    && bmp.getPixel(area[1].x, area[1].y) == Color.rgb(28, 135, 150);
             setIVButtonDisplay(shouldShow);
         }
         bmp.recycle();

--- a/app/src/main/java/com/kamron/pogoiv/ScreenGrabber.java
+++ b/app/src/main/java/com/kamron/pogoiv/ScreenGrabber.java
@@ -2,6 +2,7 @@ package com.kamron.pogoiv;
 
 import android.annotation.TargetApi;
 import android.graphics.Bitmap;
+import android.graphics.Color;
 import android.graphics.PixelFormat;
 import android.graphics.Point;
 import android.graphics.Rect;
@@ -163,11 +164,11 @@ public class ScreenGrabber {
     //Inspired by http://stackoverflow.com/a/27655022/53974.
     private static @ColorInt int getPixel(ByteBuffer buffer, Point pos, int pixelStride, int rowStride) {
         int offset = pos.y * rowStride + pos.x * pixelStride;
-        int pixel = 0;
-        pixel |= (buffer.get(offset) & 0xff) << 16;     // R
-        pixel |= (buffer.get(offset + 1) & 0xff) << 8;  // G
-        pixel |= (buffer.get(offset + 2) & 0xff);       // B
-        pixel |= (buffer.get(offset + 3) & 0xff) << 24; // A
-        return pixel;
+        //This works because the image reader is configured with PixelFormat.RGBA_8888.
+        int r = buffer.get(offset) & 0xff;
+        int g = buffer.get(offset + 1) & 0xff;
+        int b = buffer.get(offset + 2) & 0xff;
+        int a = buffer.get(offset + 3) & 0xff;
+        return Color.argb(a, r, g, b);
     }
 }

--- a/app/src/main/java/com/kamron/pogoiv/ScreenGrabber.java
+++ b/app/src/main/java/com/kamron/pogoiv/ScreenGrabber.java
@@ -115,6 +115,11 @@ public class ScreenGrabber {
         return bmp;
     }
 
+    /**
+     * Grab a few pixels from the current screen.
+     * @param points array of points representing coordinates to grab
+     * @return array of colors for the requested pixels, or null if any of them is out-of-bounds
+     */
     public @Nullable @ColorInt int[] grabPixels(Point[] points) {
         Image image = null;
         try {

--- a/app/src/main/java/com/kamron/pogoiv/ScreenGrabber.java
+++ b/app/src/main/java/com/kamron/pogoiv/ScreenGrabber.java
@@ -4,6 +4,7 @@ import android.annotation.TargetApi;
 import android.graphics.Bitmap;
 import android.graphics.PixelFormat;
 import android.hardware.display.DisplayManager;
+import android.hardware.display.VirtualDisplay;
 import android.media.Image;
 import android.media.ImageReader;
 import android.media.projection.MediaProjection;
@@ -25,6 +26,7 @@ public class ScreenGrabber {
     private MediaProjection projection = null;
     private DisplayMetrics rawDisplayMetrics;
     private DisplayMetrics displayMetrics;
+    private VirtualDisplay virtualDisplay;
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private ScreenGrabber(MediaProjection mediaProjection, DisplayMetrics raw, DisplayMetrics display) {
@@ -33,7 +35,8 @@ public class ScreenGrabber {
         projection = mediaProjection;
         imageReader = ImageReader.newInstance(rawDisplayMetrics.widthPixels, rawDisplayMetrics.heightPixels,
                 PixelFormat.RGBA_8888, 2);
-        projection.createVirtualDisplay("screen-mirror", rawDisplayMetrics.widthPixels, rawDisplayMetrics.heightPixels,
+        virtualDisplay = projection.createVirtualDisplay("screen-mirror", rawDisplayMetrics.widthPixels,
+                rawDisplayMetrics.heightPixels,
                 rawDisplayMetrics.densityDpi, DisplayManager.VIRTUAL_DISPLAY_FLAG_PUBLIC, imageReader.getSurface(),
                 null, null);
     }
@@ -58,6 +61,8 @@ public class ScreenGrabber {
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public void exit() {
         if (projection != null) {
+            virtualDisplay.release();
+            virtualDisplay = null;
             imageReader.close();
             imageReader = null;
             projection.stop();

--- a/app/src/main/java/com/kamron/pogoiv/ScreenGrabber.java
+++ b/app/src/main/java/com/kamron/pogoiv/ScreenGrabber.java
@@ -3,12 +3,16 @@ package com.kamron.pogoiv;
 import android.annotation.TargetApi;
 import android.graphics.Bitmap;
 import android.graphics.PixelFormat;
+import android.graphics.Point;
+import android.graphics.Rect;
 import android.hardware.display.DisplayManager;
 import android.hardware.display.VirtualDisplay;
 import android.media.Image;
 import android.media.ImageReader;
 import android.media.projection.MediaProjection;
 import android.os.Build;
+import android.support.annotation.ColorInt;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.DisplayMetrics;
 
@@ -56,6 +60,35 @@ public class ScreenGrabber {
     public static ScreenGrabber getInstance() {
         assert instance != null;
         return instance;
+    }
+
+    @NonNull private static Rect getBitmapBounds(Bitmap bmp) {
+        return new Rect(0, 0, bmp.getWidth(), bmp.getHeight());
+    }
+
+    static @Nullable @ColorInt int[] getPixelsSafe(Bitmap bmp, Point[] points) {
+        Rect bounds = getBitmapBounds(bmp);
+        @ColorInt int[] pixels = new int[points.length];
+        for (int i = 0; i < points.length; i++) {
+            Point p = points[i];
+            if (bounds.contains(p.x, p.y)) {
+                pixels[i] = bmp.getPixel(p.x, p.y);
+            } else {
+                return null;
+            }
+        }
+        return pixels;
+    }
+
+    public @Nullable @ColorInt int[] grabPixels(Point[] points) {
+        Bitmap bmp = grabScreen();
+        if (bmp == null) {
+            return null;
+        }
+        @ColorInt int[] pixels = ScreenGrabber.getPixelsSafe(bmp, points);
+        bmp.recycle();
+
+        return pixels;
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)


### PR DESCRIPTION
Fix #391.

This reworks branch speedup-screen-check based on discussion in 4de491198c667ba3c1ccb78f8cace24e57b60d00. I ended up doing the refactoring from scratch, but the new code still works and makes sense.

This also changes pokemon-screen detection to bound-check the individual pixels rather than check if the image is in portrait format. I expect this change to be safe.

Review assigned to @sarav.