### PR TITLE
Show button if starting on pokemon screen (#437)

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -386,6 +386,9 @@ public class Pokefly extends Service {
             if (!batterySaver) {
                 screen = ScreenGrabber.getInstance();
                 watchScreen();
+                if (GoIVSettings.getInstance(getBaseContext()).shouldLaunchPokemonGo()) {
+                    triggerDelayedScan();
+                }
             } else {
                 screenShotHelper = ScreenShotHelper.start(Pokefly.this);
             }
@@ -433,15 +436,19 @@ public class Pokefly extends Service {
             @Override
             public boolean onTouch(View v, MotionEvent event) {
                 if (event.getActionMasked() == MotionEvent.ACTION_OUTSIDE) {
-                    screenScanHandler.removeCallbacks(screenScanRunnable);
-                    screenScanHandler.postDelayed(screenScanRunnable, SCREEN_SCAN_DELAY_MS);
-                    screenScanRetries = SCREEN_SCAN_RETRIES;
+                    triggerDelayedScan();
                 }
                 return false;
             }
         });
 
         windowManager.addView(touchView, touchViewParams);
+    }
+
+    public void triggerDelayedScan() {
+        screenScanHandler.removeCallbacks(screenScanRunnable);
+        screenScanHandler.postDelayed(screenScanRunnable, SCREEN_SCAN_DELAY_MS);
+        screenScanRetries = SCREEN_SCAN_RETRIES;
     }
 
     private void unwatchScreen() {


### PR DESCRIPTION
Fix #437 in a very hacky/simple way: if we're starting Pokemon Go, trigger a
(delayed) scan at startup.

I'm not sure if/when we should merge this: it appears to work on my Nexus 7. Before that I had 10 screens from PoGo in a row though—I'm rather sure I hadn't installed this change yet so it should be unrelated, but I still wonder, so:

Q1: could this increase the frequency of black screens? EDIT: Further testing suggests no.

Also, technically, we'd want the scan to be started after MainActivity activates Pokemon Go (through an intent). But this code worked on my devices (testing on my Nexus 5), and in the worst case (except for Q1) it just won't fix #437 which is just an (annoying) cosmetic issue.