### PR TITLE
Reverts change to how scanned cp text is parsed

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
@@ -453,6 +453,12 @@ public class OcrHelper {
         tesseract.setImage(cp);
         String cpText = tesseract.getUTF8Text();
 
+        /*
+         * Always remove the two first characters instead of non-numbers: the "CP" text is 
+         * sometimes OCR'ed to something containing numbers (e.g. cp, cP, Cp, c3, s3, 73, 53 etc),
+         * depending on backgrounds/screen sizes, but it's always OCRed as two characters.
+         * This also appears true for translations.
+         */
         if (cpText.length() >= 2) { //gastly can block the "cp" text, so its not visible...
             cpText = cpText.substring(2); //remove "cp".
         }

--- a/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
@@ -451,8 +451,11 @@ public class OcrHelper {
                 (int) Math.round(heightPixels / 21.333333333));
         cp = replaceColors(cp, true, 255, 255, 255, Color.BLACK, 30, false);
         tesseract.setImage(cp);
-        String cpText = fixOcrLettersToNums(tesseract.getUTF8Text());
-        cp.recycle();
+        String cpText = tesseract.getUTF8Text();
+
+        if (cpText.length() >= 2) { //gastly can block the "cp" text, so its not visible...
+            cpText = cpText.substring(2); //remove "cp".
+        }
 
         try {
             return Optional.of(Integer.parseInt(cpText));

--- a/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
@@ -458,7 +458,7 @@ public class OcrHelper {
         }
 
         try {
-            return Optional.of(Integer.parseInt(cpText));
+            return Optional.of(Integer.parseInt(fixOcrLettersToNums(cpText)));
         } catch (NumberFormatException e) {
             return Optional.absent();
         }


### PR DESCRIPTION
This implementation assumes that the tesseract manages to scan "cp" or
"7p" or something similar, which is at least always two characters.

The reverted implementation removed all non-numerical characters, which
did not always work as sometimes "cp" was scanned as "c9" or similar.