### PR TITLE
Fix new strings breaking naming pattern

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -68,6 +68,6 @@
     <string name="pokespam">PokéSpam</string>
     <string name="pokespam_formatted_message">%1$d (%2$d řádek + %3$d navíc)</string>
     <string name="pokespam_not_available">Nedostupné</string>
-    <string name="PokeSpam_setting_title">Povolit výpočet PokéSpamu</string>
-    <string name="PokeSpam_setting_summary">Umožňuje načítání počtu candy a výpočet množství Pokémonů, které můžeš vyvinout, užitečné s lucky eggem</string>
+    <string name="pokespam_setting_title">Povolit výpočet PokéSpamu</string>
+    <string name="pokespam_setting_summary">Umožňuje načítání počtu candy a výpočet množství Pokémonů, které můžeš vyvinout, užitečné s lucky eggem</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -131,6 +131,6 @@
     <string name="pokespam_formatted_message">%1$d (%2$d lignes + %3$d)</string>
     <string name="candy">Bonbons</string>
     <string name="pokespam_not_available">Indisponible</string>
-    <string name="PokeSpam_setting_title">Activer le calcul de PokéSpam</string>
-    <string name="PokeSpam_setting_summary">Scanne le nombre de bonbons pour calculer combien de Pokémon vous pouvez faire évoluer ; utile pour prévoir quand utiliser un œuf chance</string>
+    <string name="pokespam_setting_title">Activer le calcul de PokéSpam</string>
+    <string name="pokespam_setting_summary">Scanne le nombre de bonbons pour calculer combien de Pokémon vous pouvez faire évoluer ; utile pour prévoir quand utiliser un œuf chance</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,6 +134,6 @@
     <string name="pokespam_formatted_message">%1$d (%2$d rows + %3$d more)</string>
     <string name="candy">Candy</string>
     <string name="pokespam_not_available">Not Available</string>
-    <string name="PokeSpam_setting_title">Enable PokéSpam Calculation</string>
-    <string name="PokeSpam_setting_summary">This feature enables scanning for candy amount and allows you to see how many Pokémon you can evolve, useful for use with lucky egg</string>
+    <string name="pokespam_setting_title">Enable PokéSpam Calculation</string>
+    <string name="pokespam_setting_summary">This feature enables scanning for candy amount and allows you to see how many Pokémon you can evolve, useful for use with lucky egg</string>
 </resources>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -46,8 +46,8 @@
 
     <SwitchPreference
         android:key="pokeSpamEnabled"
-        android:title="@string/PokeSpam_setting_title"
-        android:summary="@string/PokeSpam_setting_summary"
+        android:title="@string/pokespam_setting_title"
+        android:summary="@string/pokespam_setting_summary"
         android:defaultValue="true"/>
 
     <Preference


### PR DESCRIPTION
Renamed PokeSpam strings, Fixes https://github.com/farkam135/GoIV/issues/496.

By the way, speaking of Pokéspam I came up with the name when designing that feature so it will fit that little box. For now its doesn't live exist outside of GoIV, but soon the world!!! [Google Search...](https://www.google.com/webhp?sourceid=chrome-instant&ion=1&espv=2&ie=UTF-8#q=Pok%C3%A9spam)