### PR TITLE
Change colors for IV highlighting

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/GuiUtil.java
+++ b/app/src/main/java/com/kamron/pogoiv/GuiUtil.java
@@ -10,10 +10,10 @@ import android.widget.TextView;
  */
 public class GuiUtil {
 
-    private static final String RED = "#8A0808";
-    private static final String ORANGE = "#DBA901";
-    private static final String LIGHT_GREEN = "#A0A53F";
-    private static final String GREEN = "#088A08";
+    private static final String RED = "#B10000";
+    private static final String ORANGE = "#F1A900";
+    private static final String GREEN = "#00A000";
+    private static final String BLUE = "#0099EF";
 
     /**
      * Sets the text color based on IV to match the in-game appraisal system.
@@ -23,9 +23,9 @@ public class GuiUtil {
      */
     public static void setTextColorByIV(TextView text, int value) {
         if (value == 15) {
-            text.setTextColor(Color.parseColor(GREEN));
+            text.setTextColor(Color.parseColor(BLUE));
         } else if (value >= 13) {
-            text.setTextColor(Color.parseColor(LIGHT_GREEN));
+            text.setTextColor(Color.parseColor(GREEN));
         } else if (value >= 8) {
             text.setTextColor(Color.parseColor(ORANGE));
         } else {
@@ -41,9 +41,9 @@ public class GuiUtil {
      */
     public static void setTextColorByPercentage(TextView text, int value) {
         if (value > 81) { // between 80 and 82.2
-            text.setTextColor(Color.parseColor(GREEN));
+            text.setTextColor(Color.parseColor(BLUE));
         } else if (value > 65) { // between 64.4 and 66.7
-            text.setTextColor(Color.parseColor(LIGHT_GREEN));
+            text.setTextColor(Color.parseColor(GREEN));
         } else if (value > 50) { // between 48.9 and 51.1
             text.setTextColor(Color.parseColor(ORANGE));
         } else {


### PR DESCRIPTION
After much discussion in #336 and #388, no consensus has been reached about which colors to use to highlight IVs on the results screen. However, I propose that we use these red/orange/green/blue colors - http://i.imgur.com/jenqZv5.png - for the following reasons:
- of the few people who gave their opinion about the colors, a (very small) majority prefered the darkgreen/blue combination.
- I think it makes IVs easier to distinguish compared to the colors that are currently used.
- red/orange/green/blue still follows the natural progression of the spectrum of light, so blue feels like it naturally means "better than green".
- I tested 3 color combinations (the one from #336, lightgreen/darkgreen from #388 and the one from this pull request) on a color blindness simulator (Coblis). This PR looks a bit better than the one from #336, and the lightgreen/darkgreen one could be almost impossible to distinguish for some people.
- Green and blue from this PR both have better contrast on the white/grey background than lightgreen from #336.

Does anyone disagree?