### PR TITLE
Add settings to optionally disable clipboard toast

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
+++ b/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
@@ -31,6 +31,7 @@ public class GoIVSettings {
     public static final String GOIV_CLIPBOARDSINGLESETTINGS = "GoIV_ClipboardSingleSettings";
     public static final String SHOW_TRANSLATED_POKEMON_NAME = "showTranslatedPokemonName";
     public static final String HAS_WARNED_USER_NO_SCREENREC = "GOIV_hasWarnedUserNoScreenRec";
+    public static final String COPY_TO_CLIPBOARD_SHOW_TOAST = "copyToClipboardShowToast";
 
     private static GoIVSettings instance;
     private final SharedPreferences prefs;
@@ -157,5 +158,9 @@ public class GoIVSettings {
             return prefs.getBoolean(SHOW_TRANSLATED_POKEMON_NAME, false);
         }
         return false;
+    }
+
+    public boolean shouldCopyToClipboardShowToast() {
+        return prefs.getBoolean(COPY_TO_CLIPBOARD_SHOW_TOAST, true);
     }
 }

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1308,10 +1308,12 @@ public class Pokefly extends Service {
                 clipResult = cth.getResults(ivScanResult, pokeInfoCalculator, false);
             }
 
-            Toast toast = Toast.makeText(this, String.format(getString(R.string.clipboard_copy_toast), clipResult),
-                    Toast.LENGTH_SHORT);
-            toast.setGravity(Gravity.CENTER, 0, 0);
-            toast.show();
+            if (settings.shouldCopyToClipboardShowToast()) {
+                Toast toast = Toast.makeText(this, String.format(getString(R.string.clipboard_copy_toast), clipResult),
+                        Toast.LENGTH_SHORT);
+                toast.setGravity(Gravity.CENTER, 0, 0);
+                toast.show();
+            }
 
             ClipData clip = ClipData.newPlainText(clipResult, clipResult);
             clipboard.setPrimaryClip(clip);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,4 +164,6 @@
     <string name="copy_to_clipboard_setting_key">copyToClipboard</string>
     <string name="manual_screenshot_mode_key">manualScreenshotMode</string>
     <string name="android_sub5_warning">GoIV has detected that your phone does not have the MediaProjection API, which is used to automatically show the IV scan button. This might be fixed by updating your phone to Android 5 or above. The app will lock itself to screenshot mode to avoid crashing. You can use GoIV by manually triggering a screenshot, which most devices does by holding home+power for a short duration. We apologize for the inconvenience.</string>
+    <string name="copy_to_clip_show_toast_setting_summary">Show a preview of what is copied to the clipboard in a small popup</string>
+    <string name="copy_to_clip_show_toast_setting">Show clipboard preview popup</string>
 </resources>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -44,6 +44,13 @@
             android:summary="@string/copy_to_clip_single_setting_summary"
             android:title="@string/copy_to_clip_single_setting"/>
 
+        <SwitchPreference
+            android:defaultValue="true"
+            android:dependency="@string/copy_to_clipboard_setting_key"
+            android:key="copyToClipboardShowToast"
+            android:summary="@string/copy_to_clip_show_toast_setting_summary"
+            android:title="@string/copy_to_clip_show_toast_setting"/>
+
         <Preference
             android:dependency="@string/copy_to_clipboard_setting_key"
             android:key="@string/clipboardButton"


### PR DESCRIPTION
The toast message gets annoying when checking IVs after a day of catching.

The default is still to show the toast like it used to be.