### PR TITLE
Re-enable user corrections for eeveelutions

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1154,6 +1154,11 @@ public class Pokefly extends Service {
         }
     }
 
+    /**
+     * Saves the pokemon nickname relation to picked pokemon, and saves it to sharedPref settings.
+     * @param ocredPokemonName The scanned nickname
+     * @param correctedPokemonName The pokemon to connect with the nickname
+     */
     private void putCorrection(String ocredPokemonName, String correctedPokemonName) {
         corrector.putCorrection(ocredPokemonName, correctedPokemonName);
         SharedPreferences.Editor edit = sharedPref.edit();

--- a/app/src/main/java/com/kamron/pogoiv/logic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/PokemonNameCorrector.java
@@ -71,17 +71,23 @@ public class PokemonNameCorrector {
         }
 
         //3. check if there's a cached guess for the hash of the bitmap of the nickname
+        //TODO
+        // Cacheguess and userCorrections are two different caches, one checks for the bitmap cache, one
+        // checks for the scanned string cache, however the bitmap cache does not seem to save properly - I'm
+        // disabling this module until it's been fixed. - Though we could maybe remove this guessing module altogether.
+        /*
         if (guess.pokemon == null) {
             PokeDist cacheGuess = cachedCorrections.get(poketext);
             if (cacheGuess != null) {
-                return cacheGuess;
+                guess =  new PokeDist(cacheGuess.pokemon, cacheGuess.dist);
             }
-        }
+        }*/
 
         //4.  If the user previous corrected this text, go with that.
         if (guess.pokemon == null) {
             if (userCorrections.containsKey(poketext)) {
                 poketext = userCorrections.get(poketext);
+                guess = new PokeDist(pokeInfoCalculator.get(poketext), 20);
             }
         }
         //5. All else failed: make a wild guess based only on closest name match
@@ -114,12 +120,17 @@ public class PokemonNameCorrector {
     private Pokemon getCandyNameEvolutionCostGuess(ArrayList<Pokemon> bestGuessEvolutionLine,
                                                    Optional<Integer> evolutionCost) {
         if (evolutionCost.isPresent()) {
+            if (bestGuessEvolutionLine.get(0).evolutions.size() > 1 && evolutionCost.get() == -1){
+                return null; //found multiple possible evolutions, dont know which one is the real answer
+            }
+
             for (Pokemon pokemon : bestGuessEvolutionLine) {
                 if (pokemon.candyEvolutionCost == evolutionCost.get()) {
                     return pokemon;
                 }
             }
         }
+
 
         //evolution cost scan failed, or no match
         return null;

--- a/app/src/main/java/com/kamron/pogoiv/logic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/PokemonNameCorrector.java
@@ -23,6 +23,9 @@ public class PokemonNameCorrector {
         this.pokeInfoCalculator = pokeInfoCalculator;
         userCorrections = new HashMap<>(pokeInfoCalculator.getPokedex().size());
         userCorrections.putAll(storedUserCorrections);
+        userCorrections.put("Sparky", pokeInfoCalculator.get(132).name);
+        userCorrections.put("Rainer", pokeInfoCalculator.get(132).name);
+        userCorrections.put("Pyro", pokeInfoCalculator.get(132).name);
     }
 
     /**

--- a/app/src/main/java/com/kamron/pogoiv/logic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/PokemonNameCorrector.java
@@ -120,7 +120,7 @@ public class PokemonNameCorrector {
     private Pokemon getCandyNameEvolutionCostGuess(ArrayList<Pokemon> bestGuessEvolutionLine,
                                                    Optional<Integer> evolutionCost) {
         if (evolutionCost.isPresent()) {
-            if (bestGuessEvolutionLine.get(0).evolutions.size() > 1 && evolutionCost.get() == -1){
+            if (bestGuessEvolutionLine.get(0).evolutions.size() > 1 && evolutionCost.get() == -1) {
                 return null; //found multiple possible evolutions, dont know which one is the real answer
             }
 

--- a/app/src/main/java/com/kamron/pogoiv/logic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/PokemonNameCorrector.java
@@ -1,6 +1,5 @@
 package com.kamron.pogoiv.logic;
 
-import android.util.LruCache;
 
 import com.google.common.base.Optional;
 
@@ -19,19 +18,19 @@ import lombok.AllArgsConstructor;
 public class PokemonNameCorrector {
     private final PokeInfoCalculator pokeInfoCalculator;
     private final HashMap<String, String> userCorrections;
-    /* We don't want memory usage to get out of hand for stuff that can be computed. */
-    private final LruCache<String, PokeDist> cachedCorrections;
 
     public PokemonNameCorrector(PokeInfoCalculator pokeInfoCalculator, Map<String, String> storedUserCorrections) {
         this.pokeInfoCalculator = pokeInfoCalculator;
         userCorrections = new HashMap<>(pokeInfoCalculator.getPokedex().size());
         userCorrections.putAll(storedUserCorrections);
-        userCorrections.put("Sparky", pokeInfoCalculator.get(132).name);
-        userCorrections.put("Rainer", pokeInfoCalculator.get(132).name);
-        userCorrections.put("Pyro", pokeInfoCalculator.get(132).name);
-        cachedCorrections = new LruCache<>(pokeInfoCalculator.getPokedex().size() * 2);
     }
 
+    /**
+     * Saves the pokemon nickname relation to picked pokemon.
+     *
+     * @param ocredPokemonName     The scanned nickname
+     * @param correctedPokemonName The pokemon to connect with the nickname
+     */
     public void putCorrection(String ocredPokemonName, String correctedPokemonName) {
         /* TODO: Should we set a size limit on that and throw away LRU entries? */
         userCorrections.put(ocredPokemonName, correctedPokemonName);
@@ -41,9 +40,8 @@ public class PokemonNameCorrector {
      * Gets the best matching pokemon that can be found given the input, by doing the following:
      * 1. check if the nickname perfectly matches a pokemon
      * 2. check if candyname + evolution cost perfectly matches a pokemon
-     * 3. check if there's a cached result for the nickname bitmap hash
-     * 4. check if there's a stored user correction for the scanned pokemon name
-     * 5. get the pokemon with the closest name within the evolution line guessed from the candy
+     * 3. check if there's a stored user correction for the scanned pokemon name
+     * 4. get the pokemon with the closest name within the evolution line guessed from the candy
      * <p>
      * The order is decided by having high reliability guessing modules run first, and if they cant find an answer,
      * fall back to less accurate methods.
@@ -55,8 +53,7 @@ public class PokemonNameCorrector {
      */
     public PokeDist getPossiblePokemon(String poketext, String candytext, Optional<Integer> candyUpgradeCost) {
         ArrayList<Pokemon> bestGuessEvolutionLine = getBestGuessForEvolutionLine(candytext);
-        PokeDist guess = null;
-        //Warning: Don't forget to call cacheResult before exiting. Preferably keep a single return point.
+        PokeDist guess;
 
         //1. Check if nickname perfectly matches a pokemon (which means pokemon is probably not renamed)
         guess = new PokeDist(pokeInfoCalculator.get(poketext), 0);
@@ -70,43 +67,20 @@ public class PokemonNameCorrector {
             }
         }
 
-        //3. check if there's a cached guess for the hash of the bitmap of the nickname
-        //TODO
-        // Cacheguess and userCorrections are two different caches, one checks for the bitmap cache, one
-        // checks for the scanned string cache, however the bitmap cache does not seem to save properly - I'm
-        // disabling this module until it's been fixed. - Though we could maybe remove this guessing module altogether.
-        /*
-        if (guess.pokemon == null) {
-            PokeDist cacheGuess = cachedCorrections.get(poketext);
-            if (cacheGuess != null) {
-                guess =  new PokeDist(cacheGuess.pokemon, cacheGuess.dist);
-            }
-        }*/
-
-        //4.  If the user previous corrected this text, go with that.
+        //3.  If the user previous corrected this text, go with that.
         if (guess.pokemon == null) {
             if (userCorrections.containsKey(poketext)) {
                 poketext = userCorrections.get(poketext);
                 guess = new PokeDist(pokeInfoCalculator.get(poketext), 20);
             }
         }
-        //5. All else failed: make a wild guess based only on closest name match
+        //4. All else failed: make a wild guess based only on closest name match
         if (guess.pokemon == null) {
             guess = getNicknameGuess(poketext, pokeInfoCalculator.getPokedex());
         }
-        cacheResult(poketext, guess);
         return guess;
     }
 
-    /**
-     * Cache a result.
-     *
-     * @param poketext   the text to put in the cache as the scanned nickname
-     * @param cacheValue the value for the pokemon and the distance (how much we estimated)
-     */
-    private void cacheResult(String poketext, PokeDist cacheValue) {
-        cachedCorrections.put(poketext, cacheValue);
-    }
 
     /**
      * A method which returns if there's a pokemon which matches the candy name & evolution cost. This method will
@@ -159,7 +133,21 @@ public class PokemonNameCorrector {
     }
 
     /**
-     * A class representing a result of pokemon search.
+     * Get the evolution line which closest matches the string. The string is supposed to be the base evolution of a
+     * line.
+     *
+     * @param input the base evolution (ex weedle) to find a match for
+     * @return an evolution line which the string best matches the base evolution pokemon name
+     */
+    private ArrayList<Pokemon> getBestGuessForEvolutionLine(String input) {
+        //candy name will only ever match the base evolution, so search in getBasePokemons().
+        PokeDist bestMatch = getNicknameGuess(input, pokeInfoCalculator.getBasePokemons());
+        return pokeInfoCalculator.getEvolutionLine(bestMatch.pokemon);
+    }
+
+    /**
+     * A class representing a result of pokemon search. A higher distance means the result was more uncertain. This
+     * is used to colorize the background for the guessed pokemon in the overlay input screen.
      */
     @AllArgsConstructor
     public static class PokeDist {
@@ -173,18 +161,5 @@ public class PokemonNameCorrector {
          * Since it's a distance, the smaller it is the closer is the match.
          */
         public final int dist;
-    }
-
-    /**
-     * Get the evolution line which closest matches the string. The string is supposed to be the base evolution of a
-     * line.
-     *
-     * @param input the base evolution (ex weedle) to find a match for
-     * @return an evolution line which the string best matches the base evolution pokemon name
-     */
-    private ArrayList<Pokemon> getBestGuessForEvolutionLine(String input) {
-        //candy name will only ever match the base evolution, so search in getBasePokemons().
-        PokeDist bestMatch = getNicknameGuess(input, pokeInfoCalculator.getBasePokemons());
-        return pokeInfoCalculator.getEvolutionLine(bestMatch.pokemon);
     }
 }


### PR DESCRIPTION
Edited description:

The identification method which uses evolution cost and candy name now returns that it's unsure of the pokemon if it detects that the evolution line branches. (This currently only happens for eevee.) Because of this, is continues testing other guessing methods, and these guessing methods take user corrections into account.

edit: fixes #518 