### PR TITLE
Add PokeSpam calculation

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
+++ b/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
@@ -14,6 +14,7 @@ public class GoIVSettings {
     public static final String COPY_TO_CLIPBOARD = "copyToClipboard";
     public static final String SEND_CRASH_REPORTS = "sendCrashReports";
     public static final String AUTO_UPDATE_ENABLED = "autoUpdateEnabled";
+    public static final String POKESPAM_ENABLED = "pokeSpamEnabled";
     public static final String TEAM_NAME = "teamName";
 
     private static GoIVSettings instance;
@@ -69,5 +70,9 @@ public class GoIVSettings {
 
     public boolean isAutoUpdateEnabled() {
         return prefs.getBoolean(AUTO_UPDATE_ENABLED, true);
+    }
+
+    public boolean isPokeSpamEnabled() {
+        return prefs.getBoolean(POKESPAM_ENABLED, true);
     }
 }

--- a/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
@@ -338,6 +338,54 @@ public class OcrHelper {
         }
     }
 
+
+    /**
+     * Gets the candy amount from a pokemon image, it will return absent if PokeSpam is disabled.
+     *
+     * @param pokemonImage the image of the whole screen
+     * @return candyAmount the candy amount, or blank Optional object if nothing was found
+     */
+    private Optional<Integer> getCandyAmountFromImg(Bitmap pokemonImage) {
+
+        //Disable getting CandyAmount if we don't have PokeSpam enabled
+        GoIVSettings settings;
+        try {
+            //Anything better then getInstance(null)? should we let it crash?
+            settings = GoIVSettings.getInstance(null);
+        } catch (Exception ex) {
+            //Probably a crash due to getInstance
+            return Optional.absent();
+        }
+
+        if (settings == null || !settings.isPokeSpamEnabled()) {
+            return Optional.absent();
+        }
+
+        Bitmap candyAmount = Bitmap.createBitmap(pokemonImage,
+                (int) Math.round(widthPixels / 1.515), (int) Math.round(heightPixels / 1.44),
+                (int) Math.round(widthPixels / 5.0), (int) Math.round(heightPixels / 38.4));
+        String hash = "candyAmount" + hashBitmap(candyAmount);
+        String pokemonCandyStr = ocrCache.get(hash);
+
+        if (pokemonCandyStr == null) {
+            candyAmount = replaceColors(candyAmount, 55, 66, 61, Color.WHITE, 200, true);
+            tesseract.setImage(candyAmount);
+            pokemonCandyStr = tesseract.getUTF8Text();
+            ocrCache.put(hash, pokemonCandyStr);
+        }
+        candyAmount.recycle();
+
+        if (pokemonCandyStr.length() > 0) {
+            try {
+                return Optional.of(Integer.parseInt(fixOcrLettersToNums(pokemonCandyStr).replaceAll("[^0-9]", "")));
+            } catch (NumberFormatException e) {
+                //Fall-through to default.
+            }
+        }
+
+        return Optional.absent();
+    }
+
     /**
      * scanPokemon
      * Performs OCR on an image of a pokemon and returns the pulled info.
@@ -352,7 +400,8 @@ public class OcrHelper {
         String candyName = getCandyNameFromImg(pokemonImage);
         Optional<Integer> pokemonHP = getPokemonHPFromImg(pokemonImage);
         Optional<Integer> pokemonCP = getPokemonCPFromImg(pokemonImage);
+        Optional<Integer> pokemonCandyAmount = getCandyAmountFromImg(pokemonImage);
 
-        return new ScanResult(estimatedPokemonLevel, pokemonName, candyName, pokemonHP, pokemonCP);
+        return new ScanResult(estimatedPokemonLevel, pokemonName, candyName, pokemonHP, pokemonCP, pokemonCandyAmount);
     }
 }

--- a/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
@@ -30,8 +30,10 @@ public class OcrHelper {
     private final boolean candyWordFirst;
     private final String nidoFemale;
     private final String nidoMale;
+    private final boolean isPokeSpamEnabled;
 
-    private OcrHelper(String dataPath, int widthPixels, int heightPixels, String nidoFemale, String nidoMale) {
+    private OcrHelper(String dataPath, int widthPixels, int heightPixels, String nidoFemale, String nidoMale,
+                      boolean isPokeSpamEnabled) {
         tesseract = new TessBaseAPI();
         tesseract.init(dataPath, "eng");
         tesseract.setPageSegMode(TessBaseAPI.PageSegMode.PSM_SINGLE_LINE);
@@ -42,6 +44,7 @@ public class OcrHelper {
         this.candyWordFirst = isCandyWordFirst();
         this.nidoFemale = nidoFemale;
         this.nidoMale = nidoMale;
+        this.isPokeSpamEnabled = isPokeSpamEnabled;
     }
 
     /**
@@ -52,9 +55,9 @@ public class OcrHelper {
      * @return Bitmap with replaced colors
      */
     public static OcrHelper init(String dataPath, int widthPixels, int heightPixels, String nidoFemale,
-                                 String nidoMale) {
+                                 String nidoMale, boolean isPokeSpamEnabled) {
         if (instance == null) {
-            instance = new OcrHelper(dataPath, widthPixels, heightPixels, nidoFemale, nidoMale);
+            instance = new OcrHelper(dataPath, widthPixels, heightPixels, nidoFemale, nidoMale, isPokeSpamEnabled);
         }
         return instance;
     }
