### PR TITLE
Cleanup README badges and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # GoIV, Android Project for Pokémon GO.
 
-[![Travis Build Status](https://img.shields.io/travis/farkam135/GoIV/master.svg?maxAge=2592000 "Travis Build Status")](https://travis-ci.org/farkam135/GoIV)
+[![Current Release](https://img.shields.io/github/release/farkam135/GoIV.svg?maxAge=21600 "Current Release")](https://github.com/farkam135/GoIV/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/farkam135/GoIV/total.svg?maxAge=21600 "Downloads")](https://github.com/farkam135/GoIV/releases)
+[![Travis Build Status](https://img.shields.io/travis/farkam135/GoIV/master.svg?maxAge=21600 "Travis Build Status")](https://travis-ci.org/farkam135/GoIV)
 [![License](https://img.shields.io/github/license/farkam135/GoIV.svg?maxAge=2592000 "License")](LICENSE.md)
 
-### Latest Release: [![Downloads](https://img.shields.io/github/downloads/farkam135/GoIV/total.svg?maxAge=2592000 "Downloads")](https://github.com/farkam135/GoIV/releases/latest)
-### Changelog: [![Changelog](https://img.shields.io/github/release/farkam135/GoIV.svg?maxAge=2592000 "Changelog")](CHANGELOG.md)
+### [Release Downloads](https://github.com/farkam135/GoIV/releases)
+### [View Changelog](CHANGELOG.md)
 
 ## Table of Contents
 


### PR DESCRIPTION
First of two things changed is the cache on the badges was 30 days, so they weren't updating even on hard webpage refresh, so I changed the cache to 6 hours for all but the license one.

Second thing is that using the badges as links isn't obvious enough for users visiting this page just to get the latest download and see the changes. The wording is also awkward between what the badge is trying to communicate and what we're trying to say the link we're using the badge for is actually leading to. For example, the wording of what the download number actually was for (total downloads ever), versus the wording that made it seem like just downloads for the current version. Anyways, the result is I moved the badges all up all in-line so we're not relying on them to be the main links and made user-friendly links to the two thinks casual users need most.