### PR TITLE
Add perfection and hp estimates to evolution box

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -65,6 +65,7 @@ import com.kamron.pogoiv.widgets.IVResultsAdapter;
 import com.kamron.pogoiv.widgets.PokemonSpinnerAdapter;
 
 import java.io.File;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -210,6 +211,10 @@ public class Pokefly extends Service {
     TextView exResultCP;
     @BindView(R.id.exResultHP)
     TextView exResultHP;
+    @BindView(R.id.exResultPercentPerfection)
+    TextView exResultPercentPerfection;
+    @BindView(R.id.explainCPPercentageComparedToMaxIV)
+    TextView explainCPPercentageComparedToMaxIV;
     @BindView(R.id.exResStardust)
     TextView exResStardust;
     @BindView(R.id.exResPrevScan)
@@ -922,6 +927,11 @@ public class Pokefly extends Service {
         populateAdvancedInformation(ScanContainer.scanContainer.currScan);
     }
 
+    @OnClick(R.id.explainCPPercentageComparedToMaxIV)
+    public void explainCPPercentageComparedToMaxIV() {
+        Toast.makeText(getApplicationContext(), R.string.perfection_explainer, Toast.LENGTH_LONG).show();
+    }
+
     @OnClick(R.id.btnDecrementLevelExpanded)
     public void decrementLevelExpanded() {
         expandedLevelSeekbar.setProgress(expandedLevelSeekbar.getProgress() - 1);
@@ -1266,9 +1276,28 @@ public class Pokefly extends Service {
 
         setEstimateCpTextBox(ivScanResult, selectedLevel, selectedPokemon);
         setEstimateHPTextBox(ivScanResult, selectedLevel, selectedPokemon);
+        setPokemonPerfectionPercentageText(ivScanResult, selectedPokemon);
         setEstimateCostTextboxes(ivScanResult, selectedLevel, selectedPokemon);
         exResLevel.setText(String.valueOf(selectedLevel));
         setEstimateLevelTextColor(selectedLevel);
+    }
+
+    /**
+     * Sets the pokemon perfection % text in the powerup and evolution results box.
+     *
+     * @param ivScanResult    The object containing the ivs to base current pokemon on.
+     * @param selectedPokemon The pokemon to compare selected iv with max iv to.
+     */
+    private void setPokemonPerfectionPercentageText(IVScanResult ivScanResult, Pokemon selectedPokemon) {
+        CPRange cpRange = pokeInfoCalculator.getCpRangeAtLevel(selectedPokemon, ivScanResult.lowAttack, ivScanResult
+                .lowDefense, ivScanResult.lowStamina, ivScanResult.highAttack, ivScanResult.highDefense, ivScanResult
+                .highStamina, 40);
+        double averageCP = (cpRange.high + cpRange.low) / 2;
+        double maxCP = pokeInfoCalculator.getCpRangeAtLevel(selectedPokemon, 15, 15, 15, 15, 15, 15, 40).high;
+        double perfection = (100 * averageCP) / maxCP;
+        DecimalFormat df = new DecimalFormat("#.#");
+        String perfectionString = df.format(perfection) + "%";
+        exResultPercentPerfection.setText(perfectionString);
     }
 
     /**

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -208,6 +208,8 @@ public class Pokefly extends Service {
     TextView resultsCombinations;
     @BindView(R.id.exResultCP)
     TextView exResultCP;
+    @BindView(R.id.exResultHP)
+    TextView exResultHP;
     @BindView(R.id.exResStardust)
     TextView exResStardust;
     @BindView(R.id.exResPrevScan)
@@ -1263,9 +1265,21 @@ public class Pokefly extends Service {
         Pokemon selectedPokemon = initPokemonSpinnerIfNeeded(ivScanResult.pokemon);
 
         setEstimateCpTextBox(ivScanResult, selectedLevel, selectedPokemon);
+        setEstimateHPTextBox(ivScanResult, selectedLevel, selectedPokemon);
         setEstimateCostTextboxes(ivScanResult, selectedLevel, selectedPokemon);
         exResLevel.setText(String.valueOf(selectedLevel));
         setEstimateLevelTextColor(selectedLevel);
+    }
+
+    /**
+     * Sets the "expected HP  textview" to the estimat HP in the powerup and evolution estimate box
+     *
+     * @param ivScanResult  the ivscanresult of the current pokemon
+     * @param selectedLevel The goal level the pokemon in ivScanresult pokemon should reach
+     */
+    private void setEstimateHPTextBox(IVScanResult ivScanResult, double selectedLevel, Pokemon selectedPokemon) {
+        String hpText = pokeInfoCalculator.getHPAtLevel(ivScanResult, selectedLevel, selectedPokemon) + "";
+        exResultHP.setText(hpText);
     }
 
     /**

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1278,7 +1278,12 @@ public class Pokefly extends Service {
      * @param selectedLevel The goal level the pokemon in ivScanresult pokemon should reach
      */
     private void setEstimateHPTextBox(IVScanResult ivScanResult, double selectedLevel, Pokemon selectedPokemon) {
-        String hpText = pokeInfoCalculator.getHPAtLevel(ivScanResult, selectedLevel, selectedPokemon) + "";
+        int newHP = pokeInfoCalculator.getHPAtLevel(ivScanResult, selectedLevel, selectedPokemon);
+        int oldHP = pokeInfoCalculator.getHPAtLevel(ivScanResult, estimatedPokemonLevel
+                , ivScanResult.pokemon);
+        int hpDiff = newHP - oldHP;
+        String sign = (hpDiff >= 0) ? "+" : ""; //add plus in front if positive.
+        String hpText = newHP + " (" + sign + hpDiff + ")";
         exResultHP.setText(hpText);
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1301,15 +1301,14 @@ public class Pokefly extends Service {
     }
 
     /**
-     * Sets the "expected HP  textview" to the estimat HP in the powerup and evolution estimate box
+     * Sets the "expected HP  textview" to the estimat HP in the powerup and evolution estimate box.
      *
      * @param ivScanResult  the ivscanresult of the current pokemon
      * @param selectedLevel The goal level the pokemon in ivScanresult pokemon should reach
      */
     private void setEstimateHPTextBox(IVScanResult ivScanResult, double selectedLevel, Pokemon selectedPokemon) {
         int newHP = pokeInfoCalculator.getHPAtLevel(ivScanResult, selectedLevel, selectedPokemon);
-        int oldHP = pokeInfoCalculator.getHPAtLevel(ivScanResult, estimatedPokemonLevel
-                , ivScanResult.pokemon);
+        int oldHP = pokeInfoCalculator.getHPAtLevel(ivScanResult, estimatedPokemonLevel, ivScanResult.pokemon);
         int hpDiff = newHP - oldHP;
         String sign = (hpDiff >= 0) ? "+" : ""; //add plus in front if positive.
         String hpText = newHP + " (" + sign + hpDiff + ")";

--- a/app/src/main/java/com/kamron/pogoiv/logic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/PokeInfoCalculator.java
@@ -323,7 +323,7 @@ public class PokeInfoCalculator {
      * @return An integer representing how much hp selectedpokemon with ivscanresult stamina ivs has at selectedlevel
      */
     public int getHPAtLevel(IVScanResult ivScanResult, double selectedLevel, Pokemon selectedPokemon) {
-        double lvlScalar = Data.CpM[(int) (selectedLevel * 2 - 2)];
+        double lvlScalar = Data.CpM[Data.levelToLevelIdx(selectedLevel)];
         int highHp = (int) Math.max(Math.floor((selectedPokemon.baseStamina + ivScanResult.highStamina) * lvlScalar),
                 10);
         int lowHp = (int) Math.max(Math.floor((selectedPokemon.baseStamina + ivScanResult.highStamina) * lvlScalar),

--- a/app/src/main/java/com/kamron/pogoiv/logic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/PokeInfoCalculator.java
@@ -312,4 +312,23 @@ public class PokeInfoCalculator {
 
         return list;
     }
+
+    /**
+     * Get how much hp a pokemon will have at a certain level, including the stamina IV taken from the scan results.
+     * If the prediction is not exact because of big possible variation in stamina IV, the average will be returnred.
+     *
+     * @param ivScanResult    Scan results which includes stamina ivs
+     * @param selectedLevel   which level to get the hp for
+     * @param selectedPokemon Which pokemon to get Hp for
+     * @return An integer representing how much hp selectedpokemon with ivscanresult stamina ivs has at selectedlevel
+     */
+    public int getHPAtLevel(IVScanResult ivScanResult, double selectedLevel, Pokemon selectedPokemon) {
+        double lvlScalar = Data.CpM[(int) (selectedLevel * 2 - 2)];
+        int highHp = (int) Math.max(Math.floor((selectedPokemon.baseStamina + ivScanResult.highStamina) * lvlScalar),
+                10);
+        int lowHp = (int) Math.max(Math.floor((selectedPokemon.baseStamina + ivScanResult.highStamina) * lvlScalar),
+                10);
+        int averageHP = Math.round(highHp + lowHp) / 2;
+        return averageHP;
+    }
 }

--- a/app/src/main/res/layout/expanded_results_box.xml
+++ b/app/src/main/res/layout/expanded_results_box.xml
@@ -64,7 +64,45 @@
             android:textSize="@dimen/resultExpandedTextSize"/>
 
     </LinearLayout>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
 
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:text="% CP vs max IV"
+            android:textColor="@color/importantText"
+            android:textSize="@dimen/resultExpandedTextSize"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="(?)"
+            android:id="@+id/explainCPPercentageComparedToMaxIV"
+            android:paddingLeft="5dp"
+            android:paddingRight="5dp"
+            android:textColor="@color/colorPrimary"
+            android:textSize="@dimen/resultExpandedTextSize"/>
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            />
+
+        <TextView
+            android:id="@+id/exResultPercentPerfection"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="right"
+            android:text="#%perfection"
+            android:textColor="@color/importantText"
+            android:textSize="@dimen/resultExpandedTextSize"/>
+
+    </LinearLayout>
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/expanded_results_box.xml
+++ b/app/src/main/res/layout/expanded_results_box.xml
@@ -41,6 +41,36 @@
         android:orientation="horizontal">
 
         <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:text="@string/hp_expanded_box"
+            android:textColor="@color/importantText"
+            android:textSize="@dimen/resultExpandedTextSize"/>
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            />
+
+        <TextView
+            android:id="@+id/exResultHP"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="right"
+            android:text="#ofHP"
+            android:textColor="@color/importantText"
+            android:textSize="@dimen/resultExpandedTextSize"/>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
 
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,4 +129,5 @@
     <string name="iv" translatable="false">IV</string>
     <string name="percent" translatable="false">%d%%</string>
     <string name="unknown_percent" translatable="false">"?%"</string>
+    <string name="hp_expanded_box">HP</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,4 +130,6 @@
     <string name="percent" translatable="false">%d%%</string>
     <string name="unknown_percent" translatable="false">"?%"</string>
     <string name="hp_expanded_box">HP</string>
+    <string name="alert_explanation_title">Explanation</string>
+    <string name="perfection_explainer">The percentage shows how big the difference is between your pokemon and a pokemon of the same species which has perfect IVs.\n\nSo for example, if it says 92 percent, then your pokemon maxes out at 8 percent less CP compared to the same species with maximum IVs.</string>
 </resources>


### PR DESCRIPTION
This pr adds two new fields in the powerup and evolution box in the results window. HP and %CP vs max iv.


![unnamed](https://cloud.githubusercontent.com/assets/8545451/18801102/1fef5366-81e1-11e6-94aa-364a9f40b147.png)

I'm probably not going to add tier to the results, and instead just add it as an option for user configurable clipboard in another pr.