### PR TITLE
Fixes base stat errors that are found from last update

### DIFF
--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -166,7 +166,7 @@
         <item>155</item>
         <item>210</item>
         <item>62</item>
-        <item>64</item>
+        <item>94</item>
         <item>151</item>
         <item>55</item>
         <item>86</item>


### PR DESCRIPTION
Turns out metapod had an error in it in the dataset i used to copy the stat information.

The dataset has been updated now, and Ive double checked with the formula used to generate the base stats from the game stats.