### PR TITLE
Fix warning/error with String formatting

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -9,7 +9,7 @@
     <string name="use_the_slider_below_to_align_the_arc">Použij posuvník níže pro nastavení oblouku:</string>
     <string name="cancel">Zrušit</string>
     <string name="check_iv">Zkontrolovat IV</string>
-    <string name="notification_title">GoIV běží - Level %1$s</string>
+    <string name="notification_title">GoIV běží - Level %1$d</string>
     <string name="notification_open_app">Otevřít aplikaci</string>
     <string name="close">Zavřít</string>
     <string name="main_permission">Udělit povolení</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -68,7 +68,7 @@
     <string name="pokemon_name">Pokémon Name:</string>
 
     <string name="use_the_slider_below_to_align_the_arc">Verwende den Schieberegler um den roten Punkt auszurichten</string>
-    <string name="notification_title">GoIV läuft - Level %1$s</string>
+    <string name="notification_title">GoIV läuft - Level %1$d</string>
     <string name="close">Schließen</string>
     <string name="main_permission">Berechtigungen erlauben</string>
     <string name="main_start">Starten</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -67,7 +67,7 @@
     <string name="main_permission">Dar Permisos</string>
     <string name="main_start">Iniciar</string>
     <string name="main_stop">Detener</string>
-    <string name="notification_title">GoIV en Ejecución - Nivel %1$s</string>
+    <string name="notification_title">GoIV en Ejecución - Nivel %1$d</string>
     <string name="pokemon_name">Nombre del Pokémon: </string>
     <string name="trainer_level">Nivel de Entrenador</string>
     <string name="use_the_slider_below_to_align_the_arc">Use el slider para alinear el marcador en el arco</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -66,7 +66,7 @@
     <string name="use_the_slider_below_to_align_the_arc">Déplacer le curseur pour aligner l\'arc</string>
     <string name="cancel">Annuler</string>
     <string name="check_iv">Obtenir IV</string>
-    <string name="notification_title">GoIV Actif - Niveau %1$s</string>
+    <string name="notification_title">GoIV Actif - Niveau %1$d</string>
     <string name="notification_open_app">Ouvrir l\'app</string>
     <string name="close">Fermer</string>
     <string name="main_permission">Accorder permissions</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -10,7 +10,7 @@
     <string name="use_the_slider_below_to_align_the_arc">Usa lo slider per allineare l\'arco</string>
     <string name="cancel">Cancella</string>
     <string name="check_iv">Analizza IV</string>
-    <string name="notification_title">GoIV in esecuzione - Livello %1$s</string>
+    <string name="notification_title">GoIV in esecuzione - Livello %1$d</string>
     <string name="notification_open_app">Apri app</string>
     <string name="close">Chiudi</string>
     <string name="main_permission">Concedi i permessi</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -10,7 +10,7 @@
     <string name="use_the_slider_below_to_align_the_arc">Deslize para alinhar o arco</string>
     <string name="cancel">Cancelar</string>
     <string name="check_iv">Verifica o IV</string>
-    <string name="notification_title">GoIV funcionando - Nível %1$s</string>
+    <string name="notification_title">GoIV funcionando - Nível %1$d</string>
     <string name="ivtext_no_possibilities">Não há possibilides, por favor verifique os dados!</string>
     <string name="close">Fechar</string>
     <string name="main_permission">Grantir Permissões</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,7 +69,7 @@
     <string name="use_the_slider_below_to_align_the_arc">Use the slider below to align the arc:</string>
     <string name="cancel">Cancel</string>
     <string name="check_iv">Check IV</string>
-    <string name="notification_title">GoIV Running - Level %1$s</string>
+    <string name="notification_title">GoIV Running - Level %1$d</string>
     <string name="notification_open_app">Open app</string>
     <string name="close">Close</string>
     <string name="main_permission">Grant Permissions</string>


### PR DESCRIPTION
Android Studio 2.2 considers this a serious warning and even marks it as
an error. While the code works perfectly fine it's overly general (and
might be inefficient). So let's fix the warning.