### PR TITLE
Allow refining Too Many possibilities (mon with 10CP/10HP) with overall appraisal phrase. 

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -58,6 +58,7 @@ import android.widget.Toast;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.kamron.pogoiv.clipboard.ClipboardTokenHandler;
+import com.kamron.pogoiv.logic.AppraisalHelper;
 import com.kamron.pogoiv.logic.CPRange;
 import com.kamron.pogoiv.logic.Data;
 import com.kamron.pogoiv.logic.IVCombination;
@@ -1692,17 +1693,36 @@ public class Pokefly extends Service {
         int low = 0;
         int ave = 0;
         int high = 0;
+        boolean appraisalEvaluated = false;
+
         if (ivScanResult.iVCombinations.size() != 0) {
             low = ivScanResult.getLowestIVCombination().percentPerfect;
             ave = ivScanResult.getAveragePercent();
             high = ivScanResult.getHighestIVCombination().percentPerfect;
+        } else if (ivScanResult.tooManyPossibilities) {
+           //if we have too many possibilities calculate based on appraisalPercentageRange and appraisalIvRange
+           //find the  lowest and highest percentages
+            int appraisalPercentageRangeSelected = appraisalPercentageRange.getSelectedItemPosition();
+            int appraisalIvRangeSelected = appraisalIvRange.getSelectedItemPosition();
+
+            AppraisalHelper.AppraisalPercentPrefect AppraisalPercentPrefect =
+                    AppraisalHelper.calculateAppraisalPercentPrefect(appraisalPercentageRangeSelected,
+                            appraisalIvRangeSelected);
+
+            if (AppraisalPercentPrefect != null) {
+                low = AppraisalPercentPrefect.getLow();
+                ave = AppraisalPercentPrefect.getAve();
+                high = AppraisalPercentPrefect.getHigh();
+                appraisalEvaluated = true;
+            }
+
         }
         GuiUtil.setTextColorByPercentage(resultsMinPercentage, low);
         GuiUtil.setTextColorByPercentage(resultsAvePercentage, ave);
         GuiUtil.setTextColorByPercentage(resultsMaxPercentage, high);
 
 
-        if (ivScanResult.iVCombinations.size() > 0) {
+        if (ivScanResult.iVCombinations.size() > 0 || appraisalEvaluated) {
             resultsMinPercentage.setText(getString(R.string.percent, low));
             resultsAvePercentage.setText(getString(R.string.percent, ave));
             resultsMaxPercentage.setText(getString(R.string.percent, high));
@@ -2029,4 +2049,5 @@ public class Pokefly extends Service {
     private int dpToPx(int dp) {
         return Math.round(dp * (displayMetrics.xdpi / DisplayMetrics.DENSITY_DEFAULT));
     }
+
 }

--- a/app/src/main/java/com/kamron/pogoiv/logic/AppraisalHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/AppraisalHelper.java
@@ -1,0 +1,181 @@
+package com.kamron.pogoiv.logic;
+
+import android.support.annotation.Nullable;
+
+import java.util.ArrayList;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+/**
+ * Created by NightMadness on 11/21/2016.
+ * This class helps GoIV find the lowest and highest values for Appraisal and Calculates overlap
+ */
+
+public class AppraisalHelper {
+
+    /**
+     * This function calculates the Lowest and Highest IV ranges possible based on selected appraisals.
+     *
+     * @param appraisalPercentageRangeSelected Appraisal Percentage Selected
+     * @param appraisalIvRangeSelected Appraisal IV Selected
+     * @return AppraisalPercentPrefect which contains Low, Ave, High values or null if none found
+     *
+     * */
+    public static @Nullable AppraisalPercentPrefect calculateAppraisalPercentPrefect(
+            int appraisalPercentageRangeSelected, int appraisalIvRangeSelected) {
+        boolean appraisalEvaluated = false;
+        ArrayList<IVPercentPrefectPair> appraisalList = new ArrayList<>();
+
+        //Check first Percent Appraisal
+        if (appraisalPercentageRangeSelected != 0) {
+            AppraisalPercentageRange appraisalPercentageRange = new AppraisalPercentageRange(
+                    appraisalPercentageRangeSelected);
+            int lowPR = appraisalPercentageRange.getLowest();
+            int highPR = appraisalPercentageRange.getHighest();
+            appraisalEvaluated = true;
+            appraisalList.add(new IVPercentPrefectPair(lowPR, highPR));
+        }
+
+        //Check second IV Appraisal
+        if (appraisalIvRangeSelected != 0) {
+            AppraisalIVRange appraisalIVRange = new AppraisalIVRange(
+                    appraisalIvRangeSelected);
+
+            int lowPR = appraisalIVRange.getLowestPossiblePercent();
+            int highPR = appraisalIVRange.getHighestPossiblePercent();
+            appraisalEvaluated = true;
+            appraisalList.add(new IVPercentPrefectPair(lowPR, highPR));
+        }
+        //Check if we have evaluated any Appraisal
+        if (appraisalEvaluated) {
+            //tries to overlap the low and the high, if its not able to overlap appraisalEvaluated is false
+            Integer currentLow = null;
+            Integer currentHigh = null;
+
+            for (IVPercentPrefectPair appraisal : appraisalList) {
+                int lowPercent = appraisal.lowest;
+                int highPercent = appraisal.highest;
+                if (currentLow == null || currentLow < lowPercent) {
+                    currentLow = lowPercent;
+                }
+                if (currentHigh == null || currentHigh > highPercent) {
+                    currentHigh = highPercent;
+                }
+            }
+            //Try to overlap both high and low,
+            //its possible user has selected invalid combination that does not overlap
+            if (currentHigh > currentLow) {
+                // values overlap
+                int low = currentLow;
+                int high = currentHigh;
+                int ave = Math.round((low + high) / 2f);
+                return new AppraisalPercentPrefect(low, ave, high);
+            }
+        }
+        //seems user has selected selected nothing or selected an invalid combination.
+        return null;
+    }
+
+    /**
+     * This class calculates the Appraisal Percentage Range,
+     * will calculated the lowest and highest on the constrictor.
+     * */
+    public static class AppraisalPercentageRange extends IVPercentPrefectPair {
+        //inherited Lowest and Highest from IVPercentPrefectPair.
+
+        public AppraisalPercentageRange(int selectedItemPosition) {
+            switch (selectedItemPosition) {
+                case 1:
+                    lowest = 81;
+                    highest = 100;
+                    break;
+                case 2:
+                    lowest = 66;
+                    highest = 80;
+                    break;
+                case 3:
+                    lowest = 51;
+                    highest = 65;
+                    break;
+                case 4:
+                    lowest = 0;
+                    highest = 50;
+                    break;
+                default:
+                    lowest = 0;
+                    highest = 100;
+            }
+        }
+    }
+
+    /**
+     * This class calculates the Appraisal IV Range,
+     * will calculated the lowest and highest on the constrictor.
+     * */
+    public static class AppraisalIVRange extends IVPercentPrefectPair {
+        //inherited Lowest and Highest from IVPercentPrefectPair.
+
+        public AppraisalIVRange(int selectedItemPosition) {
+            switch (selectedItemPosition) {
+                case 1:
+                    lowest = 15;
+                    highest = 15;
+                    break;
+                case 2:
+                    lowest = 13;
+                    highest = 14;
+                    break;
+                case 3:
+                    lowest = 8;
+                    highest = 12;
+                    break;
+                case 4:
+                    lowest = 0;
+                    highest = 7;
+                    break;
+                default:
+                    lowest = 0;
+                    highest = 15;
+            }
+        }
+
+        //Lowest IV'S (lowest + 0 + 0) out of possible 45
+        public final int getLowestPossiblePercent() {
+            return Math.round((lowest / 45f) * 100f);
+        }
+
+        //Highest IV'S (Highest + Highest + Highest) out of possible 45
+        // = (Highest * 3) / 45
+        // = (Highest) / 15
+        public final int getHighestPossiblePercent() {
+            return Math.round((highest / 15f) * 100f);
+        }
+    }
+
+    /**
+     * This class holds the only the Low and High
+     * used when we calculate possible overlap.
+     * */
+    @NoArgsConstructor(access = AccessLevel.PRIVATE) //used in AppraisalPercentageRange and AppraisalIVRange
+    @AllArgsConstructor(access = AccessLevel.PRIVATE) //used in overlap calculation
+    private static class IVPercentPrefectPair {
+        //variables are protected so they can be used in extend class
+        @Getter protected int lowest;
+        @Getter protected int highest;
+    }
+
+    /**
+     * This class holds the Appraisal Percent Prefect
+     * Low, Ave, High Values.
+     * */
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    protected static class AppraisalPercentPrefect {
+        @Getter private int low;
+        @Getter private int ave;
+        @Getter private int high;
+    }
+
+
+}

--- a/app/src/main/java/com/kamron/pogoiv/logic/IVScanResult.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/IVScanResult.java
@@ -2,6 +2,9 @@ package com.kamron.pogoiv.logic;
 
 import android.support.annotation.Nullable;
 
+import com.kamron.pogoiv.logic.AppraisalHelper.AppraisalIVRange;
+import com.kamron.pogoiv.logic.AppraisalHelper.AppraisalPercentageRange;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -189,28 +192,10 @@ public class IVScanResult {
     public void refineByAppraisalPercentageRange(int selectedItemPosition) {
         int lowest;
         int highest;
-
-        switch (selectedItemPosition) {
-            case 1:
-                lowest = 81;
-                highest = 100;
-                break;
-            case 2:
-                lowest = 66;
-                highest = 80;
-                break;
-            case 3:
-                lowest = 51;
-                highest = 65;
-                break;
-            case 4:
-                lowest = 0;
-                highest = 50;
-                break;
-            default:
-                lowest = 0;
-                highest = 100;
-        }
+        //Get Percentage Range appraisal values
+        AppraisalPercentageRange appraisalPercentageRange = new AppraisalPercentageRange(selectedItemPosition);
+        lowest = appraisalPercentageRange.getLowest();
+        highest = appraisalPercentageRange.getHighest();
 
         ArrayList<IVCombination> refinedList = new ArrayList<>();
 
@@ -238,27 +223,10 @@ public class IVScanResult {
         int lowest;
         int highest;
 
-        switch (selectedItemPosition) {
-            case 1:
-                lowest = 15;
-                highest = 15;
-                break;
-            case 2:
-                lowest = 13;
-                highest = 14;
-                break;
-            case 3:
-                lowest = 8;
-                highest = 12;
-                break;
-            case 4:
-                lowest = 0;
-                highest = 7;
-                break;
-            default:
-                lowest = 0;
-                highest = 15;
-        }
+        //Get IV appraisal values
+        AppraisalIVRange appraisalIVRange = new AppraisalIVRange(selectedItemPosition);
+        lowest = appraisalIVRange.getLowest();
+        highest = appraisalIVRange.getHighest();
 
         ArrayList<IVCombination> refinedList = new ArrayList<>();
 

--- a/app/src/test/java/com/kamron/pogoiv/logic/AppraisalHelperTest.java
+++ b/app/src/test/java/com/kamron/pogoiv/logic/AppraisalHelperTest.java
@@ -1,0 +1,168 @@
+package com.kamron.pogoiv.logic;
+
+import android.support.test.filters.SmallTest;
+
+import com.kamron.pogoiv.logic.AppraisalHelper.AppraisalPercentPrefect;
+
+import junit.framework.Assert;
+
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.TreeMap;
+
+import static org.junit.Assert.assertEquals;
+
+
+/**
+ * Created by NightMadness on 11/23/2016.
+ * <p>
+ * This test class will test overlaps of values with appraisal selector.
+ */
+@RunWith(Parameterized.class)
+@SmallTest
+public class AppraisalHelperTest{
+    int appraisalPercentageRangeSelected;
+    int appraisalIvRangeSelected;
+    AppraisalPercentPrefect actual;
+    AppraisalPercentPrefect expected;
+    public static TreeMap<String, AppraisalPercentPrefect> results = new TreeMap<>();
+
+    @Parameters(name = "Test {index}: Percent {0}, IV {1}")
+    public static Iterable<Object[]> data() {
+
+        /* will generate object with all results, I kept it commented out in case we want to regenerate tests.
+        ArrayList<Object[]> list = new ArrayList<>();
+        for (int i = 0; i <= 5; i++) {
+            for (int j = 0; j <= 5; j++) {
+                list.add(new Object[]{i,  j, null});
+            }
+        }
+       return list;*/
+
+        return Arrays.asList(new Object[][]{
+                {0, 0, null}, //Too many possibilities
+                {0, 1, new AppraisalPercentPrefect(33, 67, 100)},
+                {0, 2, new AppraisalPercentPrefect(29, 61, 93)},
+                {0, 3, new AppraisalPercentPrefect(18, 49, 80)},
+                {0, 4, new AppraisalPercentPrefect(0, 24, 47)},
+                {0, 5, new AppraisalPercentPrefect(0, 50, 100)},
+                {1, 0, new AppraisalPercentPrefect(81, 91, 100)},
+                {1, 1, new AppraisalPercentPrefect(81, 91, 100)},
+                {1, 2, new AppraisalPercentPrefect(81, 87, 93)},
+                {1, 3, null},
+                {1, 4, null},
+                {1, 5, new AppraisalPercentPrefect(81, 91, 100)},
+                {2, 0, new AppraisalPercentPrefect(66, 73, 80)},
+                {2, 1, new AppraisalPercentPrefect(66, 73, 80)},
+                {2, 2, new AppraisalPercentPrefect(66, 73, 80)},
+                {2, 3, new AppraisalPercentPrefect(66, 73, 80)},
+                {2, 4, null},
+                {2, 5, new AppraisalPercentPrefect(66, 73, 80)},
+                {3, 0, new AppraisalPercentPrefect(51, 58, 65)},
+                {3, 1, new AppraisalPercentPrefect(51, 58, 65)},
+                {3, 2, new AppraisalPercentPrefect(51, 58, 65)},
+                {3, 3, new AppraisalPercentPrefect(51, 58, 65)},
+                {3, 4, null},
+                {3, 5, new AppraisalPercentPrefect(51, 58, 65)},
+                {4, 0, new AppraisalPercentPrefect(0, 25, 50)},
+                {4, 1, new AppraisalPercentPrefect(33, 42, 50)},
+                {4, 2, new AppraisalPercentPrefect(29, 40, 50)},
+                {4, 3, new AppraisalPercentPrefect(18, 34, 50)},
+                {4, 4, new AppraisalPercentPrefect(0, 24, 47)},
+                {4, 5, new AppraisalPercentPrefect(0, 25, 50)},
+                {5, 0, new AppraisalPercentPrefect(0, 50, 100)},
+                {5, 1, new AppraisalPercentPrefect(33, 67, 100)},
+                {5, 2, new AppraisalPercentPrefect(29, 61, 93)},
+                {5, 3, new AppraisalPercentPrefect(18, 49, 80)},
+                {5, 4, new AppraisalPercentPrefect(0, 24, 47)},
+                {5, 5, new AppraisalPercentPrefect(0, 50, 100)}
+        });
+    }
+
+
+    public AppraisalHelperTest(int appraisalPercentageRangeSelected, int appraisalIvRangeSelected,
+                               AppraisalPercentPrefect expected) {
+        this.appraisalPercentageRangeSelected = appraisalPercentageRangeSelected;
+        this.appraisalIvRangeSelected = appraisalIvRangeSelected;
+        this.expected = expected;
+    }
+
+    @Before
+    public void calculateAppraisalPercentPrefect() {
+        actual = AppraisalHelper
+                .calculateAppraisalPercentPrefect(appraisalPercentageRangeSelected,
+                        appraisalIvRangeSelected);
+
+        //will put all tested parameters in an object with actual results so we can read those later
+        results.put(
+                String.format("%1d, %2d", appraisalPercentageRangeSelected, appraisalIvRangeSelected)
+                , actual);
+
+    }
+
+    //display all results for an easy way to update the parameter list
+    @AfterClass
+    public static void displayResults() {
+        Assume.assumeTrue(results != null);
+        for (HashMap.Entry<String, AppraisalPercentPrefect> x : results.entrySet()) {
+
+            final AppraisalPercentPrefect result = x.getValue();
+            if (result == null) {
+                System.out.println(String.format("{%1s, null}, ", x.getKey()));
+
+            } else if (result != null) {
+                System.out.println(String.format("{%1s, new AppraisalHelper.AppraisalPercentPrefect(%2s, %3s, %4s)},",
+                        x.getKey(), result.getLow(), result.getAve(), result.getHigh()));
+            }
+        }
+    }
+
+
+    @Test
+    // Check that the Nullability of both expected and actual are the same.
+    public void nullCheck() {
+        Assert.assertEquals("One the values is null.", expected == null, actual == null);
+    }
+
+    //if both are null we can ignore the test since nullCheck is already checked
+    public boolean isActualAndExpectedNotNull() {
+        return (actual != null && expected != null);
+    }
+
+    //Assume costs 15 MS! No thank you...
+    @Test
+    public void lowCheck() {
+        if (!isActualAndExpectedNotNull()) {
+            return;
+        }
+        //Assume.assumeTrue("Ignore test if both expected and actual are null.", isActualAndExpectedNotNull());
+        assertEquals("Low: ", actual.getLow(), expected.getLow());
+    }
+
+    @Test
+    public void aveCheck() {
+        if (!isActualAndExpectedNotNull()) {
+            return;
+        }
+        //Assume.assumeTrue("Ignore test if both expected and actual are null.", isActualAndExpectedNotNull());
+        assertEquals("Ave: ", actual.getAve(), expected.getAve());
+    }
+
+    @Test
+    public void highCheck() {
+        if (!isActualAndExpectedNotNull()) {
+            return;
+        }
+        //Assume.assumeTrue("Ignore test if both expected and actual are null.", isActualAndExpectedNotNull());
+        assertEquals("High: ", actual.getHigh(), expected.getHigh());
+    }
+
+}

--- a/app/src/test/java/com/kamron/pogoiv/logic/AppraisalHelperTest.java
+++ b/app/src/test/java/com/kamron/pogoiv/logic/AppraisalHelperTest.java
@@ -14,9 +14,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.TreeMap;
 
 import static org.junit.Assert.assertEquals;
 
@@ -28,123 +27,253 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(Parameterized.class)
 @SmallTest
-public class AppraisalHelperTest{
-    int appraisalPercentageRangeSelected;
-    int appraisalIvRangeSelected;
-    AppraisalPercentPrefect actual;
-    AppraisalPercentPrefect expected;
-    public static TreeMap<String, AppraisalPercentPrefect> results = new TreeMap<>();
+public class AppraisalHelperTest {
+    private final int howManyCheckboxesChecked;
+    private final int appraisalPercentageRangeSelected;
+    private final int appraisalIvRangeSelected;
+    private AppraisalPercentPrefect actual;
+    private final AppraisalPercentPrefect expected;
 
-    @Parameters(name = "Test {index}: Percent {0}, IV {1}")
+    public static ArrayList<String> results = new ArrayList<>();
+
+    @Parameters(name = "Test {index}: Percent {0}, Checkbox {1}, IV {2}")
     public static Iterable<Object[]> data() {
 
         /* will generate object with all results, I kept it commented out in case we want to regenerate tests.
         ArrayList<Object[]> list = new ArrayList<>();
         for (int i = 0; i <= 5; i++) {
             for (int j = 0; j <= 5; j++) {
-                list.add(new Object[]{i,  j, null});
+                for (int k = 0; k <= 3; k++) {
+                    list.add(new Object[]{i, j, k, null});
+                }
             }
         }
-       return list;*/
+        return list;*/
 
         return Arrays.asList(new Object[][]{
-                {0, 0, null}, //Too many possibilities
-                {0, 1, new AppraisalPercentPrefect(33, 67, 100)},
-                {0, 2, new AppraisalPercentPrefect(29, 61, 93)},
-                {0, 3, new AppraisalPercentPrefect(18, 49, 80)},
-                {0, 4, new AppraisalPercentPrefect(0, 24, 47)},
-                {0, 5, new AppraisalPercentPrefect(0, 50, 100)},
-                {1, 0, new AppraisalPercentPrefect(81, 91, 100)},
-                {1, 1, new AppraisalPercentPrefect(81, 91, 100)},
-                {1, 2, new AppraisalPercentPrefect(81, 87, 93)},
-                {1, 3, null},
-                {1, 4, null},
-                {1, 5, new AppraisalPercentPrefect(81, 91, 100)},
-                {2, 0, new AppraisalPercentPrefect(66, 73, 80)},
-                {2, 1, new AppraisalPercentPrefect(66, 73, 80)},
-                {2, 2, new AppraisalPercentPrefect(66, 73, 80)},
-                {2, 3, new AppraisalPercentPrefect(66, 73, 80)},
-                {2, 4, null},
-                {2, 5, new AppraisalPercentPrefect(66, 73, 80)},
-                {3, 0, new AppraisalPercentPrefect(51, 58, 65)},
-                {3, 1, new AppraisalPercentPrefect(51, 58, 65)},
-                {3, 2, new AppraisalPercentPrefect(51, 58, 65)},
-                {3, 3, new AppraisalPercentPrefect(51, 58, 65)},
-                {3, 4, null},
-                {3, 5, new AppraisalPercentPrefect(51, 58, 65)},
-                {4, 0, new AppraisalPercentPrefect(0, 25, 50)},
-                {4, 1, new AppraisalPercentPrefect(33, 42, 50)},
-                {4, 2, new AppraisalPercentPrefect(29, 40, 50)},
-                {4, 3, new AppraisalPercentPrefect(18, 34, 50)},
-                {4, 4, new AppraisalPercentPrefect(0, 24, 47)},
-                {4, 5, new AppraisalPercentPrefect(0, 25, 50)},
-                {5, 0, new AppraisalPercentPrefect(0, 50, 100)},
-                {5, 1, new AppraisalPercentPrefect(33, 67, 100)},
-                {5, 2, new AppraisalPercentPrefect(29, 61, 93)},
-                {5, 3, new AppraisalPercentPrefect(18, 49, 80)},
-                {5, 4, new AppraisalPercentPrefect(0, 24, 47)},
-                {5, 5, new AppraisalPercentPrefect(0, 50, 100)}
+                /* AppraisalPercentage, howManyCheckboxesChecked, appraisalIvRange, expected */
+                {0, 0, 0, null}, //Too many possibilities
+                {0, 0, 1, new AppraisalPercentPrefect( 33,  67, 100)},
+                {0, 0, 2, new AppraisalPercentPrefect( 29,  61,  93)},
+                {0, 0, 3, new AppraisalPercentPrefect( 18,  49,  80)},
+                {0, 0, 4, new AppraisalPercentPrefect(  0,  24,  47)},
+                {0, 0, 5, new AppraisalPercentPrefect(  0,  50, 100)},
+                {0, 1, 0, new AppraisalPercentPrefect(  0,  48,  96)},
+                {0, 1, 1, new AppraisalPercentPrefect( 33,  65,  96)},
+                {0, 1, 2, new AppraisalPercentPrefect( 29,  59,  89)},
+                {0, 1, 3, new AppraisalPercentPrefect( 18,  47,  76)},
+                {0, 1, 4, new AppraisalPercentPrefect(  0,  21,  42)},
+                {0, 1, 5, new AppraisalPercentPrefect(  0,  48,  96)},
+                {0, 2, 0, new AppraisalPercentPrefect(  0,  49,  98)},
+                {0, 2, 1, new AppraisalPercentPrefect( 67,  83,  98)},
+                {0, 2, 2, new AppraisalPercentPrefect( 58,  75,  91)},
+                {0, 2, 3, new AppraisalPercentPrefect( 36,  57,  78)},
+                {0, 2, 4, new AppraisalPercentPrefect(  0,  22,  44)},
+                {0, 2, 5, new AppraisalPercentPrefect(  0,  49,  98)},
+                {0, 3, 0, new AppraisalPercentPrefect(  0,  50, 100)},
+                {0, 3, 1, new AppraisalPercentPrefect(100, 100, 100)},
+                {0, 3, 2, new AppraisalPercentPrefect( 87,  90,  93)},
+                {0, 3, 3, new AppraisalPercentPrefect( 53,  67,  80)},
+                {0, 3, 4, new AppraisalPercentPrefect(  0,  24,  47)},
+                {0, 3, 5, new AppraisalPercentPrefect(  0,  50, 100)},
+                {1, 0, 0, new AppraisalPercentPrefect( 81,  91, 100)},
+                {1, 0, 1, new AppraisalPercentPrefect( 81,  91, 100)},
+                {1, 0, 2, new AppraisalPercentPrefect( 81,  87,  93)},
+                {1, 0, 3, null},
+                {1, 0, 4, null},
+                {1, 0, 5, new AppraisalPercentPrefect( 81,  91, 100)},
+                {1, 1, 0, new AppraisalPercentPrefect( 81,  89,  96)},
+                {1, 1, 1, new AppraisalPercentPrefect( 81,  89,  96)},
+                {1, 1, 2, new AppraisalPercentPrefect( 81,  85,  89)},
+                {1, 1, 3, null},
+                {1, 1, 4, null},
+                {1, 1, 5, new AppraisalPercentPrefect( 81,  89,  96)},
+                {1, 2, 0, new AppraisalPercentPrefect( 81,  90,  98)},
+                {1, 2, 1, new AppraisalPercentPrefect( 81,  90,  98)},
+                {1, 2, 2, new AppraisalPercentPrefect( 81,  86,  91)},
+                {1, 2, 3, null},
+                {1, 2, 4, null},
+                {1, 2, 5, new AppraisalPercentPrefect( 81,  90,  98)},
+                {1, 3, 0, new AppraisalPercentPrefect( 81,  91, 100)},
+                {1, 3, 1, new AppraisalPercentPrefect(100, 100, 100)},
+                {1, 3, 2, new AppraisalPercentPrefect( 87,  90,  93)},
+                {1, 3, 3, null},
+                {1, 3, 4, null},
+                {1, 3, 5, new AppraisalPercentPrefect( 81,  91, 100)},
+                {2, 0, 0, new AppraisalPercentPrefect( 66,  73,  80)},
+                {2, 0, 1, new AppraisalPercentPrefect( 66,  73,  80)},
+                {2, 0, 2, new AppraisalPercentPrefect( 66,  73,  80)},
+                {2, 0, 3, new AppraisalPercentPrefect( 66,  73,  80)},
+                {2, 0, 4, null},
+                {2, 0, 5, new AppraisalPercentPrefect( 66,  73,  80)},
+                {2, 1, 0, new AppraisalPercentPrefect( 66,  73,  80)},
+                {2, 1, 1, new AppraisalPercentPrefect( 66,  73,  80)},
+                {2, 1, 2, new AppraisalPercentPrefect( 66,  73,  80)},
+                {2, 1, 3, new AppraisalPercentPrefect( 66,  71,  76)},
+                {2, 1, 4, null},
+                {2, 1, 5, new AppraisalPercentPrefect( 66,  73,  80)},
+                {2, 2, 0, new AppraisalPercentPrefect( 66,  73,  80)},
+                {2, 2, 1, new AppraisalPercentPrefect( 67,  74,  80)},
+                {2, 2, 2, new AppraisalPercentPrefect( 66,  73,  80)},
+                {2, 2, 3, new AppraisalPercentPrefect( 66,  72,  78)},
+                {2, 2, 4, null},
+                {2, 2, 5, new AppraisalPercentPrefect( 66,  73,  80)},
+                {2, 3, 0, new AppraisalPercentPrefect( 66,  73,  80)},
+                {2, 3, 1, null},
+                {2, 3, 2, null},
+                {2, 3, 3, new AppraisalPercentPrefect( 66,  73,  80)},
+                {2, 3, 4, null},
+                {2, 3, 5, new AppraisalPercentPrefect( 66,  73,  80)},
+                {3, 0, 0, new AppraisalPercentPrefect( 51,  58,  65)},
+                {3, 0, 1, new AppraisalPercentPrefect( 51,  58,  65)},
+                {3, 0, 2, new AppraisalPercentPrefect( 51,  58,  65)},
+                {3, 0, 3, new AppraisalPercentPrefect( 51,  58,  65)},
+                {3, 0, 4, null},
+                {3, 0, 5, new AppraisalPercentPrefect( 51,  58,  65)},
+                {3, 1, 0, new AppraisalPercentPrefect( 51,  58,  65)},
+                {3, 1, 1, new AppraisalPercentPrefect( 51,  58,  65)},
+                {3, 1, 2, new AppraisalPercentPrefect( 51,  58,  65)},
+                {3, 1, 3, new AppraisalPercentPrefect( 51,  58,  65)},
+                {3, 1, 4, null},
+                {3, 1, 5, new AppraisalPercentPrefect( 51,  58,  65)},
+                {3, 2, 0, new AppraisalPercentPrefect( 51,  58,  65)},
+                {3, 2, 1, null},
+                {3, 2, 2, new AppraisalPercentPrefect( 58,  62,  65)},
+                {3, 2, 3, new AppraisalPercentPrefect( 51,  58,  65)},
+                {3, 2, 4, null},
+                {3, 2, 5, new AppraisalPercentPrefect( 51,  58,  65)},
+                {3, 3, 0, new AppraisalPercentPrefect( 51,  58,  65)},
+                {3, 3, 1, null},
+                {3, 3, 2, null},
+                {3, 3, 3, new AppraisalPercentPrefect( 53,  59,  65)},
+                {3, 3, 4, null},
+                {3, 3, 5, new AppraisalPercentPrefect( 51,  58,  65)},
+                {4, 0, 0, new AppraisalPercentPrefect(  0,  25,  50)},
+                {4, 0, 1, new AppraisalPercentPrefect( 33,  42,  50)},
+                {4, 0, 2, new AppraisalPercentPrefect( 29,  40,  50)},
+                {4, 0, 3, new AppraisalPercentPrefect( 18,  34,  50)},
+                {4, 0, 4, new AppraisalPercentPrefect(  0,  24,  47)},
+                {4, 0, 5, new AppraisalPercentPrefect(  0,  25,  50)},
+                {4, 1, 0, new AppraisalPercentPrefect(  0,  25,  50)},
+                {4, 1, 1, new AppraisalPercentPrefect( 33,  42,  50)},
+                {4, 1, 2, new AppraisalPercentPrefect( 29,  40,  50)},
+                {4, 1, 3, new AppraisalPercentPrefect( 18,  34,  50)},
+                {4, 1, 4, new AppraisalPercentPrefect(  0,  21,  42)},
+                {4, 1, 5, new AppraisalPercentPrefect(  0,  25,  50)},
+                {4, 2, 0, new AppraisalPercentPrefect(  0,  25,  50)},
+                {4, 2, 1, null},
+                {4, 2, 2, null},
+                {4, 2, 3, new AppraisalPercentPrefect( 36,  43,  50)},
+                {4, 2, 4, new AppraisalPercentPrefect(  0,  22,  44)},
+                {4, 2, 5, new AppraisalPercentPrefect(  0,  25,  50)},
+                {4, 3, 0, new AppraisalPercentPrefect(  0,  25,  50)},
+                {4, 3, 1, null},
+                {4, 3, 2, null},
+                {4, 3, 3, null},
+                {4, 3, 4, new AppraisalPercentPrefect(  0,  24,  47)},
+                {4, 3, 5, new AppraisalPercentPrefect(  0,  25,  50)},
+                {5, 0, 0, new AppraisalPercentPrefect(  0,  50, 100)},
+                {5, 0, 1, new AppraisalPercentPrefect( 33,  67, 100)},
+                {5, 0, 2, new AppraisalPercentPrefect( 29,  61,  93)},
+                {5, 0, 3, new AppraisalPercentPrefect( 18,  49,  80)},
+                {5, 0, 4, new AppraisalPercentPrefect(  0,  24,  47)},
+                {5, 0, 5, new AppraisalPercentPrefect(  0,  50, 100)},
+                {5, 1, 0, new AppraisalPercentPrefect(  0,  48,  96)},
+                {5, 1, 1, new AppraisalPercentPrefect( 33,  65,  96)},
+                {5, 1, 2, new AppraisalPercentPrefect( 29,  59,  89)},
+                {5, 1, 3, new AppraisalPercentPrefect( 18,  47,  76)},
+                {5, 1, 4, new AppraisalPercentPrefect(  0,  21,  42)},
+                {5, 1, 5, new AppraisalPercentPrefect(  0,  48,  96)},
+                {5, 2, 0, new AppraisalPercentPrefect(  0,  49,  98)},
+                {5, 2, 1, new AppraisalPercentPrefect( 67,  83,  98)},
+                {5, 2, 2, new AppraisalPercentPrefect( 58,  75,  91)},
+                {5, 2, 3, new AppraisalPercentPrefect( 36,  57,  78)},
+                {5, 2, 4, new AppraisalPercentPrefect(  0,  22,  44)},
+                {5, 2, 5, new AppraisalPercentPrefect(  0,  49,  98)},
+                {5, 3, 0, new AppraisalPercentPrefect(  0,  50, 100)},
+                {5, 3, 1, new AppraisalPercentPrefect(100, 100, 100)},
+                {5, 3, 2, new AppraisalPercentPrefect( 87,  90,  93)},
+                {5, 3, 3, new AppraisalPercentPrefect( 53,  67,  80)},
+                {5, 3, 4, new AppraisalPercentPrefect(  0,  24,  47)},
+                {5, 3, 5, new AppraisalPercentPrefect(  0,  50, 100)}
         });
     }
 
-
-    public AppraisalHelperTest(int appraisalPercentageRangeSelected, int appraisalIvRangeSelected,
+    /**
+     * This gets parameters from parametrized test.
+     * @param appraisalPercentageRangeSelected Selected percent appraisal
+     * @param howManyCheckboxesChecked Selected appraisal checkboxes
+     * @param appraisalIvRangeSelected Selected IV appraisal
+     * @param expected expect object value for the test.
+     */
+    public AppraisalHelperTest(int appraisalPercentageRangeSelected, int howManyCheckboxesChecked,
+                               int appraisalIvRangeSelected,
                                AppraisalPercentPrefect expected) {
         this.appraisalPercentageRangeSelected = appraisalPercentageRangeSelected;
+        this.howManyCheckboxesChecked = howManyCheckboxesChecked;
         this.appraisalIvRangeSelected = appraisalIvRangeSelected;
         this.expected = expected;
     }
 
+    /**
+     * This setups the actual variable, it is the in the setUp method since it *could* fail.
+     */
     @Before
-    public void calculateAppraisalPercentPrefect() {
-        actual = AppraisalHelper
-                .calculateAppraisalPercentPrefect(appraisalPercentageRangeSelected,
-                        appraisalIvRangeSelected);
-
-        //will put all tested parameters in an object with actual results so we can read those later
-        results.put(
-                String.format("%1d, %2d", appraisalPercentageRangeSelected, appraisalIvRangeSelected)
-                , actual);
-
+    public void setUp() {
+        actual = AppraisalHelper.calculateAppraisalPercentPrefect(
+                appraisalPercentageRangeSelected,
+                howManyCheckboxesChecked,
+                appraisalIvRangeSelected);
     }
 
-    //display all results for an easy way to update the parameter list
+    //Display all results for an easy way to update the parameter list
     @AfterClass
     public static void displayResults() {
-        Assume.assumeTrue(results != null);
-        for (HashMap.Entry<String, AppraisalPercentPrefect> x : results.entrySet()) {
-
-            final AppraisalPercentPrefect result = x.getValue();
-            if (result == null) {
-                System.out.println(String.format("{%1s, null}, ", x.getKey()));
-
-            } else if (result != null) {
-                System.out.println(String.format("{%1s, new AppraisalHelper.AppraisalPercentPrefect(%2s, %3s, %4s)},",
-                        x.getKey(), result.getLow(), result.getAve(), result.getHigh()));
-            }
+        Assume.assumeTrue(results != null && !results.isEmpty());
+        System.out.println("Actual Results:");
+        System.out.println(String.format("{%1s, %2s, %3s, %4s}",
+                "appraisalPercentage", "howManyCheckboxesChecked",
+                "appraisalIvRange", "expected(Low, Ave, High)"));
+        for (String result: results) {
+            System.out.println(result);
         }
     }
 
-
     @Test
-    // Check that the Nullability of both expected and actual are the same.
+    //Check that the Nullability of expected and actual are the same.
     public void nullCheck() {
+        saveResults();
         Assert.assertEquals("One the values is null.", expected == null, actual == null);
     }
 
-    //if both are null we can ignore the test since nullCheck is already checked
-    public boolean isActualAndExpectedNotNull() {
+    /*
+    will put all tested parameters in an object with actual results so we can read
+    those later
+    */
+    private void saveResults() {
+        if (actual == null) {
+            results.add(String.format("{%1$1d, %2$1d, %3$1d, null},",
+                    appraisalPercentageRangeSelected, howManyCheckboxesChecked, appraisalIvRangeSelected));
+        } else if (actual != null) {
+            results.add(String.format("{%1$1d, %2$1d, %3$1d, new AppraisalPercentPrefect(%4$3s, %5$3s, %6$3s)},",
+                    appraisalPercentageRangeSelected, howManyCheckboxesChecked, appraisalIvRangeSelected,
+                    actual.getLow(), actual.getAve(), actual.getHigh()));
+        }
+    }
+
+    //If both are null we can ignore the test since nullCheck is already checked
+    private boolean isActualAndExpectedNotNull() {
         return (actual != null && expected != null);
     }
 
-    //Assume costs 15 MS! No thank you...
+    //Assume costs 60 MS! No thank you...
     @Test
     public void lowCheck() {
         if (!isActualAndExpectedNotNull()) {
             return;
         }
         //Assume.assumeTrue("Ignore test if both expected and actual are null.", isActualAndExpectedNotNull());
-        assertEquals("Low: ", actual.getLow(), expected.getLow());
+        assertEquals("Low: ", expected.getLow(), actual.getLow());
     }
 
     @Test
@@ -153,7 +282,7 @@ public class AppraisalHelperTest{
             return;
         }
         //Assume.assumeTrue("Ignore test if both expected and actual are null.", isActualAndExpectedNotNull());
-        assertEquals("Ave: ", actual.getAve(), expected.getAve());
+        assertEquals("Ave: ", expected.getAve(), actual.getAve());
     }
 
     @Test
@@ -162,7 +291,7 @@ public class AppraisalHelperTest{
             return;
         }
         //Assume.assumeTrue("Ignore test if both expected and actual are null.", isActualAndExpectedNotNull());
-        assertEquals("High: ", actual.getHigh(), expected.getHigh());
+        assertEquals("High: ", expected.getHigh(), actual.getHigh());
     }
 
 }


### PR DESCRIPTION
Fixes #568 by allowing of refining "Too Many possibilities" (mon with 10CP/10HP) with both appraisal phrases. 
-- Refactored **some** Appraisal calculation to AppraisalHelper
-- Tried to keep much of the original code undisturbed.
-- Added calculations for Appraisal texts
-- Added AppraisalHelper parameterized Tests
-- Added Appraisal checkbox calculations

**Known issue:** 
-- Clipboard module doesn't use new calculation, this can be fixed in adding Appraisal selected variable to _ivScanResult_ which I can work on adding at a later time.