### PR TITLE
Avoid using toString in lookup

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1064,8 +1064,8 @@ public class Pokefly extends Service {
         //below picks a pokemon from either the pokemon spinner or the user text input
         Pokemon pokemon;
         if (pokeInputSpinner.getVisibility() == View.VISIBLE) { //user picked pokemon from spinner
-            String selectedPokemon = pokeInputSpinner.getSelectedItem().toString();
-            pokemon = pokeInfoCalculator.get(selectedPokemon);
+            //This could be pokemon = pokeInputSpinner.getSelectedItem(); if they didn't give it type Object.
+            pokemon = pokeInputSpinnerAdapter.getItem(pokeInputSpinner.getSelectedItemPosition());
         } else { //user typed manually
             String userInput = autoCompleteTextView1.getText().toString();
             pokemon = pokeInfoCalculator.get(userInput);


### PR DESCRIPTION
`Pokemon.toString()` should just have a cosmetic function (I proposed
changing it in #503). And there's no need for a lookup. The problem is
only that `getSelectedItem` is declared to return `Object` when in fact
it returns `Pokemon` (part of the involved classes have not been
generified yet).

Testing ongoing.