### PR TITLE
Add Next and Done to keyboard; select all text on Focus in confirmation screen

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -39,6 +39,7 @@ import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.WindowManager;
+import android.view.inputmethod.EditorInfo;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.AutoCompleteTextView;
@@ -1755,15 +1756,23 @@ public class Pokefly extends Service {
             onCheckButtonsLayout.setVisibility(View.GONE);
         }
         moveOverlayUpOrDownToMatchAppraisalBox();
-        enableOrDisablePokeSpamBoxBasedOnSettings();
+        showCandyTextBoxBasedOnSettings();
     }
 
-    private void enableOrDisablePokeSpamBoxBasedOnSettings() {
+
+    /**
+     * showCandyTextBoxBasedOnSettings
+     * Shows candy text box if pokespam is enabled
+     * Will set the Text Edit box to use next action or done if its the last text box.
+     */
+    private void showCandyTextBoxBasedOnSettings() {
         //enable/disable visibility based on PokeSpam enabled or not
         if (GoIVSettings.getInstance(getApplicationContext()).isPokeSpamEnabled()) {
             pokeSpamDialogInputContentBox.setVisibility(View.VISIBLE);
+            pokemonHPEdit.setImeOptions(EditorInfo.IME_ACTION_NEXT);
         } else {
             pokeSpamDialogInputContentBox.setVisibility(View.GONE);
+            pokemonHPEdit.setImeOptions(EditorInfo.IME_ACTION_DONE);
         }
     }
 
@@ -1816,7 +1825,7 @@ public class Pokefly extends Service {
                 checkIv();
             }
         }
-        enableOrDisablePokeSpamBoxBasedOnSettings();
+        showCandyTextBoxBasedOnSettings();
     }
 
     private <T> String optionalIntToString(Optional<T> src) {

--- a/app/src/main/res/layout/dialog_input.xml
+++ b/app/src/main/res/layout/dialog_input.xml
@@ -67,7 +67,11 @@
                 android:maxLength="4"
                 android:minWidth="60dp"
                 android:textAlignment="center"
-                android:inputType="number"/>
+                android:inputType="number"
+                android:maxLines="1"
+                android:selectAllOnFocus="true"
+                android:nextFocusDown="@+id/etHp"
+                />
 
         </LinearLayout>
 
@@ -98,7 +102,12 @@
                 android:text="XX"
                 android:maxLength="4"
                 android:textAlignment="center"
-                android:inputType="number"/>
+                android:inputType="number"
+                android:selectAllOnFocus="true"
+                android:maxLines="1"
+                android:nextFocusDown="@+id/etCandy"
+                android:nextFocusForward="@+id/etCandy"
+                />
 
         </LinearLayout>
         <LinearLayout
@@ -127,7 +136,11 @@
                 android:text="XX"
                 android:maxLength="4"
                 android:textAlignment="center"
-                android:inputType="number"/>
+                android:inputType="number"
+                android:selectAllOnFocus="true"
+                android:imeOptions="actionDone"
+                android:maxLines="1"
+                />
 
         </LinearLayout>
 


### PR DESCRIPTION
1. Clicking on textbox will now have a **working** next and done buttons.
2. All text in EditText will be selected on focus 
3. Renamed enableOrDisablePokeSpamBoxBasedOnSettings to showCandyTextBoxBasedOnSettings

![screenshot_20161116-013555](https://cloud.githubusercontent.com/assets/22281828/20337167/59946ee0-ab9d-11e6-9ee1-043315cf1dbf.png)
![screenshot_20161116-013844](https://cloud.githubusercontent.com/assets/22281828/20337184/7f11caa0-ab9d-11e6-9a57-0cdfcbe01ac2.png)
