### PR TITLE
Removes hardcoded "user" corrections

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/logic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/PokemonNameCorrector.java
@@ -23,9 +23,6 @@ public class PokemonNameCorrector {
         this.pokeInfoCalculator = pokeInfoCalculator;
         userCorrections = new HashMap<>(pokeInfoCalculator.getPokedex().size());
         userCorrections.putAll(storedUserCorrections);
-        userCorrections.put("Sparky", pokeInfoCalculator.get(132).name);
-        userCorrections.put("Rainer", pokeInfoCalculator.get(132).name);
-        userCorrections.put("Pyro", pokeInfoCalculator.get(132).name);
     }
 
     /**


### PR DESCRIPTION
I dont think these hardcoded suggestions help the users more than they can potentially annoy users, now with the new identification module.


They're initiated every new restart of goiv
They assume that rainer, pyro and sparky are eevees, not vaporeon, flaroeon and jolteon.