### PR TITLE
Update Gradle to 2.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.0'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Android Studio 2.2.0 has been released and gradle plugin has been updated.
Performance and fixes were done.
More info in [Release Notes](https://developer.android.com/studio/releases/gradle-plugin.html)

Should be updated to as soon as possible.

PR recreated as commit has been moved to a separate branch.