### PR TITLE
Hides "See all" link if tooManyPossibilities set

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1065,8 +1065,22 @@ public class Pokefly extends Service {
         setResultScreenPercentageRange(ivScanResult); //color codes the result
         adjustSeekbarsThumbs();
 
+        hideSeeAllLinkIfFlagSet(ivScanResult);
         populateAdvancedInformation(ivScanResult);
         populatePrevScanNarrowing();
+    }
+
+    /**
+     * Hides the "See all" iv possibilities link if the iv scan result reports that there are too many possibilities.
+     *
+     * @param ivScanResult The iv scan result to examine if it makes sense to have a "show all" button.
+     */
+    private void hideSeeAllLinkIfFlagSet(IVScanResult ivScanResult) {
+        if (ivScanResult.tooManyPossibilities) {
+            seeAllPossibilities.setVisibility(View.GONE);
+        } else {
+            seeAllPossibilities.setVisibility(View.VISIBLE);
+        }
     }
 
     /**


### PR DESCRIPTION
If the user scanns a 10 cp pokemon, the iv scan will simply set a flag
saying "too many iv combinations", because there are 16^3 possible
combinations, and it's not been narrowed down. Clicking the "See all"
button simply takes you to an empty list. This change removes this link.

fixes #376