### PR TITLE
New MixedUnicodeToken for copy to clipboard

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/clipboard/ClipboardTokenCollection.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboard/ClipboardTokenCollection.java
@@ -14,6 +14,7 @@ import com.kamron.pogoiv.clipboard.tokens.PokemonNameToken;
 import com.kamron.pogoiv.clipboard.tokens.PowerupsToMaxToken;
 import com.kamron.pogoiv.clipboard.tokens.SeparatorToken;
 import com.kamron.pogoiv.clipboard.tokens.UnicodeToken;
+import com.kamron.pogoiv.clipboard.tokens.MixedUnicodeToken;
 
 import java.util.ArrayList;
 
@@ -85,6 +86,8 @@ public class ClipboardTokenCollection {
         //Unicode iv representations
         tokens.add(new UnicodeToken(false)); //Unicode iv circled numbers not filled in ex ⑦⑦⑦
         tokens.add(new UnicodeToken(true));//Unicode iv circled numbers  filled in black ex ⓿⓿⓿
+        tokens.add(new MixedUnicodeToken(false)); //Mixed Unicode IV circled numbers, empty exact, filled multiple ex ⑦⓿⑦
+        tokens.add(new MixedUnicodeToken(true)); //Mixed Unicode IV circled numbers, filled exact, empty multiple ex ⓿⓿⑦
         tokens.add(new HexIVToken()); //hex representation of iv (ex A4B)
         /////////////////////////////////////////////////////////
 

--- a/app/src/main/java/com/kamron/pogoiv/clipboard/ClipboardTokenCollection.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboard/ClipboardTokenCollection.java
@@ -86,8 +86,8 @@ public class ClipboardTokenCollection {
         //Unicode iv representations
         tokens.add(new UnicodeToken(false)); //Unicode iv circled numbers not filled in ex ⑦⑦⑦
         tokens.add(new UnicodeToken(true));//Unicode iv circled numbers  filled in black ex ⓿⓿⓿
-        tokens.add(new MixedUnicodeToken(false)); //Mixed Unicode IV circled numbers, empty exact, filled multiple ex ⑦⓿⑦
-        tokens.add(new MixedUnicodeToken(true)); //Mixed Unicode IV circled numbers, filled exact, empty multiple ex ⓿⓿⑦
+        tokens.add(new MixedUnicodeToken(false)); //Mixed Unicode IV, empty exact, filled multiple ex ⑦⓿⑦
+        tokens.add(new MixedUnicodeToken(true)); //Mixed Unicode IV, filled exact, empty multiple ex ⓿⓿⑦
         tokens.add(new HexIVToken()); //hex representation of iv (ex A4B)
         /////////////////////////////////////////////////////////
 

--- a/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/MixedUnicodeToken.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/MixedUnicodeToken.java
@@ -1,0 +1,121 @@
+package com.kamron.pogoiv.clipboard.tokens;
+
+import android.content.Context;
+
+import com.kamron.pogoiv.clipboard.ClipboardToken;
+import com.kamron.pogoiv.logic.IVCombination;
+import com.kamron.pogoiv.logic.IVScanResult;
+import com.kamron.pogoiv.logic.PokeInfoCalculator;
+
+/**
+ * Copied from UnicodeToken created by Johan on 2016-09-25.
+ * MixedUnicodeToken created by TripSixes on 2017-01-12
+ * Represents the lowest possible IV combination with ⓪①②③④⑤⑥⑦⑧⑨⑩⑪⑫⑬⑭⑮, but also
+ * mixes the filled and non-filled characters depending on if there are multiple or single of
+ * a given IV Result list.
+ */
+
+public class MixedUnicodeToken extends ClipboardToken {
+    private String[] unicode_0_15 = {"⓪", "①", "②", "③", "④", "⑤", "⑥", "⑦", "⑧", "⑨", "⑩", "⑪", "⑫", "⑬", "⑭", "⑮"};
+    private String[] unicode_0_15filled = {"⓿", "❶", "❷", "❸", "❹", "❺", "❻", "❼", "❽", "❾", "❿", "⓫", "⓬", "⓭", "⓮", "⓯"};
+    private boolean filled;
+
+    /**
+     * Define which of the unicode character sets is the "default" set.  In this token, the default
+     * set will be the one that is used for single-result values.  The Non-default unicode character
+     * set will be used for multi-result values (showing lowest)
+     * @param filled boolean indicating user preference for exact-match characters.
+     */
+    public MixedUnicodeToken(boolean filled) {
+        super(false);
+        this.filled = filled;
+    }
+
+    @Override
+    public int getMaxLength() {
+        return 3;
+    }
+
+    @Override
+    public String getValue(IVScanResult ivScanResult, PokeInfoCalculator pokeInfoCalculator) {
+        //Get the absolute lowest stats for each att/def/sta
+        IVCombination lowest = ivScanResult.getAbsoluteLowestStats();
+        //Get the absolute highest stats for each att/def/sta
+        IVCombination highest = ivScanResult.getAbsoluteHighestStats();
+
+        if ((lowest == null) || (highest == null)) {
+            return "";
+        }
+
+        String[] attToUse;
+        String[] defToUse;
+        String[] staToUse;
+
+        if (filled) {
+            attToUse = (lowest.att == highest.att) ? unicode_0_15filled : unicode_0_15;
+            defToUse = (lowest.def == highest.def) ? unicode_0_15filled : unicode_0_15;
+            staToUse = (lowest.sta == highest.sta) ? unicode_0_15filled : unicode_0_15;
+        }
+        else {
+            attToUse = (lowest.att == highest.att) ? unicode_0_15 : unicode_0_15filled;
+            defToUse = (lowest.def == highest.def) ? unicode_0_15 : unicode_0_15filled;
+            staToUse = (lowest.sta == highest.sta) ? unicode_0_15 : unicode_0_15filled;
+        }
+
+        //We still need to get thew lowest combination when showing the final result, but this time
+        //each unicode character will be filled or empty depending on whether multiple or exact values
+        //were calculated for each stat.
+        IVCombination lowestIVCombination = ivScanResult.getLowestIVCombination();
+        if (lowestIVCombination == null) {
+            return "";
+        }
+
+        return attToUse[lowestIVCombination.att] +
+                defToUse[lowestIVCombination.def] +
+                staToUse[lowestIVCombination.sta];
+
+    }
+
+    @Override
+    public String getStringRepresentation() {
+        return super.getStringRepresentation() + String.valueOf(filled);
+    }
+
+    @Override
+    public String getPreview() {
+        return filled ? "❾⑫①" : "⑨⓬❶";
+    }
+
+    @Override
+    public String getTokenName(Context context) {
+        return "UIV-mixed";
+    }
+
+    @Override
+    public String getLongDescription(Context context) {
+        String returner = "Similar to UIV, UNICODE circular numbers are used to represent IV.";
+
+        if (filled) {
+            returner += " This token uses filled characters to represent single values and empty characters "
+                    + "to represent the lowest of multiple values. For example, ⓭ in the attack position would "
+                    + "mean that all Attack values are 13, while ① in the defense or HP means there are "
+                    + "multiple values possible and that 1 is the lowest.";
+        } else {
+            returner += " This token uses empty characters to represent single values and filled characters "
+                    + "to represent the lowest of multiple values. For example, ⑪ in the attack position would "
+                    + "mean that all Attack values are 11, while ❾ in the defense or HP means there are "
+                    + "multiple values possible and that 9 is the lowest.";
+        }
+        return returner;
+    }
+
+    @Override
+    public String getCategory() {
+        return "IV Info";
+    }
+
+    @Override
+    public boolean changesOnEvolutionMax() {
+        return false;
+    }
+}

--- a/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/MixedUnicodeToken.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/MixedUnicodeToken.java
@@ -16,8 +16,10 @@ import com.kamron.pogoiv.logic.PokeInfoCalculator;
  */
 
 public class MixedUnicodeToken extends ClipboardToken {
-    private String[] unicode_0_15 = {"⓪", "①", "②", "③", "④", "⑤", "⑥", "⑦", "⑧", "⑨", "⑩", "⑪", "⑫", "⑬", "⑭", "⑮"};
-    private String[] unicode_0_15filled = {"⓿", "❶", "❷", "❸", "❹", "❺", "❻", "❼", "❽", "❾", "❿", "⓫", "⓬", "⓭", "⓮", "⓯"};
+    private String[] unicode_0_15 = {"⓪", "①", "②", "③", "④", "⑤", "⑥", "⑦",
+                                     "⑧", "⑨", "⑩", "⑪", "⑫", "⑬", "⑭", "⑮"};
+    private String[] unicode_0_15filled = {"⓿", "❶", "❷", "❸", "❹", "❺", "❻", "❼",
+                                           "❽", "❾", "❿", "⓫", "⓬", "⓭", "⓮", "⓯"};
     private boolean filled;
 
     /**
@@ -55,8 +57,7 @@ public class MixedUnicodeToken extends ClipboardToken {
             attToUse = (lowest.att == highest.att) ? unicode_0_15filled : unicode_0_15;
             defToUse = (lowest.def == highest.def) ? unicode_0_15filled : unicode_0_15;
             staToUse = (lowest.sta == highest.sta) ? unicode_0_15filled : unicode_0_15;
-        }
-        else {
+        } else {
             attToUse = (lowest.att == highest.att) ? unicode_0_15 : unicode_0_15filled;
             defToUse = (lowest.def == highest.def) ? unicode_0_15 : unicode_0_15filled;
             staToUse = (lowest.sta == highest.sta) ? unicode_0_15 : unicode_0_15filled;
@@ -70,9 +71,9 @@ public class MixedUnicodeToken extends ClipboardToken {
             return "";
         }
 
-        return attToUse[lowestIVCombination.att] +
-                defToUse[lowestIVCombination.def] +
-                staToUse[lowestIVCombination.sta];
+        return attToUse[lowestIVCombination.att]
+                + defToUse[lowestIVCombination.def]
+                + staToUse[lowestIVCombination.sta];
 
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/logic/IVScanResult.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/IVScanResult.java
@@ -32,12 +32,6 @@ public class IVScanResult {
     public int highAttack = 0;
     public int highDefense = 0;
     public int highStamina = 0;
-    int lowestAttackStat = 15;
-    int lowestDefenseStat = 15;
-    int lowestStaminaStat = 15;
-    int highestAttackStat = 0;
-    int highestDefenseStat = 0;
-    int highestStaminaStat = 0;
     public final int scannedCP;
     public ArrayList<IVCombination> iVCombinations = new ArrayList<>();
     public Pokemon pokemon = null;
@@ -123,28 +117,6 @@ public class IVScanResult {
             highStamina = staminaIV;
         }
 
-        // Save the lowest and highest attackIV of any Combination
-        if (attackIV < lowestAttackStat) {
-            lowestAttackStat = attackIV;
-        }
-        if (attackIV > highestAttackStat) {
-            highestAttackStat = attackIV;
-        }
-        // Save the lowest and highest defenseIV of any Combination
-        if (defenseIV < lowestDefenseStat) {
-            lowestDefenseStat = defenseIV;
-        }
-        if (defenseIV > highestDefenseStat) {
-            highestDefenseStat = defenseIV;
-        }
-        // Save the lowest and highest staminaIV of any Combination
-        if (staminaIV < lowestStaminaStat) {
-            lowestStaminaStat = staminaIV;
-        }
-        if (staminaIV > highestStaminaStat) {
-            highestStaminaStat = staminaIV;
-        }
-
         iVCombinations.add(new IVCombination(attackIV, defenseIV, staminaIV));
     }
 
@@ -184,27 +156,6 @@ public class IVScanResult {
     public IVCombination getCombinationLowIVs() {
         return new IVCombination(lowAttack, lowDefense, lowStamina);
     }
-
-    /**
-     * Return the list of the absolute lowest of each of the three statistics.  This set does not
-     * represent a valid IVCombination, since each of the values returned may not have came from
-     * the same IV Combination, or the LowestIVCombination for that matter.
-     * @return an array representing the lowest of each stat, regardless of combination
-     */
-    public IVCombination getAbsoluteLowestStats() {
-        return new IVCombination(lowestAttackStat, lowestDefenseStat, lowestStaminaStat);
-    }
-
-    /**
-     * Return the list of the absolute highest of each of the three statistics.  This set does not
-     * represent a valid IVCombination, since each of the values returned may not have came from
-     * the same IV Combination, or the HighestIVCombination for that matter
-     * @return an array representing the highest of each stat, regardless of combination
-     */
-    public IVCombination getAbsoluteHighestStats() {
-        return new IVCombination(highestAttackStat, highestDefenseStat, highestStaminaStat);
-    }
-
 
     /**
      * Removes all possible IV combinations where the boolean set to true stat isnt the highest.

--- a/app/src/main/java/com/kamron/pogoiv/logic/IVScanResult.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/IVScanResult.java
@@ -32,6 +32,12 @@ public class IVScanResult {
     public int highAttack = 0;
     public int highDefense = 0;
     public int highStamina = 0;
+    int lowestAttackStat = 15;
+    int lowestDefenseStat = 15;
+    int lowestStaminaStat = 15;
+    int highestAttackStat = 0;
+    int highestDefenseStat = 0;
+    int highestStaminaStat = 0;
     public final int scannedCP;
     public ArrayList<IVCombination> iVCombinations = new ArrayList<>();
     public Pokemon pokemon = null;
@@ -117,6 +123,27 @@ public class IVScanResult {
             highStamina = staminaIV;
         }
 
+        // Save the lowest and highest attackIV of any Combination
+        if (attackIV < lowestAttackStat) {
+            lowestAttackStat = attackIV;
+        }
+        if (attackIV > highestAttackStat) {
+            highestAttackStat = attackIV;
+        }
+        // Save the lowest and highest defenseIV of any Combination
+        if (defenseIV < lowestDefenseStat) {
+            lowestDefenseStat = defenseIV;
+        }
+        if (defenseIV > highestDefenseStat) {
+            highestDefenseStat = defenseIV;
+        }
+        // Save the lowest and highest staminaIV of any Combination
+        if (staminaIV < lowestStaminaStat) {
+            lowestStaminaStat = staminaIV;
+        }
+        if (staminaIV > highestStaminaStat) {
+            highestStaminaStat = staminaIV;
+        }
 
         iVCombinations.add(new IVCombination(attackIV, defenseIV, staminaIV));
     }
@@ -157,6 +184,27 @@ public class IVScanResult {
     public IVCombination getCombinationLowIVs() {
         return new IVCombination(lowAttack, lowDefense, lowStamina);
     }
+
+    /**
+     * Return the list of the absolute lowest of each of the three statistics.  This set does not
+     * represent a valid IVCombination, since each of the values returned may not have came from
+     * the same IV Combination, or the LowestIVCombination for that matter.
+     * @return an array representing the lowest of each stat, regardless of combination
+     */
+    public IVCombination getAbsoluteLowestStats() {
+        return new IVCombination(lowestAttackStat, lowestDefenseStat, lowestStaminaStat);
+    }
+
+    /**
+     * Return the list of the absolute highest of each of the three statistics.  This set does not
+     * represent a valid IVCombination, since each of the values returned may not have came from
+     * the same IV Combination, or the HighestIVCombination for that matter
+     * @return an array representing the highest of each stat, regardless of combination
+     */
+    public IVCombination getAbsoluteHighestStats() {
+        return new IVCombination(highestAttackStat, highestDefenseStat, highestStaminaStat);
+    }
+
 
     /**
      * Removes all possible IV combinations where the boolean set to true stat isnt the highest.


### PR DESCRIPTION
The new MixedUnicodeToken is intended to be have exactly as the
original UnicodeToken, except that the filled vs. empty unicode
characters are now used to indicate exact or multiple values for each
 stat.

 For example, if CheckIV returns multiple results, this token will
 look at each stat individually to determine if each one only has 1
 possible value or multiple. (ie: Attack 11-12, Defense 9-11, and HP
 only has 13 for all combinations... this would result in Attack and
 Defense being one unicode character set and HP being the other.

 When modifying the clipboard settings, the trainer may select whether
 they wish for the "empty" to represent exact values or the "filled"
 to represent exact values.

 This provides a bit more clarity to the UIV value without adding any
  extra characters in the process.
(cherry picked from commit ecd2658)