### PR TITLE
Encapsulate screen info (from metrics and trainer level)

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -155,8 +155,6 @@ public class MainActivity extends AppCompatActivity {
         npTrainerLevel.setWrapSelectorWheel(false);
         npTrainerLevel.setValue(trainerLevel);
 
-        ScreenInfo.init(MainActivity.this);
-
         launchButton = (Button) findViewById(R.id.start);
         launchButton.setOnClickListener(new View.OnClickListener() {
 
@@ -177,6 +175,8 @@ public class MainActivity extends AppCompatActivity {
                 } else if (!Pokefly.isRunning()) {
                     batterySaver = settings.isManualScreenshotModeEnabled();
                     trainerLevel = setupTrainerLevel(npTrainerLevel);
+
+                    ScreenInfo.init(MainActivity.this);
 
                     Data.setupArcPoints(ScreenInfo.getInstance(), trainerLevel);
 

--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -37,7 +37,6 @@ import android.widget.Spinner;
 import android.widget.TextView;
 
 import com.kamron.pogoiv.clipboard.ClipboardModifierActivity;
-import com.kamron.pogoiv.logic.Data;
 import com.kamron.pogoiv.updater.AppUpdate;
 import com.kamron.pogoiv.updater.AppUpdateUtil;
 import com.kamron.pogoiv.updater.DownloadUpdateService;
@@ -177,8 +176,7 @@ public class MainActivity extends AppCompatActivity {
                     trainerLevel = setupTrainerLevel(npTrainerLevel);
 
                     ScreenInfo.init(MainActivity.this);
-
-                    Data.setupArcPoints(ScreenInfo.getInstance(), trainerLevel);
+                    ScreenInfo.getInstance().setupArcPoints(trainerLevel);
 
                     if (batterySaver) {
                         startPokeFly();
@@ -204,6 +202,7 @@ public class MainActivity extends AppCompatActivity {
 
     /**
      * Method that navigates the user to the custom clipboard builder activity.
+     *
      * @param v Param required for the xml onclick to work.
      */
     public void navigateToClipboardModifier(View v) {

--- a/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
@@ -2,6 +2,7 @@ package com.kamron.pogoiv;
 
 import android.graphics.Bitmap;
 import android.graphics.Color;
+import android.graphics.Point;
 import android.support.annotation.NonNull;
 import android.util.LruCache;
 
@@ -143,9 +144,8 @@ public class OcrHelper {
         double estimatedPokemonLevel = Data.trainerLevelToMaxPokeLevel(trainerLevel);
         for (double estPokemonLevel = estimatedPokemonLevel; estPokemonLevel >= 1.0; estPokemonLevel -= 0.5) {
             int index = Data.levelToLevelIdx(estPokemonLevel);
-            int x = Data.arcX[index];
-            int y = Data.arcY[index];
-            if (pokemonImage.getPixel(x, y) == Color.rgb(255, 255, 255)) {
+            Point point = ScreenInfo.getInstance().getArcPoint(index);
+            if (pokemonImage.getPixel(point.x, point.y) == Color.rgb(255, 255, 255)) {
                 return estPokemonLevel;
             }
         }

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -632,8 +632,9 @@ public class Pokefly extends Service {
      */
     private void setArcPointer(double pokeLevel) {
         int index = Data.levelToLevelIdx(pokeLevel);
-        arcParams.x = Data.arcX[index] - pointerWidth;
-        arcParams.y = Data.arcY[index] - pointerHeight - statusBarHeight;
+        Point point = ScreenInfo.getInstance().getArcPoint(index);
+        arcParams.x = point.x - pointerWidth;
+        arcParams.y = point.y - pointerHeight - statusBarHeight;
         //That is, (int) (arcCenter + (radius * Math.cos(angleInRadians))) and
         //(int) (arcInitialY + (radius * Math.sin(angleInRadians))).
         windowManager.updateViewLayout(arcPointer, arcParams);

--- a/app/src/main/java/com/kamron/pogoiv/ScreenGrabber.java
+++ b/app/src/main/java/com/kamron/pogoiv/ScreenGrabber.java
@@ -33,9 +33,9 @@ public class ScreenGrabber {
     private VirtualDisplay virtualDisplay;
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    private ScreenGrabber(MediaProjection mediaProjection, DisplayMetrics raw, DisplayMetrics display) {
-        rawDisplayMetrics = raw;
-        displayMetrics = display;
+    private ScreenGrabber(MediaProjection mediaProjection, ScreenInfo screenInfo) {
+        rawDisplayMetrics = screenInfo.getRawDisplayMetrics();
+        displayMetrics = screenInfo.getDisplayMetrics();
         projection = mediaProjection;
         imageReader = ImageReader.newInstance(rawDisplayMetrics.widthPixels, rawDisplayMetrics.heightPixels,
                 PixelFormat.RGBA_8888, 2);
@@ -45,9 +45,9 @@ public class ScreenGrabber {
                 null, null);
     }
 
-    public static ScreenGrabber init(MediaProjection mediaProjection, DisplayMetrics raw, DisplayMetrics display) {
+    public static ScreenGrabber init(MediaProjection mediaProjection, ScreenInfo screenInfo) {
         if (instance == null) {
-            instance = new ScreenGrabber(mediaProjection, raw, display);
+            instance = new ScreenGrabber(mediaProjection, screenInfo);
         }
         return instance;
     }

--- a/app/src/main/java/com/kamron/pogoiv/ScreenInfo.java
+++ b/app/src/main/java/com/kamron/pogoiv/ScreenInfo.java
@@ -1,0 +1,63 @@
+package com.kamron.pogoiv;
+
+import android.app.Activity;
+import android.content.Context;
+import android.graphics.Point;
+import android.util.DisplayMetrics;
+import android.view.Display;
+import android.view.WindowManager;
+
+import lombok.Getter;
+
+/**
+ * Created by pgiarrusso on 1/10/2016.
+ */
+
+public class ScreenInfo {
+    @Getter
+    private final Point arcInit = new Point();
+    @Getter
+    private int arcRadius;
+    @Getter
+    private final DisplayMetrics displayMetrics;
+    @Getter
+    private final DisplayMetrics rawDisplayMetrics;
+
+    private static ScreenInfo singletonInstance;
+
+    public static void init(Activity ctx) {
+        singletonInstance = new ScreenInfo(ctx);
+    }
+
+    public static ScreenInfo getInstance() {
+        return singletonInstance;
+    }
+
+    private ScreenInfo(Activity ctx) {
+        this.displayMetrics = ctx.getResources().getDisplayMetrics();
+
+        WindowManager windowManager = (WindowManager) ctx.getSystemService(Context.WINDOW_SERVICE);
+        this.rawDisplayMetrics = new DisplayMetrics();
+        Display disp = windowManager.getDefaultDisplay();
+        disp.getRealMetrics(rawDisplayMetrics);
+
+        setupDisplaySizeInfo(displayMetrics);
+    }
+
+    private void setupDisplaySizeInfo(DisplayMetrics displayMetrics) {
+        arcInit.x = (int) (displayMetrics.widthPixels * 0.5);
+
+        arcInit.y = (int) Math.floor(displayMetrics.heightPixels / 2.803943);
+        if (displayMetrics.heightPixels == 2392 || displayMetrics.heightPixels == 800) {
+            arcInit.y--;
+        } else if (displayMetrics.heightPixels == 1920) {
+            arcInit.y++;
+        }
+
+        arcRadius = (int) Math.round(displayMetrics.heightPixels / 4.3760683);
+        if (displayMetrics.heightPixels == 1776 || displayMetrics.heightPixels == 960
+                || displayMetrics.heightPixels == 800) {
+            arcRadius++;
+        }
+    }
+}

--- a/app/src/main/java/com/kamron/pogoiv/ScreenInfo.java
+++ b/app/src/main/java/com/kamron/pogoiv/ScreenInfo.java
@@ -16,6 +16,9 @@ import lombok.Getter;
  */
 
 public class ScreenInfo {
+    private int[] arcX;
+    private int[] arcY;
+
     @Getter
     private final Point arcInit = new Point();
     @Getter
@@ -57,8 +60,8 @@ public class ScreenInfo {
          * the level can be used to index CpM, arcX and arcY.
          */
         int maxPokeLevelIdx = Data.trainerLevelToMaxPokeLevelIdx(trainerLevel);
-        Data.arcX = new int[maxPokeLevelIdx + 1]; //We access entries [0..maxPokeLevelIdx], hence + 1.
-        Data.arcY = new int[maxPokeLevelIdx + 1];
+        arcX = new int[maxPokeLevelIdx + 1]; //We access entries [0..maxPokeLevelIdx], hence + 1.
+        arcY = new int[maxPokeLevelIdx + 1];
 
         double baseCpM = Data.getLevelIdxCpM(0);
         //TODO: debug this formula when we get to the end of CpM (that is, levels 39/40).
@@ -70,8 +73,8 @@ public class ScreenInfo {
             double arcRatio = pokeCurrCpMDelta / maxPokeCpMDelta;
             double angleInRadians = (arcRatio + 1) * Math.PI;
 
-            Data.arcX[pokeLevelIdx] = (int) (arcInit.x + (arcRadius * Math.cos(angleInRadians)));
-            Data.arcY[pokeLevelIdx] = (int) (arcInit.y + (arcRadius * Math.sin(angleInRadians)));
+            arcX[pokeLevelIdx] = (int) (arcInit.x + (arcRadius * Math.cos(angleInRadians)));
+            arcY[pokeLevelIdx] = (int) (arcInit.y + (arcRadius * Math.sin(angleInRadians)));
         }
     }
 
@@ -90,5 +93,9 @@ public class ScreenInfo {
                 || displayMetrics.heightPixels == 800) {
             arcRadius++;
         }
+    }
+
+    public Point getArcPoint(int levelIdx) {
+        return new Point(arcX[levelIdx], arcY[levelIdx]);
     }
 }

--- a/app/src/main/java/com/kamron/pogoiv/ScreenInfo.java
+++ b/app/src/main/java/com/kamron/pogoiv/ScreenInfo.java
@@ -7,6 +7,8 @@ import android.util.DisplayMetrics;
 import android.view.Display;
 import android.view.WindowManager;
 
+import com.kamron.pogoiv.logic.Data;
+
 import lombok.Getter;
 
 /**
@@ -42,6 +44,35 @@ public class ScreenInfo {
         disp.getRealMetrics(rawDisplayMetrics);
 
         setupDisplaySizeInfo(displayMetrics);
+    }
+
+    /**
+     * setupArcPoints
+     * Sets up the x,y coordinates of the arc using the trainer level, stores it in Data.arcX/arcY
+     */
+    public void setupArcPoints(int trainerLevel) {
+        /*
+         * Pokemon levels go from 1 to trainerLevel + 1.5, in increments of 0.5.
+         * Here we use levelIdx for levels that are doubled and shifted by - 2; after this adjustment,
+         * the level can be used to index CpM, arcX and arcY.
+         */
+        int maxPokeLevelIdx = Data.trainerLevelToMaxPokeLevelIdx(trainerLevel);
+        Data.arcX = new int[maxPokeLevelIdx + 1]; //We access entries [0..maxPokeLevelIdx], hence + 1.
+        Data.arcY = new int[maxPokeLevelIdx + 1];
+
+        double baseCpM = Data.getLevelIdxCpM(0);
+        //TODO: debug this formula when we get to the end of CpM (that is, levels 39/40).
+        double maxPokeCpMDelta = Data.getLevelIdxCpM(Math.min(maxPokeLevelIdx + 1, Data.getCpMLength() - 1)) - baseCpM;
+
+        //pokeLevelIdx <= maxPokeLevelIdx ensures we never overflow CpM/arc/arcY.
+        for (int pokeLevelIdx = 0; pokeLevelIdx <= maxPokeLevelIdx; pokeLevelIdx++) {
+            double pokeCurrCpMDelta = Data.getLevelIdxCpM(pokeLevelIdx) - baseCpM;
+            double arcRatio = pokeCurrCpMDelta / maxPokeCpMDelta;
+            double angleInRadians = (arcRatio + 1) * Math.PI;
+
+            Data.arcX[pokeLevelIdx] = (int) (arcInit.x + (arcRadius * Math.cos(angleInRadians)));
+            Data.arcY[pokeLevelIdx] = (int) (arcInit.y + (arcRadius * Math.sin(angleInRadians)));
+        }
     }
 
     private void setupDisplaySizeInfo(DisplayMetrics displayMetrics) {

--- a/app/src/main/java/com/kamron/pogoiv/logic/Data.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/Data.java
@@ -2,6 +2,8 @@ package com.kamron.pogoiv.logic;
 
 import android.graphics.Point;
 
+import com.kamron.pogoiv.ScreenInfo;
+
 /**
  * Created by Pascal on 17.08.2016.
  */
@@ -32,7 +34,9 @@ public class Data {
      * setupArcPoints
      * Sets up the x,y coordinates of the arc using the trainer level, stores it in Data.arcX/arcY
      */
-    public static void setupArcPoints(Point arcInit, int arcRadius, int trainerLevel) {
+    public static void setupArcPoints(ScreenInfo screenInfo, int trainerLevel) {
+        Point arcInit = screenInfo.getArcInit();
+        int arcRadius = screenInfo.getArcRadius();
         /*
          * Pokemon levels go from 1 to trainerLevel + 1.5, in increments of 0.5.
          * Here we use levelIdx for levels that are doubled and shifted by - 2; after this adjustment,

--- a/app/src/main/java/com/kamron/pogoiv/logic/Data.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/Data.java
@@ -23,9 +23,6 @@ public class Data {
             0.767397165298462, 0.770297293677362, 0.773186504840851, 0.776064947064992, 0.778932750225067,
             0.781790050767666, 0.784636974334717, 0.787473608513275, 0.790300011634827};
 
-    public static int[] arcX;
-    public static int[] arcY;
-
     /**
      * Convert a pokemon/trainer level to a <em>level index</em> (<code>levelIdx</code> in code).
      * The mapping is invertible, but level indexes can be used to index an array (like Data.CpM), or seekbars.

--- a/app/src/main/java/com/kamron/pogoiv/logic/Data.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/Data.java
@@ -1,9 +1,5 @@
 package com.kamron.pogoiv.logic;
 
-import android.graphics.Point;
-
-import com.kamron.pogoiv.ScreenInfo;
-
 /**
  * Created by Pascal on 17.08.2016.
  */
@@ -29,37 +25,6 @@ public class Data {
 
     public static int[] arcX;
     public static int[] arcY;
-
-    /**
-     * setupArcPoints
-     * Sets up the x,y coordinates of the arc using the trainer level, stores it in Data.arcX/arcY
-     */
-    public static void setupArcPoints(ScreenInfo screenInfo, int trainerLevel) {
-        Point arcInit = screenInfo.getArcInit();
-        int arcRadius = screenInfo.getArcRadius();
-        /*
-         * Pokemon levels go from 1 to trainerLevel + 1.5, in increments of 0.5.
-         * Here we use levelIdx for levels that are doubled and shifted by - 2; after this adjustment,
-         * the level can be used to index CpM, arcX and arcY.
-         */
-        int maxPokeLevelIdx = trainerLevelToMaxPokeLevelIdx(trainerLevel);
-        arcX = new int[maxPokeLevelIdx + 1]; //We access entries [0..maxPokeLevelIdx], hence + 1.
-        arcY = new int[maxPokeLevelIdx + 1];
-
-        double baseCpM = getLevelIdxCpM(0);
-        //TODO: debug this formula when we get to the end of CpM (that is, levels 39/40).
-        double maxPokeCpMDelta = getLevelIdxCpM(Math.min(maxPokeLevelIdx + 1, getCpMLength() - 1)) - baseCpM;
-
-        //pokeLevelIdx <= maxPokeLevelIdx ensures we never overflow CpM/arc/arcY.
-        for (int pokeLevelIdx = 0; pokeLevelIdx <= maxPokeLevelIdx; pokeLevelIdx++) {
-            double pokeCurrCpMDelta = getLevelIdxCpM(pokeLevelIdx) - baseCpM;
-            double arcRatio = pokeCurrCpMDelta / maxPokeCpMDelta;
-            double angleInRadians = (arcRatio + 1) * Math.PI;
-
-            arcX[pokeLevelIdx] = (int) (arcInit.x + (arcRadius * Math.cos(angleInRadians)));
-            arcY[pokeLevelIdx] = (int) (arcInit.y + (arcRadius * Math.sin(angleInRadians)));
-        }
-    }
 
     /**
      * Convert a pokemon/trainer level to a <em>level index</em> (<code>levelIdx</code> in code).

--- a/app/src/main/java/com/kamron/pogoiv/logic/Data.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/Data.java
@@ -46,13 +46,13 @@ public class Data {
         arcX = new int[maxPokeLevelIdx + 1]; //We access entries [0..maxPokeLevelIdx], hence + 1.
         arcY = new int[maxPokeLevelIdx + 1];
 
-        double baseCpM = CpM[0];
+        double baseCpM = getLevelIdxCpM(0);
         //TODO: debug this formula when we get to the end of CpM (that is, levels 39/40).
-        double maxPokeCpMDelta = CpM[Math.min(maxPokeLevelIdx + 1, CpM.length - 1)] - baseCpM;
+        double maxPokeCpMDelta = getLevelIdxCpM(Math.min(maxPokeLevelIdx + 1, getCpMLength() - 1)) - baseCpM;
 
         //pokeLevelIdx <= maxPokeLevelIdx ensures we never overflow CpM/arc/arcY.
         for (int pokeLevelIdx = 0; pokeLevelIdx <= maxPokeLevelIdx; pokeLevelIdx++) {
-            double pokeCurrCpMDelta = CpM[pokeLevelIdx] - baseCpM;
+            double pokeCurrCpMDelta = getLevelIdxCpM(pokeLevelIdx) - baseCpM;
             double arcRatio = pokeCurrCpMDelta / maxPokeCpMDelta;
             double angleInRadians = (arcRatio + 1) * Math.PI;
 
@@ -90,7 +90,15 @@ public class Data {
      * @return Associated CpM.
      */
     public static double getLevelCpM(double level) {
-        return CpM[levelToLevelIdx(level)];
+        return getLevelIdxCpM(levelToLevelIdx(level));
+    }
+
+    public static double getLevelIdxCpM(int levelIdx) {
+        return CpM[levelIdx];
+    }
+
+    public static int getCpMLength() {
+        return CpM.length;
     }
 
     /**


### PR DESCRIPTION
Two reasons:
- this is tricky logic
- some features might require different screen info (e.g. scanning screenshots from other phones)
- some features might require different trainer level.

But there are still other places using screen dimensions, in ScreenGrabber and in Pokefly. I'm not sure they should be changed though, since at least ScreenGrabber really needs the dimensions from the current screen.
