### PR TITLE
Fix sizing of CP/HP/Candy fields in dialog_input for translations

### DIFF
--- a/app/src/main/res/layout/dialog_input.xml
+++ b/app/src/main/res/layout/dialog_input.xml
@@ -57,7 +57,7 @@
                 android:textColor="@color/colorPrimary"
                 android:text="XX"
                 android:maxLength="4"
-                android:minWidth="80dp"
+                android:minWidth="60dp"
                 android:textAlignment="center"
                 android:inputType="number"/>
 
@@ -86,7 +86,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textColor="@color/colorPrimary"
-                android:minWidth="80dp"
+                android:minWidth="60dp"
                 android:text="XX"
                 android:maxLength="4"
                 android:textAlignment="center"
@@ -98,7 +98,7 @@
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:gravity="center"
-            android:layout_weight="1"
+            android:layout_weight="1.6"
             android:id="@+id/llPokeSpamDialogInputContentBox">
 
             <TextView

--- a/app/src/main/res/layout/dialog_input.xml
+++ b/app/src/main/res/layout/dialog_input.xml
@@ -35,7 +35,7 @@
         android:baselineAligned="false">
 
         <LinearLayout
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:gravity="center"
@@ -66,7 +66,7 @@
 
 
         <LinearLayout
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:gravity="center"
@@ -94,11 +94,11 @@
 
         </LinearLayout>
         <LinearLayout
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:gravity="center"
-            android:layout_weight="1.6"
+            android:layout_weight="1"
             android:id="@+id/llPokeSpamDialogInputContentBox">
 
             <TextView
@@ -115,9 +115,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textColor="@color/colorPrimary"
-                android:minWidth="80dp"
+                android:minWidth="60dp"
                 android:text="XX"
-                android:maxLength="5"
+                android:maxLength="4"
                 android:textAlignment="center"
                 android:inputType="number"/>
 


### PR DESCRIPTION
With the adding of PokéSpam, a "Candy" field appeared next to the CP and HP ones in the dialog where you input your Pokémon's info. But the word "Candy" is longer in other languages ("Caramelos" in Spanish, "Bonbons" in French), so there wasn't enough room to input a 4-digits number of candies.

This change is the best way I found to make enough room in every language. Here's what it looks like in Spanish: http://i.imgur.com/dHcGP32.png
and in English: http://i.imgur.com/05HxEdz.png

I left the width of the "candy" field bigger than the CP and HP ones because it allows 5-digits numbers, while CP and HP only allow 4-digits numbers. (I tried to see what it would look like if it was the same width as the two other fields, to be more consistent (http://i.imgur.com/LXEjaSq.png), and I think it looks weirder because the left and right margins of the "candy" field are too big compared to the left and right margins of the "hp" field.)

On the first English screenshot I linked, you can see that the margins are still a bit different. I don't know if this is going to bother anyone, and I couldn't think of another solution that would adapt to every language. If you don't think this solution is good enough, does anyone have a better idea?