### PR TITLE
Adds bottom margin to manual pokemon select

### DIFF
--- a/app/src/main/res/layout/dialog_input_poke_picker.xml
+++ b/app/src/main/res/layout/dialog_input_poke_picker.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="horizontal"
               android:layout_width="match_parent"
-              android:layout_height="match_parent">
+              android:layout_height="match_parent"
+              android:orientation="horizontal">
 
 
     <Spinner
@@ -11,22 +11,25 @@
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:background="@drawable/spinner"
-        android:popupBackground="#FFF"
-        android:gravity="center"/>
+        android:gravity="center"
+        android:popupBackground="#FFF"/>
 
     <AutoCompleteTextView
         android:id="@+id/autoCompleteTextView1"
         android:layout_width="120dp"
         android:layout_height="wrap_content"
-        android:inputType="text"
+        android:layout_marginBottom="60dp"
         android:imeOptions="actionDone"
+        android:inputType="text"
         android:visibility="gone">
 
     </AutoCompleteTextView>
 
     <Button
         android:id="@+id/pokePickerToggleSpinnerVsInput"
-        android:background="@android:drawable/ic_menu_edit"
         android:layout_width="40dp"
-        android:layout_height="40dp"/>
+        android:layout_height="40dp"
+        android:background="@android:drawable/ic_menu_edit"/>
+
+
 </LinearLayout>


### PR DESCRIPTION
Moves around code lines as suggested by reformat code in android studio,
and adds a margin to the text input so that it's not covered by the
keyboard when you type.

The only new thing in this commit is really the margin.

Visually this is not great nor optimal, but it makes things easier.

Fixes #345 - the fix is kinda hacky, so a better fix could be implemented, but it's better than nothing imo.