### PR TITLE
Ensure GoIV survives "Don't keep activities"

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -354,10 +354,6 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     public void onDestroy() {
-        if (Pokefly.isRunning()) {
-            stopService(new Intent(MainActivity.this, Pokefly.class));
-        }
-
         LocalBroadcastManager.getInstance(this).unregisterReceiver(pokeflyStateChanged);
         LocalBroadcastManager.getInstance(this).unregisterReceiver(showUpdateDialog);
         super.onDestroy();

--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -357,9 +357,6 @@ public class MainActivity extends AppCompatActivity {
         if (Pokefly.isRunning()) {
             stopService(new Intent(MainActivity.this, Pokefly.class));
         }
-        if (screen != null) {
-            screen.exit();
-        }
 
         LocalBroadcastManager.getInstance(this).unregisterReceiver(pokeflyStateChanged);
         LocalBroadcastManager.getInstance(this).unregisterReceiver(showUpdateDialog);

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -368,11 +368,7 @@ public class Pokefly extends Service {
         running = true;
 
         if (ACTION_STOP.equals(intent.getAction())) {
-            if (screen != null) {
-                screen.exit();
-            }
             stopSelf();
-
         } else if (intent.hasExtra(KEY_TRAINER_LEVEL)) {
             trainerLevel = intent.getIntExtra(KEY_TRAINER_LEVEL, 1);
             statusBarHeight = intent.getIntExtra(KEY_STATUS_BAR_HEIGHT, 0);
@@ -495,6 +491,10 @@ public class Pokefly extends Service {
 
         if (!batterySaver) {
             unwatchScreen();
+            if (screen != null) {
+                screen.exit();
+                screen = null;
+            }
         } else {
             screenShotHelper.stop();
             screenShotHelper = null;

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -440,6 +440,9 @@ public class Pokefly extends Service {
         windowManager.addView(touchView, touchViewParams);
     }
 
+    /**
+     * Undoes the effects of watchScreen.
+     */
     private void unwatchScreen() {
         windowManager.removeView(touchView);
         touchViewParams = null;


### PR DESCRIPTION
If I enable "Don't keep activities" (tested under Android 7 on my Nexus 5X), GoIV dies immediately after going away from the MainActivity, which is to be expected from the description.

This PR fixes the problem, and generally enables GoIV to keep working if Android kills MainActivity (which it can do at will). Conversely, Android will try to keep Pokefly active till possible, because it is considered a foreground (hence important) activity, thanks to our persistent notification (technically, thanks to `startForeground`), according to [relevant docs](https://developer.android.com/reference/android/app/Service.html#ProcessLifecycle).