### PR TITLE
Fixed spelling of Misdreavus and syntax of XML

### DIFF
--- a/app/src/main/res/values/pokemons.xml
+++ b/app/src/main/res/values/pokemons.xml
@@ -159,10 +159,10 @@
         <item>Meganium</item>
         <item>Cyndaquil</item>
         <item>Quilava</item>
-        <item>Typhlosio</item>n
+        <item>Typhlosio</item>
         <item>Totodile</item>
         <item>Croconaw</item>
-        <item>Feraligat</item>r
+        <item>Feraligat</item>
         <item>Sentret</item>
         <item>Furret</item>
         <item>Hoothoot</item>
@@ -202,12 +202,12 @@
         <item>Umbreon</item>
         <item>Murkrow</item>
         <item>Slowking</item>
-        <item>Misdreavu</item>s
+        <item>Misdreavus</item>
         <item>Unown</item>
         <item>Wobbuffet</item>
         <item>Girafarig</item>
         <item>Pineco</item>
-        <item>Forretres</item>s
+        <item>Forretres</item>
         <item>Dunsparce</item>
         <item>Gligar</item>
         <item>Steelix</item>


### PR DESCRIPTION
Misdreavus was missing the final "s".
Lines 162, 165, 205 & 210 had extra characters outside of the <item></item> tags.