### PR TITLE
Upgrade dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,8 +127,8 @@ android {
  * annotation processing)
  */
 dependencies {
-    compile 'com.android.support:appcompat-v7:24.2.0'
-    compile 'com.android.support:recyclerview-v7:24.2.0'
+    compile 'com.android.support:appcompat-v7:24.2.1'
+    compile 'com.android.support:recyclerview-v7:24.2.1'
     compile 'com.jakewharton:butterknife:8.4.0'
     compile 'com.jakewharton.timber:timber:4.3.0'
     compile 'com.rmtheis:tess-two:6.0.4'
@@ -159,9 +159,9 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'com.squareup.assertj:assertj-android:1.1.1'
     testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'com.android.support:support-annotations:24.2.0'
+    testCompile 'com.android.support:support-annotations:24.2.1'
     testCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support:support-annotations:24.2.0'
+    androidTestCompile 'com.android.support:support-annotations:24.2.1'
     androidTestCompile 'com.android.support.test:runner:0.5'
 }
 allprojects {


### PR DESCRIPTION
This is needed to build with version 37 of "Android support repository", and Travis already seems to default to that version at least according to this log:
https://travis-ci.org/farkam135/GoIV/builds/159657295

Also @Eremiell got stuck onto this when trying to install.

Here is the install of the offending version:
https://travis-ci.org/farkam135/GoIV/builds/159657295#L927-L932

This might require other devs to update their tools. Conversely, I've updated and need this to build. This PR is to give a heads up to all.

BTW: tooling is being stupid here, why can't the older library be downloaded from some maven repositories? Bah.