### PR TITLE
Simplify Nidoran correction

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1390,9 +1390,7 @@ public class Pokefly extends Service {
             CopyUtils.copyAssetFolder(getAssets(), "tessdata", extdir + "/tessdata");
         }
 
-        ocr = OcrHelper.init(extdir, displayMetrics.widthPixels, displayMetrics.heightPixels,
-                getResources().getString(R.string.pokemon029),
-                getResources().getString(R.string.pokemon032));
+        ocr = OcrHelper.init(extdir, displayMetrics.widthPixels, displayMetrics.heightPixels);
     }
 
 

--- a/app/src/main/java/com/kamron/pogoiv/logic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/PokemonNameCorrector.java
@@ -42,6 +42,30 @@ public class PokemonNameCorrector {
     }
 
     /**
+     * Fix Nidoran gender identification
+     *
+     * @param ocrText   The text that OCR generated
+     * @param p         The pokemon that was the best match for the OCR text
+     * @return          a Pokemon that's fixed if it was Nidoran. Otherwise, unchanged.
+     */
+    private Pokemon fixNido(String ocrText, Pokemon p) {
+        String pokeName = p.name;
+        Pokemon p28 = pokeInfoCalculator.get(28);
+        Pokemon p31 = pokeInfoCalculator.get(31);
+
+        if (pokeName.equals(p28.name) || pokeName.equals(p31.name)) {
+            char lastChar = ocrText.charAt(ocrText.length() - 1);
+            if (lastChar == 'd') {
+                return p31;
+            } else if (lastChar == 'Q') {
+                return p28;
+            }
+        }
+
+        return p;
+    }
+
+    /**
      * Compute the most likely pokemon ID based on the pokemon and candy names.
      *
      * @return a PokeDist with pokemon ID and distance.
@@ -91,6 +115,8 @@ public class PokemonNameCorrector {
         } else {
             bestCandyMatch = 0;
         }
+
+        p = fixNido(candytext, p);
 
         /* Search through all the pokemon with the same candy name and pick the one with the best
          * match to the pokemon name (not the candy name) */

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,5 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="pokemon029">ニドラン♀</string>
-    <string name="pokemon032">ニドラン♂</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="pokemon029">Nidoran♀</string>
-    <string name="pokemon032">Nidoran♂</string>
-
     <string name="welcome_message">Instructions:\n1. Enter your trainer level\n2. Press the start button and allow screen capture\n3. Open up your desired Pokémon in \'Pokémon Go\'\n4. Tap the IV Button to scan the Pokémon\n5. Adjust the scanned data if necessary\n6. Check IV!</string>
     <string name="goiv_is_open_source">GoIV is open source!\ngithub.com/farkam135/GoIV\nreddit.com/r/GoIV</string>
     <string name="trainer_level">Trainer Level</string>


### PR DESCRIPTION
We can just check the last character of the OCR text to identify the
proper gender of the Nidoran. We don't need to do a color check. With
this change, we can apply the Nidoran correction to the candy name
before we search for the final pokemon. This will be useful for future
improvements to Pokemon detection.

Fixes #381 