@@ -346,18 +349,7 @@ public class OcrHelper {
      * @return candyAmount the candy amount, or blank Optional object if nothing was found
      */
     private Optional<Integer> getCandyAmountFromImg(Bitmap pokemonImage) {
-
-        //Disable getting CandyAmount if we don't have PokeSpam enabled
-        GoIVSettings settings;
-        try {
-            //Anything better then getInstance(null)? should we let it crash?
-            settings = GoIVSettings.getInstance(null);
-        } catch (Exception ex) {
-            //Probably a crash due to getInstance
-            return Optional.absent();
-        }
-
-        if (settings == null || !settings.isPokeSpamEnabled()) {
+        if (!isPokeSpamEnabled) {
             return Optional.absent();
         }
 

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1660,7 +1660,8 @@ public class Pokefly extends Service {
 
         ocr = OcrHelper.init(extdir, displayMetrics.widthPixels, displayMetrics.heightPixels,
                 pokeInfoCalculator.get(28).name,
-                pokeInfoCalculator.get(31).name);
+                pokeInfoCalculator.get(31).name,
+                GoIVSettings.getInstance(this).isPokeSpamEnabled());
     }
 
 

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1353,14 +1353,18 @@ public class Pokefly extends Service {
      * setAndCalculatePokeSpamText sets pokespamtext and makes it visible.
      *
      * @param ivScanResult IVScanResult object that contains the scan results, mainly needed to get candEvolutionCost
-     *                     varible
+     *                     variable
      */
     private void setAndCalculatePokeSpamText(IVScanResult ivScanResult) {
         if (GoIVSettings.getInstance(getApplicationContext()).isPokeSpamEnabled()
-                && pokemonCandy.isPresent() && ivScanResult.pokemon != null
-                && ivScanResult.pokemon.candyEvolutionCost > 0) {
-            PokeSpam pokeSpamCalculator = new PokeSpam(pokemonCandy.get(), ivScanResult.pokemon.candyEvolutionCost);
+                 && ivScanResult.pokemon != null) {
+            if (ivScanResult.pokemon.candyEvolutionCost < 0) {
+                exResPokeSpam.setText(getString(R.string.pokespam_not_available));
+                pokeSpamView.setVisibility(View.VISIBLE);
+                return;
+            }
 
+            PokeSpam pokeSpamCalculator = new PokeSpam(pokemonCandy.or(0),ivScanResult.pokemon.candyEvolutionCost);
             String text = getString(R.string.pokespam_formatted_message,
                     pokeSpamCalculator.getTotalEvolvable(), pokeSpamCalculator.getEvolveRows(),
                     pokeSpamCalculator.getEvolveExtra());

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1647,6 +1647,7 @@ public class Pokefly extends Service {
                 checkIv();
             }
         }
+        enableOrDisablePokeSpamBoxBasedOnSettings();
     }
 
     private <T> String optionalIntToString(Optional<T> src) {

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1360,7 +1360,7 @@ public class Pokefly extends Service {
                 &&  ivScanResult.pokemon.candyEvolutionCost > 0) {
             PokeSpam pokeSpamCalculator = new PokeSpam(pokemonCandy.get(),ivScanResult.pokemon.candyEvolutionCost);
 
-            String text = getString(R.string.pokespamformatedmessage,
+            String text = getString(R.string.pokespam_formatted_message,
                     pokeSpamCalculator.getTotalEvolvable(),pokeSpamCalculator.getEvolveRows(),
                     pokeSpamCalculator.getEvolveExtra());
             exResPokeSpam.setText(text);

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -56,6 +56,7 @@ import com.kamron.pogoiv.logic.Data;
 import com.kamron.pogoiv.logic.IVCombination;
 import com.kamron.pogoiv.logic.IVScanResult;
 import com.kamron.pogoiv.logic.PokeInfoCalculator;
+import com.kamron.pogoiv.logic.PokeSpam;
 import com.kamron.pogoiv.logic.Pokemon;
 import com.kamron.pogoiv.logic.PokemonNameCorrector;
 import com.kamron.pogoiv.logic.ScanContainer;
@@ -96,6 +97,7 @@ public class Pokefly extends Service {
     private static final String KEY_SEND_INFO_CP = "key_send_info_cp";
     private static final String KEY_SEND_INFO_LEVEL = "key_send_info_level";
     private static final String KEY_SEND_SCREENSHOT_FILE = "key_send_screenshot_file";
+    private static final String KEY_SEND_INFO_CANDY_AMOUNT = "key_send_info_candy_amount";
 
     private static final String ACTION_PROCESS_BITMAP = "com.kamron.pogoiv.PROCESS_BITMAP";
     private static final String KEY_BITMAP = "bitmap";
@@ -158,6 +160,8 @@ public class Pokefly extends Service {
     EditText pokemonCPEdit;
     @BindView(R.id.etHp)
     EditText pokemonHPEdit;
+    @BindView(R.id.etCandy)
+    EditText pokemonCandyEdit;
     @BindView(R.id.sbArcAdjust)
     SeekBar arcAdjustBar;
     @BindView(R.id.llButtonsInitial)
@@ -180,7 +184,6 @@ public class Pokefly extends Service {
     LinearLayout expandedResultsBox;
     @BindView(R.id.allPossibilitiesBox)
     LinearLayout allPossibilitiesBox;
-
 
     @BindView(R.id.appraisalBox)
     LinearLayout appraisalBox;
@@ -249,9 +252,16 @@ public class Pokefly extends Service {
     @BindView(R.id.inputAppraisalExpandBox)
     TextView inputAppraisalExpandBox;
 
-
     @BindView(R.id.rvResults)
     RecyclerView rvResults;
+
+    //PokeSpam
+    @BindView(R.id.llPokeSpamDialogInputContentBox)
+    LinearLayout pokeSpamDialogInputContentBox;
+    @BindView(R.id.llPokeSpam)
+    LinearLayout pokeSpamView;
+    @BindView(R.id.exResPokeSpam)
+    TextView exResPokeSpam;
 
     // Refine by appraisal
     @BindView(R.id.attCheckbox)
@@ -264,6 +274,7 @@ public class Pokefly extends Service {
 
     private String pokemonName;
     private String candyName;
+    private Optional<Integer> pokemonCandy = Optional.absent();
     private Optional<Integer> pokemonCP = Optional.absent();
     private Optional<Integer> pokemonHP = Optional.absent();
     private double estimatedPokemonLevel = 1.0;
@@ -318,6 +329,7 @@ public class Pokefly extends Service {
         intent.putExtra(KEY_SEND_INFO_CP, scanResult.getPokemonCP());
         intent.putExtra(KEY_SEND_INFO_LEVEL, scanResult.getEstimatedPokemonLevel());
         intent.putExtra(KEY_SEND_SCREENSHOT_FILE, filePath);
+        intent.putExtra(KEY_SEND_INFO_CANDY_AMOUNT, scanResult.getPokemonCandyAmount());
     }
 
     public static Intent createProcessBitmapIntent(Bitmap bitmap, String file) {
@@ -964,6 +976,12 @@ public class Pokefly extends Service {
         } catch (NumberFormatException e) {
             return false;
         }
+        //do not require pokemon candy to be filled
+        try {
+            pokemonCandy = Optional.of(Integer.parseInt(pokemonCandyEdit.getText().toString()));
+        }  catch (NumberFormatException e) {
+            pokemonCandy = Optional.absent();
+        }
         return true;
     }
 
@@ -1294,6 +1312,8 @@ public class Pokefly extends Service {
         setEstimateCostTextboxes(ivScanResult, selectedLevel, selectedPokemon);
         exResLevel.setText(String.valueOf(selectedLevel));
         setEstimateLevelTextColor(selectedLevel);
+
+        setAndCalculatePokeSpamText(ivScanResult);
     }
 
     /**
@@ -1328,6 +1348,29 @@ public class Pokefly extends Service {
         String hpText = newHP + " (" + sign + hpDiff + ")";
         exResultHP.setText(hpText);
     }
+
+    /**
+     * setAndCalculatePokeSpamText sets pokespamtext and makes it visible.
+     * @param ivScanResult IVScanResult object that contains the scan results, mainly needed to get candEvolutionCost
+     *                     varible
+     */
+    private void setAndCalculatePokeSpamText(IVScanResult ivScanResult) {
+        if (GoIVSettings.getInstance(getApplicationContext()).isPokeSpamEnabled()
+                && pokemonCandy.isPresent() && ivScanResult.pokemon != null
+                &&  ivScanResult.pokemon.candyEvolutionCost > 0) {
+            PokeSpam pokeSpamCalculator = new PokeSpam(pokemonCandy.get(),ivScanResult.pokemon.candyEvolutionCost);
+
+            String text = getString(R.string.pokespamformatedmessage,
+                    pokeSpamCalculator.getTotalEvolvable(),pokeSpamCalculator.getEvolveRows(),
+                    pokeSpamCalculator.getEvolveExtra());
+            exResPokeSpam.setText(text);
+            pokeSpamView.setVisibility(View.VISIBLE);
+        } else {
+            exResPokeSpam.setText("");
+            pokeSpamView.setVisibility(View.GONE);
+        }
+    }
+
 
     /**
      * Sets the "expected cp textview" to (+x) or (-y) in the powerup and evolution estimate box depending on what's
@@ -1540,6 +1583,16 @@ public class Pokefly extends Service {
             onCheckButtonsLayout.setVisibility(View.GONE);
         }
         moveOverlayUpOrDownToMatchAppraisalBox();
+        enableOrDisablePokeSpamBoxBasedOnSettings();
+    }
+
+    private void enableOrDisablePokeSpamBoxBasedOnSettings() {
+        //enable/disable visibility based on PokeSpam enabled or not
+        if (GoIVSettings.getInstance(getApplicationContext()).isPokeSpamEnabled()) {
+            pokeSpamDialogInputContentBox.setVisibility(View.VISIBLE);
+        } else  {
+            pokeSpamDialogInputContentBox.setVisibility(View.GONE);
+        }
     }
 
     /**
@@ -1574,6 +1627,7 @@ public class Pokefly extends Service {
 
             pokemonHPEdit.setText(optionalIntToString(pokemonHP));
             pokemonCPEdit.setText(optionalIntToString(pokemonCP));
+            pokemonCandyEdit.setText(optionalIntToString(pokemonCandy));
 
             showInfoLayoutArcPointer();
             setVisibility(inputAppraisalExpandBox, appraisalBox, false, false);
@@ -1683,6 +1737,7 @@ public class Pokefly extends Service {
                     pokemonName = intent.getStringExtra(KEY_SEND_INFO_NAME);
                     candyName = intent.getStringExtra(KEY_SEND_INFO_CANDY);
 
+
                     @SuppressWarnings("unchecked") Optional<String> lScreenShotFile =
                             (Optional<String>) intent.getSerializableExtra(KEY_SEND_SCREENSHOT_FILE);
                     @SuppressWarnings("unchecked") Optional<Integer> lPokemonCP =
@@ -1692,6 +1747,10 @@ public class Pokefly extends Service {
                     pokemonCP = lPokemonCP;
                     pokemonHP = lPokemonHP;
                     screenShotPath = lScreenShotFile;
+
+                    @SuppressWarnings("unchecked") Optional<Integer> lcandyAmount =
+                            (Optional<Integer>) intent.getSerializableExtra(KEY_SEND_INFO_CANDY_AMOUNT);
+                    pokemonCandy = lcandyAmount;
 
                     estimatedPokemonLevel = intent.getDoubleExtra(KEY_SEND_INFO_LEVEL, estimatedPokemonLevel);
                     if (estimatedPokemonLevel < 1.0) {
@@ -1726,5 +1785,4 @@ public class Pokefly extends Service {
     private int dpToPx(int dp) {
         return Math.round(dp * (displayMetrics.xdpi / DisplayMetrics.DENSITY_DEFAULT));
     }
-
 }

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -979,7 +979,7 @@ public class Pokefly extends Service {
         //do not require pokemon candy to be filled
         try {
             pokemonCandy = Optional.of(Integer.parseInt(pokemonCandyEdit.getText().toString()));
-        }  catch (NumberFormatException e) {
+        } catch (NumberFormatException e) {
             pokemonCandy = Optional.absent();
         }
         return true;
@@ -1351,17 +1351,18 @@ public class Pokefly extends Service {
 
     /**
      * setAndCalculatePokeSpamText sets pokespamtext and makes it visible.
+     *
      * @param ivScanResult IVScanResult object that contains the scan results, mainly needed to get candEvolutionCost
      *                     varible
      */
     private void setAndCalculatePokeSpamText(IVScanResult ivScanResult) {
         if (GoIVSettings.getInstance(getApplicationContext()).isPokeSpamEnabled()
                 && pokemonCandy.isPresent() && ivScanResult.pokemon != null
-                &&  ivScanResult.pokemon.candyEvolutionCost > 0) {
-            PokeSpam pokeSpamCalculator = new PokeSpam(pokemonCandy.get(),ivScanResult.pokemon.candyEvolutionCost);
+                && ivScanResult.pokemon.candyEvolutionCost > 0) {
+            PokeSpam pokeSpamCalculator = new PokeSpam(pokemonCandy.get(), ivScanResult.pokemon.candyEvolutionCost);
 
             String text = getString(R.string.pokespam_formatted_message,
-                    pokeSpamCalculator.getTotalEvolvable(),pokeSpamCalculator.getEvolveRows(),
+                    pokeSpamCalculator.getTotalEvolvable(), pokeSpamCalculator.getEvolveRows(),
                     pokeSpamCalculator.getEvolveExtra());
             exResPokeSpam.setText(text);
             pokeSpamView.setVisibility(View.VISIBLE);
@@ -1590,7 +1591,7 @@ public class Pokefly extends Service {
         //enable/disable visibility based on PokeSpam enabled or not
         if (GoIVSettings.getInstance(getApplicationContext()).isPokeSpamEnabled()) {
             pokeSpamDialogInputContentBox.setVisibility(View.VISIBLE);
-        } else  {
+        } else {
             pokeSpamDialogInputContentBox.setVisibility(View.GONE);
         }
     }

--- a/app/src/main/java/com/kamron/pogoiv/logic/PokeSpam.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/PokeSpam.java
@@ -25,9 +25,10 @@ public class PokeSpam {
 
     /**
      * pokeSpam this object allows you to calculate how many pokemon we can evolve using current candy..
-     * @param candyPlayerHas How much candy the player has for this pokemon
+     *
+     * @param candyPlayerHas     How much candy the player has for this pokemon
      * @param candyEvolutionCost How much candy it cost to evolve the pokemon
-     * @param bonus How much bonus for evolving, for example 1 is for regular evolve, 2 is for transferring
+     * @param bonus              How much bonus for evolving, for example 1 is for regular evolve, 2 is for transferring
      */
     public PokeSpam(int candyPlayerHas, int candyEvolutionCost, Optional<Integer> bonus) {
         calculatePokeSpam(candyPlayerHas, candyEvolutionCost, bonus.or(defaultBonus));
@@ -35,9 +36,11 @@ public class PokeSpam {
 
     /**
      * calculatePokeSpam calculates how many pokemon we can evolve using current candy.
-     * @param candyPlayerHas How much candy the player has for this pokemon
+     *
+     * @param candyPlayerHas     How much candy the player has for this pokemon
      * @param candyEvolutionCost How much candy it cost to evolve the pokemon
-     * @param bonus Optional: How much bonus for evolving, for example 1 is for regular evolve, 2 is for transferring
+     * @param bonus              Optional: How much bonus for evolving, for example 1 is for regular evolve, 2 is for
+     *                           transferring
      */
     private void calculatePokeSpam(int candyPlayerHas, int candyEvolutionCost, int bonus) {
         //Candy Amount divided by Evolve Cost without the left over,

--- a/app/src/main/java/com/kamron/pogoiv/logic/PokeSpam.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/PokeSpam.java
@@ -13,11 +13,11 @@ public class PokeSpam {
     final int howManyPokemonWeHavePerRow = 3;
     final int defaultBonus = 1;
 
-    private Integer totalEvolvable;
-    private Integer evolveRows;
-    private Integer evolveExtra;
-    private Integer amountXP;
-    private Integer amountXPWithLuckyEgg;
+    private int totalEvolvable;
+    private int evolveRows;
+    private int evolveExtra;
+    private int amountXP;
+    private int amountXPWithLuckyEgg;
 
     public PokeSpam(int candyPlayerHas, int candyEvolutionCost) {
         calculatePokeSpam(candyPlayerHas, candyEvolutionCost, defaultBonus);
@@ -50,7 +50,7 @@ public class PokeSpam {
         evolveRows = (int) Math.floor(totalEvolvable / howManyPokemonWeHavePerRow);
         evolveExtra = (int) Math.floor(totalEvolvable % howManyPokemonWeHavePerRow);
         amountXP = 500 * totalEvolvable;
-        amountXPWithLuckyEgg = (amountXP * 2);
+        amountXPWithLuckyEgg = amountXP * 2;
     }
 
 }

--- a/app/src/main/java/com/kamron/pogoiv/logic/PokeSpam.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/PokeSpam.java
@@ -1,0 +1,56 @@
+package com.kamron.pogoiv.logic;
+
+import com.google.common.base.Optional;
+
+import lombok.Getter;
+
+/**
+ * Created by NightMadness on 9/20/2016.
+ */
+
+@Getter
+public class PokeSpam {
+    final int howManyPokemonWeHavePerRow = 3;
+    final int defaultBonus = 1;
+
+    private Integer totalEvolvable;
+    private Integer evolveRows;
+    private Integer evolveExtra;
+    private Integer amountXP;
+    private Integer amountXPWithLuckyEgg;
+
+    public PokeSpam(int candyPlayerHas, int candyEvolutionCost) {
+        calculatePokeSpam(candyPlayerHas, candyEvolutionCost, defaultBonus);
+    }
+
+    /**
+     * pokeSpam this object allows you to calculate how many pokemon we can evolve using current candy..
+     * @param candyPlayerHas How much candy the player has for this pokemon
+     * @param candyEvolutionCost How much candy it cost to evolve the pokemon
+     * @param bonus How much bonus for evolving, for example 1 is for regular evolve, 2 is for transferring
+     */
+    public PokeSpam(int candyPlayerHas, int candyEvolutionCost, Optional<Integer> bonus) {
+        calculatePokeSpam(candyPlayerHas, candyEvolutionCost, bonus.or(defaultBonus));
+    }
+
+    /**
+     * calculatePokeSpam calculates how many pokemon we can evolve using current candy.
+     * @param candyPlayerHas How much candy the player has for this pokemon
+     * @param candyEvolutionCost How much candy it cost to evolve the pokemon
+     * @param bonus Optional: How much bonus for evolving, for example 1 is for regular evolve, 2 is for transferring
+     */
+    private void calculatePokeSpam(int candyPlayerHas, int candyEvolutionCost, int bonus) {
+        //Candy Amount divided by Evolve Cost without the left over,
+        //maybe in the future we will have better bonuses
+        //bonus = 1 for regular
+        //bonus = 2 for transfer
+
+        //math.floor is not needed as int already does it, but its makes it explicit that we do it for readability
+        totalEvolvable = (int) Math.floor((candyPlayerHas - bonus) / (candyEvolutionCost - bonus));
+        evolveRows = (int) Math.floor(totalEvolvable / howManyPokemonWeHavePerRow);
+        evolveExtra = (int) Math.floor(totalEvolvable % howManyPokemonWeHavePerRow);
+        amountXP = 500 * totalEvolvable;
+        amountXPWithLuckyEgg = (amountXP * 2);
+    }
+
+}

--- a/app/src/main/java/com/kamron/pogoiv/logic/ScanResult.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/ScanResult.java
@@ -17,7 +17,7 @@ public class ScanResult {
     private final Optional<Integer> pokemonCandyAmount;
 
     public ScanResult(double estimatedPokemonLevel, String pokemonName, String candyName, Optional<Integer> pokemonHP,
-                      Optional<Integer> pokemonCP,Optional<Integer> pokemonCandyAmount) {
+                      Optional<Integer> pokemonCP, Optional<Integer> pokemonCandyAmount) {
         this.estimatedPokemonLevel = estimatedPokemonLevel;
         this.pokemonName = pokemonName;
         this.candyName = candyName;

--- a/app/src/main/java/com/kamron/pogoiv/logic/ScanResult.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/ScanResult.java
@@ -14,14 +14,16 @@ public class ScanResult {
     private final String candyName;
     private final Optional<Integer> pokemonHP;
     private final Optional<Integer> pokemonCP;
+    private final Optional<Integer> pokemonCandyAmount;
 
     public ScanResult(double estimatedPokemonLevel, String pokemonName, String candyName, Optional<Integer> pokemonHP,
-                      Optional<Integer> pokemonCP) {
+                      Optional<Integer> pokemonCP,Optional<Integer> pokemonCandyAmount) {
         this.estimatedPokemonLevel = estimatedPokemonLevel;
         this.pokemonName = pokemonName;
         this.candyName = candyName;
         this.pokemonHP = pokemonHP;
         this.pokemonCP = pokemonCP;
+        this.pokemonCandyAmount = pokemonCandyAmount;
     }
 
     public double getEstimatedPokemonLevel() {
@@ -42,6 +44,10 @@ public class ScanResult {
 
     public Optional<Integer> getPokemonCP() {
         return pokemonCP;
+    }
+
+    public Optional<Integer> getPokemonCandyAmount() {
+        return pokemonCandyAmount;
     }
 
     /**

--- a/app/src/main/res/layout/dialog_input.xml
+++ b/app/src/main/res/layout/dialog_input.xml
@@ -93,6 +93,35 @@
                 android:inputType="number"/>
 
         </LinearLayout>
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center"
+            android:layout_weight="1"
+            android:id="@+id/llPokeSpamDialogInputContentBox">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/candy"
+                android:textColor="@color/black"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                android:gravity="center"/>
+
+            <EditText
+                android:id="@+id/etCandy"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/colorPrimary"
+                android:minWidth="80dp"
+                android:text="XX"
+                android:maxLength="5"
+                android:textAlignment="center"
+                android:inputType="number"/>
+
+        </LinearLayout>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/expanded_results_box.xml
+++ b/app/src/main/res/layout/expanded_results_box.xml
@@ -293,4 +293,35 @@
         android:layout_marginTop="5dp"
         android:background="@android:color/darker_gray"/>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:visibility="visible"
+        android:id="@+id/llPokeSpam">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:text="@string/pokespam"
+            android:textColor="@color/importantText"
+            android:textSize="@dimen/resultExpandedTextSize"/>
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            />
+
+        <TextView
+            android:id="@+id/exResPokeSpam"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="right"
+            android:text="#ofSpam"
+            android:textColor="@color/importantText"
+            android:textSize="@dimen/resultExpandedTextSize"/>
+
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,4 +130,9 @@
     <string name="cp_vs_iv" formatted="false">% CP vs max IV</string>
     <string name="alert_explanation_title">Explanation</string>
     <string name="perfection_explainer">The percentage shows how big the difference is between your Pokémon and a Pokémon of the same species which has perfect IVs.\n\nSo for example, if it says 92 percent, then your Pokémon maxes out at 8 percent less CP compared to the same species with maximum IVs.</string>
+    <string name="pokespam">PokeSpam</string>
+    <string name="pokespamformatedmessage">%1$d (%2$d rows + %3$d more)</string>
+    <string name="candy">Candy</string>
+    <string name="PokeSpam_setting_title">Enable PokeSpam Calculation</string>
+    <string name="PokeSpam_setting_summary">This feature enables scanning for candy amount and allows you to see how many pokemon you can evolve, useful for use with lucky egg</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,6 +133,7 @@
     <string name="pokespam">PokeSpam</string>
     <string name="pokespam_formatted_message">%1$d (%2$d rows + %3$d more)</string>
     <string name="candy">Candy</string>
+    <string name="pokespam_not_available">Not Available</string>
     <string name="PokeSpam_setting_title">Enable PokeSpam Calculation</string>
     <string name="PokeSpam_setting_summary">This feature enables scanning for candy amount and allows you to see how many pokemon you can evolve, useful for use with lucky egg</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,7 +131,7 @@
     <string name="alert_explanation_title">Explanation</string>
     <string name="perfection_explainer">The percentage shows how big the difference is between your Pokémon and a Pokémon of the same species which has perfect IVs.\n\nSo for example, if it says 92 percent, then your Pokémon maxes out at 8 percent less CP compared to the same species with maximum IVs.</string>
     <string name="pokespam">PokeSpam</string>
-    <string name="pokespamformatedmessage">%1$d (%2$d rows + %3$d more)</string>
+    <string name="pokespam_formatted_message">%1$d (%2$d rows + %3$d more)</string>
     <string name="candy">Candy</string>
     <string name="PokeSpam_setting_title">Enable PokeSpam Calculation</string>
     <string name="PokeSpam_setting_summary">This feature enables scanning for candy amount and allows you to see how many pokemon you can evolve, useful for use with lucky egg</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -44,6 +44,12 @@
         android:summary="@string/auto_update_setting_summary"
         android:defaultValue="true"/>
 
+    <SwitchPreference
+        android:key="pokeSpamEnabled"
+        android:title="@string/PokeSpam_setting_title"
+        android:summary="@string/PokeSpam_setting_summary"
+        android:defaultValue="true"/>
+
     <Preference
         android:key="checkForUpdate"
         android:title="@string/check_for_update_setting_title"

--- a/app/src/test/java/com/kamron/pogoiv/logic/PokeSpamTest.java
+++ b/app/src/test/java/com/kamron/pogoiv/logic/PokeSpamTest.java
@@ -48,6 +48,7 @@ public class PokeSpamTest {
     public void testVenonat() throws Exception {
         assertEquals((new PokeSpam(150, 50).getTotalEvolvable()),(Integer) 3);
     }
+    @Test
     public void testExtraPokemonBasedOnExtraCandy() throws Exception {
         assertEquals((new PokeSpam(144, 12).getTotalEvolvable()),(Integer) 13);
     }

--- a/app/src/test/java/com/kamron/pogoiv/logic/PokeSpamTest.java
+++ b/app/src/test/java/com/kamron/pogoiv/logic/PokeSpamTest.java
@@ -36,6 +36,7 @@ public class PokeSpamTest {
         assertEquals(pokeSpamCalculator.getEvolveExtra(), 0);
     }
 
+    // From https://github.com/farkam135/GoIV/pull/457#issuecomment-248880815.
     @Test
     public void testBlaisorbladeTestCases() throws Exception {
         assertEquals(new PokeSpam(11, 12).getTotalEvolvable(), 0);

--- a/app/src/test/java/com/kamron/pogoiv/logic/PokeSpamTest.java
+++ b/app/src/test/java/com/kamron/pogoiv/logic/PokeSpamTest.java
@@ -13,45 +13,45 @@ public class PokeSpamTest {
     @Test
     public void testGetHowMuchWeCanEvolve() throws Exception {
         PokeSpam pokeSpamCalculator = new PokeSpam(536, 11);
-        assertEquals((int) pokeSpamCalculator.getTotalEvolvable(), 53);
+        assertEquals(pokeSpamCalculator.getTotalEvolvable(), 53);
     }
 
     @Test
     public void testEvolveRows() throws Exception {
         PokeSpam pokeSpamCalculator = new PokeSpam(536, 12);
-        assertEquals((int) pokeSpamCalculator.getEvolveRows(), 16);
+        assertEquals(pokeSpamCalculator.getEvolveRows(), 16);
     }
 
     @Test
     public void testGetEvolveExtra() throws Exception {
         PokeSpam pokeSpamCalculator = new PokeSpam(536, 12);
-        assertEquals((int) pokeSpamCalculator.getEvolveExtra(), 0);
+        assertEquals(pokeSpamCalculator.getEvolveExtra(), 0);
     }
 
     @Test
     public void testNotEnoughCandy() throws Exception {
         PokeSpam pokeSpamCalculator = new PokeSpam(2, 12);
-        assertEquals((int) pokeSpamCalculator.getTotalEvolvable(), 0);
-        assertEquals((int) pokeSpamCalculator.getEvolveRows(), 0);
-        assertEquals((int) pokeSpamCalculator.getEvolveExtra(), 0);
+        assertEquals(pokeSpamCalculator.getTotalEvolvable(), 0);
+        assertEquals(pokeSpamCalculator.getEvolveRows(), 0);
+        assertEquals(pokeSpamCalculator.getEvolveExtra(), 0);
     }
 
     @Test
     public void testBlaisorbladeTestCases() throws Exception {
-        assertEquals((new PokeSpam(11, 12).getTotalEvolvable()), (Integer) 0);
-        assertEquals((new PokeSpam(12, 12).getTotalEvolvable()), (Integer) 1);
-        assertEquals((new PokeSpam(22, 12).getTotalEvolvable()), (Integer) 1);
-        assertEquals((new PokeSpam(23, 12).getTotalEvolvable()), (Integer) 2);
+        assertEquals(new PokeSpam(11, 12).getTotalEvolvable(), 0);
+        assertEquals(new PokeSpam(12, 12).getTotalEvolvable(), 1);
+        assertEquals(new PokeSpam(22, 12).getTotalEvolvable(), 1);
+        assertEquals(new PokeSpam(23, 12).getTotalEvolvable(), 2);
     }
 
     @Test
     public void testVenonat() throws Exception {
-        assertEquals((new PokeSpam(150, 50).getTotalEvolvable()), (Integer) 3);
+        assertEquals(new PokeSpam(150, 50).getTotalEvolvable(), 3);
     }
 
     @Test
     public void testExtraPokemonBasedOnExtraCandy() throws Exception {
-        assertEquals((new PokeSpam(144, 12).getTotalEvolvable()), (Integer) 13);
+        assertEquals(new PokeSpam(144, 12).getTotalEvolvable(), 13);
     }
 
 }

--- a/app/src/test/java/com/kamron/pogoiv/logic/PokeSpamTest.java
+++ b/app/src/test/java/com/kamron/pogoiv/logic/PokeSpamTest.java
@@ -1,0 +1,55 @@
+package com.kamron.pogoiv.logic;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by NightMadness on 9/20/2016.
+ */
+public class PokeSpamTest {
+
+
+
+    @Test
+    public void testGethowMuchWeCanEvolve() throws Exception {
+        PokeSpam pokeSpamCalculator = new PokeSpam(536, 11);
+        assertEquals((int)pokeSpamCalculator.getTotalEvolvable(),53);
+    }
+
+    @Test
+    public void testEvolveRows() throws Exception {
+        PokeSpam pokeSpamCalculator = new PokeSpam(536, 12);
+        assertEquals((int)pokeSpamCalculator.getEvolveRows(),16);
+    }
+
+    @Test
+    public void testGetEvolveExtra() throws Exception {
+        PokeSpam pokeSpamCalculator = new PokeSpam(536, 12);
+        assertEquals((int)pokeSpamCalculator.getEvolveExtra(),0);
+    }
+
+    @Test
+    public void testNotEnoghCandy() throws Exception {
+        PokeSpam pokeSpamCalculator = new PokeSpam(2, 12);
+        assertEquals((int)pokeSpamCalculator.getTotalEvolvable(), 0);
+        assertEquals((int)pokeSpamCalculator.getEvolveRows(), 0);
+        assertEquals((int)pokeSpamCalculator.getEvolveExtra(), 0);
+    }
+
+    @Test
+    public void testBlaisorbladeTestCases() throws Exception {
+        assertEquals((new PokeSpam(11, 12).getTotalEvolvable()),(Integer) 0);
+        assertEquals((new PokeSpam(12, 12).getTotalEvolvable()),(Integer) 1);
+        assertEquals((new PokeSpam(22, 12).getTotalEvolvable()),(Integer) 1);
+        assertEquals((new PokeSpam(23, 12).getTotalEvolvable()),(Integer) 2);
+    }
+    @Test
+    public void testVenonat() throws Exception {
+        assertEquals((new PokeSpam(150, 50).getTotalEvolvable()),(Integer) 3);
+    }
+    public void testExtraPokemonBasedOnExtraCandy() throws Exception {
+        assertEquals((new PokeSpam(144, 12).getTotalEvolvable()),(Integer) 13);
+    }
+
+}

--- a/app/src/test/java/com/kamron/pogoiv/logic/PokeSpamTest.java
+++ b/app/src/test/java/com/kamron/pogoiv/logic/PokeSpamTest.java
@@ -10,47 +10,48 @@ import static org.junit.Assert.assertEquals;
 public class PokeSpamTest {
 
 
-
     @Test
-    public void testGethowMuchWeCanEvolve() throws Exception {
+    public void testGetHowMuchWeCanEvolve() throws Exception {
         PokeSpam pokeSpamCalculator = new PokeSpam(536, 11);
-        assertEquals((int)pokeSpamCalculator.getTotalEvolvable(),53);
+        assertEquals((int) pokeSpamCalculator.getTotalEvolvable(), 53);
     }
 
     @Test
     public void testEvolveRows() throws Exception {
         PokeSpam pokeSpamCalculator = new PokeSpam(536, 12);
-        assertEquals((int)pokeSpamCalculator.getEvolveRows(),16);
+        assertEquals((int) pokeSpamCalculator.getEvolveRows(), 16);
     }
 
     @Test
     public void testGetEvolveExtra() throws Exception {
         PokeSpam pokeSpamCalculator = new PokeSpam(536, 12);
-        assertEquals((int)pokeSpamCalculator.getEvolveExtra(),0);
+        assertEquals((int) pokeSpamCalculator.getEvolveExtra(), 0);
     }
 
     @Test
-    public void testNotEnoghCandy() throws Exception {
+    public void testNotEnoughCandy() throws Exception {
         PokeSpam pokeSpamCalculator = new PokeSpam(2, 12);
-        assertEquals((int)pokeSpamCalculator.getTotalEvolvable(), 0);
-        assertEquals((int)pokeSpamCalculator.getEvolveRows(), 0);
-        assertEquals((int)pokeSpamCalculator.getEvolveExtra(), 0);
+        assertEquals((int) pokeSpamCalculator.getTotalEvolvable(), 0);
+        assertEquals((int) pokeSpamCalculator.getEvolveRows(), 0);
+        assertEquals((int) pokeSpamCalculator.getEvolveExtra(), 0);
     }
 
     @Test
     public void testBlaisorbladeTestCases() throws Exception {
-        assertEquals((new PokeSpam(11, 12).getTotalEvolvable()),(Integer) 0);
-        assertEquals((new PokeSpam(12, 12).getTotalEvolvable()),(Integer) 1);
-        assertEquals((new PokeSpam(22, 12).getTotalEvolvable()),(Integer) 1);
-        assertEquals((new PokeSpam(23, 12).getTotalEvolvable()),(Integer) 2);
+        assertEquals((new PokeSpam(11, 12).getTotalEvolvable()), (Integer) 0);
+        assertEquals((new PokeSpam(12, 12).getTotalEvolvable()), (Integer) 1);
+        assertEquals((new PokeSpam(22, 12).getTotalEvolvable()), (Integer) 1);
+        assertEquals((new PokeSpam(23, 12).getTotalEvolvable()), (Integer) 2);
     }
+
     @Test
     public void testVenonat() throws Exception {
-        assertEquals((new PokeSpam(150, 50).getTotalEvolvable()),(Integer) 3);
+        assertEquals((new PokeSpam(150, 50).getTotalEvolvable()), (Integer) 3);
     }
+
     @Test
     public void testExtraPokemonBasedOnExtraCandy() throws Exception {
-        assertEquals((new PokeSpam(144, 12).getTotalEvolvable()),(Integer) 13);
+        assertEquals((new PokeSpam(144, 12).getTotalEvolvable()), (Integer) 13);
     }
 
 }


### PR DESCRIPTION
If enabled, compute how many pokemons of the current species can be
evolved with the current amount of candies.

Squashed version of #457 until
7dedc5ed0977e5a5cc0ed676f340a44e1dbc6c80 (excluding the plugin system).

This is just the changes between that commit and
196b638333fb2586ffef60a7a4af91525ed5e504 (the latest commit on master
reflected on that PR).

Open issues:
- [x] refactor fetching of settings as suggested in the last comments of the PR.
- [x] fix conflicts.
- [x] miscellaneous cleanups (see commits).
- [x] testing shows that the input part for Candy is shown (but not filled in) even if the feature is disabled. That looks confusing.
- [x] testing also shows nothing for non-evolvable pokemons. That might be fine, but I wonder if saying something might be better for users looking for PokeSpam info (like me).

Closes #457.