### PR TITLE
New Feature to add a toast when text is copied to the clipboard.

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
+++ b/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
@@ -3,12 +3,13 @@ package com.kamron.pogoiv;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Build;
-import android.util.Log;
 
 import com.kamron.pogoiv.clipboard.ClipboardToken;
 import com.kamron.pogoiv.clipboard.tokens.IVPercentageToken;
 import com.kamron.pogoiv.clipboard.tokens.IVPercentageTokenMode;
+import com.kamron.pogoiv.clipboard.tokens.PokemonNameToken;
 import com.kamron.pogoiv.clipboard.tokens.SeparatorToken;
+import com.kamron.pogoiv.clipboard.tokens.UnicodeToken;
 
 import java.util.ArrayList;
 
@@ -70,17 +71,24 @@ public class GoIVSettings {
     }
 
     public String getClipboardPreference() {
-
         //Below code creates tokens so we can get the representation corresponding to how the previous default
         // clipboard setting was - so that the default reflects what users had before they could configure the
         // clipboard themselves.
-        String lowrep = new IVPercentageToken(IVPercentageTokenMode.MIN).getStringRepresentation();
-        String highrep = new IVPercentageToken(IVPercentageTokenMode.MAX).getStringRepresentation();
-        String dashRepresentation = new SeparatorToken("-").getStringRepresentation();
+        StringBuilder defaultString = new StringBuilder(); // Name (3 char)+ MIN-MAX + Unicode not filled (MAX IV)
+        //pokemon name max 3 characters
+        defaultString.append(new PokemonNameToken(false, 3).getStringRepresentation());
 
-        Log.d("NahojjjenClippy", "String representation of token train from settings: "
-                + prefs.getString(GOIV_CLIPBOARDSETTINGS, "error"));
-        return prefs.getString(GOIV_CLIPBOARDSETTINGS, lowrep + dashRepresentation + highrep);
+        //lowrep
+        defaultString.append(new IVPercentageToken(IVPercentageTokenMode.MIN).getStringRepresentation());
+        //dashRepresentation
+        defaultString.append(new SeparatorToken("-").getStringRepresentation());
+        //highrep
+        defaultString.append(new IVPercentageToken(IVPercentageTokenMode.MAX).getStringRepresentation());
+
+        //Unicode iv circled numbers not filled in ex ⑦⑦⑦
+        defaultString.append(new UnicodeToken(false).getStringRepresentation());
+
+        return prefs.getString(GOIV_CLIPBOARDSETTINGS, defaultString.toString());
     }
 
     public void setClipboardPreference(ArrayList<ClipboardToken> tokens) {

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -34,7 +34,6 @@ import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -1288,11 +1287,15 @@ public class Pokefly extends Service {
         if (GoIVSettings.getInstance(getApplicationContext()).shouldCopyToClipboard()) {
             ClipboardTokenHandler cth = new ClipboardTokenHandler(getApplicationContext());
             String clipResult = cth.getResults(ivScanResult, pokeInfoCalculator);
-            Log.d("NahojjjenClippy", "Clipboard content to add: " + clipResult);
+
+            Toast toast = Toast.makeText(this, String.format(getString(R.string.clipboard_copy_toast),clipResult),
+                    Toast.LENGTH_SHORT);
+            toast.setGravity(Gravity.CENTER,0,0);
+            toast.show();
+
             ClipData clip = ClipData.newPlainText(clipResult, clipResult);
             clipboard.setPrimaryClip(clip);
         }
-
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,4 +150,5 @@
     <string name="showtranslatedpokemonname_setting_title">Show translated Pokémon name</string>
     <string name="showtranslatedpokemonname_setting_summary">Display translated Pokémon name on GoIV but use its English name for OCR. This is for Pokémon Go app is in English but user\'s native language is not.</string>
     <string name="pause_goiv_notification">Pause</string>
+    <string name="clipboard_copy_toast">Copied %s to clipboard</string>
 </resources>


### PR DESCRIPTION
Fixes #551
1. Added **short** toast message in "Center" gravity.
2. Changed default setting to `Name (3 char)` + `Min-Max` + `Unicode not filled (MAX IV)`
3. Removed some debug log messages.

![unnamed](https://cloud.githubusercontent.com/assets/22281828/20248037/ee007290-a9a9-11e6-9fbe-3ed19b0ca50e.png)

