### PR TITLE
Better notification Start, settings and +1 level  in notification bar

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -146,6 +146,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
         Timber.tag(TAG);
 
         settings = GoIVSettings.getInstance(this);
@@ -231,6 +232,8 @@ public class MainActivity extends AppCompatActivity {
         LocalBroadcastManager.getInstance(this).registerReceiver(clickOnStopStart,
                 new IntentFilter(ACTION_CLICK_ON_BUTTON));
         initiateTeamPickerSpinner();
+
+        runActionOnIntent(getIntent());
     }
 
     /**
@@ -442,16 +445,24 @@ public class MainActivity extends AppCompatActivity {
     }
 
     /**
-     * Handles custom action intents probably from notification.
+     * We will get custom intents from notifications.
      */
     @Override
-    public void onNewIntent(Intent intent) {
+    protected final void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
+        runActionOnIntent(intent);
+    }
 
-        if (ACTION_CLICK_ON_BUTTON.equals(intent.getAction())) {
-            clickOnStopStart.onReceive(this,intent);
-        }
-        if (ACTION_START_SETTINGS.equals(intent.getAction())) {
+    /**
+     * Handles custom action intents action probably from notification.
+     * @param intent will get send the intent to check the action on.
+     */
+    private void runActionOnIntent(Intent intent) {
+        if (intent == null || intent.getAction() == null ) {
+            return;
+        } else if (ACTION_CLICK_ON_BUTTON.equals(intent.getAction())) {
+            clickOnStopStart.onReceive(this, intent);
+        } else if (ACTION_START_SETTINGS.equals(intent.getAction())) {
             Intent settingsIntent = new Intent(MainActivity.this, SettingsActivity.class);
             startActivity(settingsIntent);
         }

--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -51,6 +51,7 @@ public class MainActivity extends AppCompatActivity {
 
     public static final String ACTION_SHOW_UPDATE_DIALOG = "com.kamron.pogoiv.SHOW_UPDATE_DIALOG";
     public static final String ACTION_CLICK_ON_BUTTON = "com.kamron.pogoiv.ACTION_CLICK_ON_BUTTON";
+    public static final String ACTION_START_SETTINGS = "com.kamron.pogoiv.ACTION_START_SETTINGS";
 
     private static final String TAG = MainActivity.class.getSimpleName();
     private static final int OVERLAY_PERMISSION_REQ_CODE = 1234;
@@ -438,5 +439,21 @@ public class MainActivity extends AppCompatActivity {
         MediaProjectionManager projectionManager = (MediaProjectionManager) getSystemService(
                 Context.MEDIA_PROJECTION_SERVICE);
         startActivityForResult(projectionManager.createScreenCaptureIntent(), SCREEN_CAPTURE_REQ_CODE);
+    }
+
+    /**
+     * Handles custom action intents probably from notification.
+     */
+    @Override
+    public void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+
+        if (ACTION_CLICK_ON_BUTTON.equals(intent.getAction())) {
+            clickOnStopStart.onReceive(this,intent);
+        }
+        if (ACTION_START_SETTINGS.equals(intent.getAction())) {
+            Intent settingsIntent = new Intent(MainActivity.this, SettingsActivity.class);
+            startActivity(settingsIntent);
+        }
     }
 }

--- a/app/src/main/java/com/kamron/pogoiv/NpTrainerLevelPickerListener.java
+++ b/app/src/main/java/com/kamron/pogoiv/NpTrainerLevelPickerListener.java
@@ -6,11 +6,9 @@ import android.os.Handler;
 import android.support.v4.content.LocalBroadcastManager;
 import android.widget.NumberPicker;
 
-import lombok.Getter;
-import lombok.Setter;
-
-
 /**
+ * This handler will handle changes to NpTrainerLevelPickerListener and handles if we restart on complete and if we
+ * skip restarting Pogo.
  * Created by NightMadness on 11/5/2016.
  */
 
@@ -20,8 +18,6 @@ class NpTrainerLevelPickerListener implements NumberPicker.OnScrollListener, Num
     private final int delayTime = 500;
     private Context context;
 
-    @Getter @Setter
-    private boolean restartingOnStop;
 
     public NpTrainerLevelPickerListener(Context context) {
         this.context = context;
@@ -31,9 +27,8 @@ class NpTrainerLevelPickerListener implements NumberPicker.OnScrollListener, Num
         @Override
         public void run() {
             if (Pokefly.isRunning()) {
-                restartingOnStop = true;
                 LocalBroadcastManager.getInstance(context)
-                        .sendBroadcast(new Intent(MainActivity.ACTION_CLICK_ON_BUTTON));
+                        .sendBroadcast(new Intent(MainActivity.ACTION_RESTART_POKEFLY));
             }
         }
     };
@@ -45,12 +40,13 @@ class NpTrainerLevelPickerListener implements NumberPicker.OnScrollListener, Num
             update();
         } else {
             //we are scrolling (or flinging) so we don't need to run update
+            //just in case we had any pending posts in queue.
             handler.removeCallbacks(runnable);
         }
     }
 
     @Override
