### PR TITLE
OcrHelper: Prevent crash if hpStr = "/"

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
@@ -295,10 +295,14 @@ public class OcrHelper {
             try {
                 //If "/" comes at the end we'll get an array with only one component.
                 String[] hpParts = pokemonHPStr.split("/");
-                String hpStr =
-                        hpParts.length >= 2
-                                ? hpParts[1]
-                                : hpParts[0];
+                String hpStr;
+                if (hpParts.length >= 2) {
+                    hpStr = hpParts[1];
+                } else if (hpParts.length == 1) {
+                    hpStr = hpParts[0];
+                } else {
+                    return Optional.absent();
+                }
 
                 return Optional.of(Integer.parseInt(fixOcrLettersToNums(hpStr).replaceAll("[^0-9]", "")));
             } catch (NumberFormatException e) {


### PR DESCRIPTION
Just got an exception here, when sharing through Now on Tap a PoGo
screen without pokemons. I assume this would be triggered by having "/"
as string; I've confirmed that `"/".split("/")` gives indeed an array of
length 0.

```
09-23 02:20:20.758 29581-29581/com.kamron.pogoiv E/AndroidRuntime:
FATAL EXCEPTION: main
Process: com.kamron.pogoiv, PID: 29581
java.lang.ArrayIndexOutOfBoundsException: length=0; index=0
    at com.kamron.pogoiv.OcrHelper.getPokemonHPFromImg(OcrHelper.java:298)
    at com.kamron.pogoiv.OcrHelper.scanPokemon(OcrHelper.java:349)
    at com.kamron.pogoiv.Pokefly.scanPokemon(Pokefly.java:1566)
    at com.kamron.pogoiv.Pokefly.access$1200(Pokefly.java:82)
    at com.kamron.pogoiv.Pokefly$11.onReceive(Pokefly.java:1606)
    at android.support.v4.content.LocalBroadcastManager.executePendingBroadcasts(LocalBroadcastManager.java:297)
    at android.support.v4.content.LocalBroadcastManager.access$000(LocalBroadcastManager.java:46)
    at android.support.v4.content.LocalBroadcastManager$1.handleMessage(LocalBroadcastManager.java:116)
    at android.os.Handler.dispatchMessage(Handler.java:102)
    at android.os.Looper.loop(Looper.java:154)
    at android.app.ActivityThread.main(ActivityThread.java:6077)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:865)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:755)
```