### PR TITLE
Fix crash when no external storage is available

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1442,7 +1442,11 @@ public class Pokefly extends Service {
     }
 
     private void initOcr() {
-        String extdir = getExternalFilesDir(null).toString();
+        File externalFilesDir = getExternalFilesDir(null);
+        if (externalFilesDir == null) {
+            externalFilesDir = getFilesDir();
+        }
+        String extdir = externalFilesDir.toString();
         if (!new File(extdir + "/tessdata/eng.traineddata").exists()) {
             CopyUtils.copyAssetFolder(getAssets(), "tessdata", extdir + "/tessdata");
         }


### PR DESCRIPTION
Close http://crashes.to/s/c99c9d8a9c5. But this might lead to duplicated
assets if the external folder becomes unavailable.

This is a new PR for #421 — I closed that accidentally when I moved the branch to my fork—consider this an issue, we're still not sure this is the correct approach.