-    public void onValueChange(NumberPicker picker, int oldVal, int newVal) {
+    public void onValueChange(final NumberPicker picker, final int oldVal, final int newVal) {
         if (scrollState == SCROLL_STATE_IDLE) {
             update();
         }

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -582,24 +582,24 @@ public class Pokefly extends Service {
      * @param isStopping should we make starting or stopping notification
      */
     private void makeNotification(boolean isStopping) {
-        Intent startSettingAppIntent = new Intent(this, MainActivity.class);
-
-        startSettingAppIntent.setAction(MainActivity.ACTION_START_SETTINGS);
-
-        PendingIntent startSettingsPendingIntent = PendingIntent.getActivity(
-                this, 0, startSettingAppIntent, PendingIntent.FLAG_UPDATE_CURRENT);
-
-        NotificationCompat.Action startSettingsAction = new NotificationCompat.Action.Builder(
-                R.drawable.ic_settings_white_24dp,
-                getString(R.string.settings_page_title),
-                startSettingsPendingIntent).build();
-
         Intent openAppIntent = new Intent(this, MainActivity.class);
 
         PendingIntent openAppPendingIntent = PendingIntent.getActivity(
                 this, 0, openAppIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
         if (!isStopping) {
+
+            Intent incrementLevelIntent = new Intent(this, MainActivity.class);
+
+            incrementLevelIntent.setAction(MainActivity.ACTION_INCREMENT_LEVEL);
+
+            PendingIntent incrementLevelPendingIntent = PendingIntent.getActivity(
+                    this, 0, incrementLevelIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+
+            NotificationCompat.Action incrementLevelAction = new NotificationCompat.Action.Builder(
+                    android.R.drawable.ic_input_add,
+                    getString(R.string.increment_level),
+                    incrementLevelPendingIntent).build();
 
             Intent stopServiceIntent = new Intent(this, Pokefly.class);
             stopServiceIntent.setAction(ACTION_STOP);
@@ -619,16 +619,29 @@ public class Pokefly extends Service {
                     .setSmallIcon(R.drawable.notification_icon)
                     .setContentTitle(getString(R.string.notification_title, trainerLevel))
                     .setContentIntent(openAppPendingIntent)
-                    .addAction(startSettingsAction)
+                    .addAction(incrementLevelAction)
                     .addAction(stopServiceAction)
                     .build();
 
             startForeground(NOTIFICATION_REQ_CODE, notification);
             
         } else {
+
+            Intent startSettingAppIntent = new Intent(this, MainActivity.class);
+            startSettingAppIntent.setAction(MainActivity.ACTION_OPEN_SETTINGS);
+
+            PendingIntent startSettingsPendingIntent = PendingIntent.getActivity(
+                    this, 0, startSettingAppIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+
+            NotificationCompat.Action startSettingsAction = new NotificationCompat.Action.Builder(
+                    R.drawable.ic_settings_white_24dp,
+                    getString(R.string.settings_page_title),
+                    startSettingsPendingIntent).build();
+
+
             Intent startAppIntent = new Intent(this, MainActivity.class);
 
-            startAppIntent.setAction(MainActivity.ACTION_CLICK_ON_BUTTON);
+            startAppIntent.setAction(MainActivity.ACTION_START_POKEFLY);
 
             PendingIntent startServicePendingIntent = PendingIntent.getActivity(
                     this, 0, startAppIntent, PendingIntent.FLAG_UPDATE_CURRENT);

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -4,6 +4,7 @@ import android.animation.Animator;
 import android.animation.ObjectAnimator;
 import android.app.Activity;
 import android.app.Notification;
+import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.BroadcastReceiver;
@@ -425,12 +426,16 @@ public class Pokefly extends Service {
         running = true;
 
         if (ACTION_STOP.equals(intent.getAction())) {
+            if (android.os.Build.VERSION.SDK_INT >= 24) {
+                stopForeground(STOP_FOREGROUND_DETACH);
+            }
             stopSelf();
+            makeNotification(true);
         } else if (intent.hasExtra(KEY_TRAINER_LEVEL)) {
             trainerLevel = intent.getIntExtra(KEY_TRAINER_LEVEL, 1);
             statusBarHeight = intent.getIntExtra(KEY_STATUS_BAR_HEIGHT, 0);
             batterySaver = intent.getBooleanExtra(KEY_BATTERY_SAVER, false);
-            makeNotification();
+            makeNotification(false);
             createInfoLayout();
             createIVButton();
             createArcPointer();
@@ -574,41 +579,80 @@ public class Pokefly extends Service {
 
     /**
      * Creates the GoIV notification.
+     * @param isStopping should we make starting or stopping notification
      */
-    private void makeNotification() {
+    private void makeNotification(boolean isStopping) {
+        Intent startSettingAppIntent = new Intent(this, MainActivity.class);
+
+        startSettingAppIntent.setAction(MainActivity.ACTION_START_SETTINGS);
+
+        PendingIntent startSettingsPendingIntent = PendingIntent.getActivity(
+                this, 0, startSettingAppIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+
+        NotificationCompat.Action startSettingsAction = new NotificationCompat.Action.Builder(
+                R.drawable.ic_settings_white_24dp,
+                getString(R.string.settings_page_title),
+                startSettingsPendingIntent).build();
+
         Intent openAppIntent = new Intent(this, MainActivity.class);
 
         PendingIntent openAppPendingIntent = PendingIntent.getActivity(
                 this, 0, openAppIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
-        NotificationCompat.Action openAppAction = new NotificationCompat.Action.Builder(
-                android.R.drawable.ic_menu_more,
-                getString(R.string.notification_open_app),
-                openAppPendingIntent).build();
+        if (!isStopping) {
 
-        Intent stopServiceIntent = new Intent(this, Pokefly.class);
-        stopServiceIntent.setAction(ACTION_STOP);
+            Intent stopServiceIntent = new Intent(this, Pokefly.class);
+            stopServiceIntent.setAction(ACTION_STOP);
 
-        PendingIntent stopServicePendingIntent = PendingIntent.getService(
-                this, 0, stopServiceIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+            PendingIntent stopServicePendingIntent = PendingIntent.getService(
+                    this, 0, stopServiceIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
-        NotificationCompat.Action stopServiceAction = new NotificationCompat.Action.Builder(
-                android.R.drawable.ic_menu_close_clear_cancel,
-                getString(R.string.main_stop),
-                stopServicePendingIntent).build();
+            NotificationCompat.Action stopServiceAction = new NotificationCompat.Action.Builder(
+                    android.R.drawable.ic_menu_close_clear_cancel,
+                    getString(R.string.main_stop),
+                    stopServicePendingIntent).build();
 
-        Notification notification = new NotificationCompat.Builder(this)
-                .setOngoing(true)
-                .setCategory(NotificationCompat.CATEGORY_SERVICE)
-                .setColor(getColorC(R.color.colorPrimary))
-                .setSmallIcon(R.drawable.notification_icon)
-                .setContentTitle(getString(R.string.notification_title, trainerLevel))
-                .setContentIntent(openAppPendingIntent)
-                .addAction(openAppAction)
-                .addAction(stopServiceAction)
-                .build();
+            Notification notification = new NotificationCompat.Builder(this)
+                    .setOngoing(true)
+                    .setCategory(NotificationCompat.CATEGORY_SERVICE)
+                    .setColor(getColorC(R.color.colorPrimary))
+                    .setSmallIcon(R.drawable.notification_icon)
+                    .setContentTitle(getString(R.string.notification_title, trainerLevel))
+                    .setContentIntent(openAppPendingIntent)
+                    .addAction(startSettingsAction)
+                    .addAction(stopServiceAction)
+                    .build();
 
-        startForeground(NOTIFICATION_REQ_CODE, notification);
+            startForeground(NOTIFICATION_REQ_CODE, notification);
+            
+        } else {
+            Intent startAppIntent = new Intent(this, MainActivity.class);
+
+            startAppIntent.setAction(MainActivity.ACTION_CLICK_ON_BUTTON);
+
+            PendingIntent startServicePendingIntent = PendingIntent.getActivity(
+                    this, 0, startAppIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+
+            NotificationCompat.Action startServiceAction = new NotificationCompat.Action.Builder(
+                    R.drawable.notification_icon,
+                    getString(R.string.main_start),
+                    startServicePendingIntent).build();
+
+            Notification notification = new NotificationCompat.Builder(getApplicationContext())
+                    .setOngoing(false)
+                    .setCategory(NotificationCompat.CATEGORY_SERVICE)
+                    .setColor(getColorC(R.color.colorPrimary))
+                    .setSmallIcon(R.drawable.notification_icon)
+                    .setContentTitle(getString(R.string.notification_titleStopped))
+                    .setContentIntent(openAppPendingIntent)
+                    .addAction(startSettingsAction)
+                    .addAction(startServiceAction)
+                    .build();
+
+            NotificationManager mNotifyMgr =
+                    (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
+            mNotifyMgr.notify(NOTIFICATION_REQ_CODE,notification);
+        }
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -147,4 +147,5 @@
     <string name="clipboard_activity_title">GoIV Clipboard configuration</string>
     <string name="showtranslatedpokemonname_setting_title">Show translated Pokémon name</string>
     <string name="showtranslatedpokemonname_setting_summary">Display translated Pokémon name on GoIV but use its English name for OCR. This is for Pokémon Go app is in English but user\'s native language is not.</string>
+    <string name="increment_level">Level +1</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
     <string name="cancel">Cancel</string>
     <string name="check_iv">Check IV</string>
     <string name="notification_title">GoIV Running - Level %1$d</string>
+    <string name="notification_titleStopped">GoIV is stopped.</string>
     <string name="notification_open_app">Open app</string>
     <string name="close">Close</string>
     <string name="main_permission">Grant Permissions</string>


### PR DESCRIPTION
## Better notifications
Fixes #504
1. Added stop button to notifcation (if we stopped from notification)
2. Added settings button. (Only when stopped)
3. Removed Open App button (only room for 2 icons), clicking on GoIV notification will open GoIV. (based on android docs we should not have 2 objects do the same thing)
4. added +1 trainer level button as requested in https://github.com/farkam135/GoIV/issues/268 (will only show if GoIV is started)

![20161108_144003](https://cloud.githubusercontent.com/assets/22281828/20114187/4958eaba-a5c1-11e6-88d8-232197804ffb.png)
![screenshot_20161108-143907](https://cloud.githubusercontent.com/assets/22281828/20114186/4958a97e-a5c1-11e6-8334-7836f099b106.jpg)

Known issues:
1. Notification is destroyed then a new one is created:  Notification is tied to service (to make it a foreground service), so when selfstop is fires it will kill the notification. At api 24 stopForeground(STOP_FOREGROUND_DETACH) should fix that but I don't have API 24 to test.
2. if we are in screen capture mode, start button in notification will open the main activity screen first, then start GoIV, (if you have open pogo option it will start pogo.)

I think we can live with those limitations for now.