### PR TITLE
Bump version for 3.3.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -73,8 +73,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 24
-        versionCode 17
-        versionName "3.2.0"
+        versionCode 19
+        versionName "3.3.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
We should have done this earlier. Maybe we should update to the next version code directly.