### PR TITLE
Power optimization: Scan screen only when user touches it

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -429,14 +429,16 @@ public class Pokefly extends Service {
      * Scans the device screen to check area[0] for the white and area[1] for the transfer button.
      * If both exist then the user is on the pokemon screen.
      */
-    private void scanPokemonScreen() {
+    private boolean scanPokemonScreen() {
         @ColorInt int[] pixels = screen.grabPixels(area);
 
         if (pixels != null) {
             boolean shouldShow =
                     pixels[0] == Color.rgb(250, 250, 250) && pixels[1] == Color.rgb(28, 135, 150);
             setIVButtonDisplay(shouldShow);
+            return shouldShow;
         }
+        return false;
     }
 
     private boolean infoLayoutArcPointerVisible = false;

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -382,9 +382,13 @@ public class Pokefly extends Service {
             @Override
             public void run() {
                 if (screenScanRetries > 0) {
-                    scanPokemonScreen();
-                    screenScanRetries--;
-                    screenScanHandler.postDelayed(screenScanRunnable, SCREEN_SCAN_DELAY_MS);
+                    boolean ret = scanPokemonScreen();
+                    if (ret) {
+                        screenScanRetries = 0; //skip further retries.
+                    } else {
+                        screenScanRetries--;
+                        screenScanHandler.postDelayed(screenScanRunnable, SCREEN_SCAN_DELAY_MS);
+                    }
                 }
             }
         };


### PR DESCRIPTION
This addresses #300 

The current implementation scans the screen every 750 milliseconds. This
is pretty expensive in terms of power consumption.

Since the screen mode (map, gym, pokemon, etc) doesn't change unless the
user actually touches the screen, we just need to scan the screen around
the time the screen is touched.

Also, since the user touches the screen a lot during a gym battle, add
some throttling to scan the screen only after the last touch if multiple
touches happen in quick succession (within 750 milliseconds).

This should significantly improve the power.

Since there are some animations which take time when the user opens a
pokemon switches pokemon, scan a couple of times before stopping.

**Caveat:** The touch events only come when the user touches the screen and not when the lift the finger. So, if they do a long drag (2.5 seconds), the scanning would finish before they lift the finger. But this hasn't really happened to me when I use the game UI normally. Also, in that case, they just need to touch the screen once to trigger the scan again. So, it's not that bad for the enormous power savings.

**Result:** Not sure if it's placebo, but I feel like the device is running cooler. Also, this is the first time I was able to start GoIV and then go back to the game that was already running without having to restart it.