### PR TITLE
Show diff max cp

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1556,14 +1556,14 @@ public class Pokefly extends Service {
         double maxCP = pokeInfoCalculator.getCpRangeAtLevel(selectedPokemon,
                 IVCombination.MAX, IVCombination.MAX, 40).high;
         double perfection = (100.0 * cpRange.getFloatingAvg()) / maxCP;
-        int difference = (int)(cpRange.getFloatingAvg() - maxCP);
+        int difference = (int) (cpRange.getFloatingAvg() - maxCP);
         DecimalFormat df = new DecimalFormat("#.#");
         String sign = "";
         if (difference >= 0) {
             sign = "+";
         }
         String differenceString = "(" + sign + difference + ")";
-        String perfectionString = df.format(perfection) + "% "  + differenceString;
+        String perfectionString = df.format(perfection) + "% " + differenceString;
         exResultPercentPerfection.setText(perfectionString);
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1556,8 +1556,14 @@ public class Pokefly extends Service {
         double maxCP = pokeInfoCalculator.getCpRangeAtLevel(selectedPokemon,
                 IVCombination.MAX, IVCombination.MAX, 40).high;
         double perfection = (100.0 * cpRange.getFloatingAvg()) / maxCP;
+        int difference = (int)(cpRange.getFloatingAvg() - maxCP);
         DecimalFormat df = new DecimalFormat("#.#");
-        String perfectionString = df.format(perfection) + "%";
+        String sign = "";
+        if (difference >= 0) {
+            sign = "+";
+        }
+        String differenceString = "(" + sign + difference + ")";
+        String perfectionString = df.format(perfection) + "% "  + differenceString;
         exResultPercentPerfection.setText(perfectionString);
     }
 


### PR DESCRIPTION
Adds in parenthesis to %CP vs max IV how much cp is actually less than max, so for example, if you have a pokemon which will max out at 900 cp, but a perfect iv would max out at 1000, the row would now say:

% CP vs max IV(?)  90.0% (-100)

suggested in #629 