### PR TITLE
Change slider prompt to be shorter and consume only 1 line.

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -67,7 +67,7 @@
     <string name="hp">KP</string>
     <string name="pokemon_name">Pokémon Name:</string>
 
-    <string name="use_the_slider_below_to_align_the_arc">Verwende den Schieberegler um den roten Punkt auszurichten</string>
+    <string name="use_the_slider_below_to_align_the_arc">Verschiebe den roten Punkt mit dem Slider</string>
     <string name="notification_title">GoIV läuft - Level %1$d</string>
     <string name="close">Schließen</string>
     <string name="main_permission">Berechtigungen erlauben</string>


### PR DESCRIPTION
Change German translation based on user @chrisi51 at #567

I don't speak German so I used google translate to check.
before: `Use the slider to align the red point`
after:    `Move the red dot with the slider`