### PR TITLE
Fixes #463 Crash when scanning screenshot from another device.

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1822,6 +1822,14 @@ public class Pokefly extends Service {
             } else {
                 screenShotPath = Optional.absent();
             }
+
+            // this should allow processing of images where the displaymetrics don't match, for example a different
+            // phone, it is known that the red dot might not display correctly.
+            if (displayMetrics.heightPixels != bitmap.getHeight() || displayMetrics.widthPixels != bitmap.getWidth()) {
+                bitmap = Bitmap.createScaledBitmap(bitmap, displayMetrics.widthPixels, displayMetrics.heightPixels,
+                        true);
+            }
+
             scanPokemon(bitmap, screenShotPath);
             bitmap.recycle();
         }


### PR DESCRIPTION
Hi Team,
below is a check for GOIV screenshot, I was able to scan images from iphone.

code:

```
// this should allow processing of images where the displaymetrics don't match, for example a different
// phone, it is known that the red dot might not display correctly.
if (displayMetrics.heightPixels != bitmap.getHeight() || displayMetrics.widthPixels != bitmap.getWidth()) {
     bitmap = Bitmap.createScaledBitmap(bitmap, displayMetrics.widthPixels, displayMetrics.heightPixels,
              false);
}
```

Known issues:
Red dot location MIGHT be off if the image height is different
since red dot is based on the screen, and since the photo display software (andorid photos etc.) probably stretches the display to fill width of the screen that red dot might be located elsewhere especially if height of the screen is significantly different (see https://github.com/farkam135/GoIV/issues/463#issuecomment-250882817 for example), most of the time the height will be the same and the red dot will work. It might be easier to recalculate the metric's when https://github.com/farkam135/GoIV/pull/499 is complete.
