### PR TITLE
Overlay gravity only top if on input screen

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -842,7 +842,8 @@ public class Pokefly extends Service {
             return;
         }
 
-        moveOverlay(appraisalBox.getVisibility() == View.VISIBLE);
+        //move up if on input screen & appraisal box is open, else move down
+        moveOverlay(inputBox.getVisibility() == View.VISIBLE && appraisalBox.getVisibility() == View.VISIBLE);
     }
 
     private void adjustArcPointerBar(double estimatedPokemonLevel) {


### PR DESCRIPTION
This commit makes the moveOverlayUpOrDownToMatchAppraisalBox method
always move the overlay down if the user is not on the input screen, as
it's not possible to end up in a situation where the appraisal box is
both intended to be expanded and not exist.

Fixes #406 