### PR TITLE
Stop pokefly service on destroy of main activity

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -507,8 +507,9 @@ public class MainActivity extends AppCompatActivity {
             if (screen != null) {
                 screen.exit();
             }
+        } else { // If Pokefly is not running, we probably have a Paused Notification to clear away
+            Pokefly.cancelNotification();
         }
-        // TODO: What if !Pokefly.isRunning()
         super.onDestroy();
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -501,6 +501,14 @@ public class MainActivity extends AppCompatActivity {
         LocalBroadcastManager.getInstance(this).unregisterReceiver(pokeflyStateChanged);
         LocalBroadcastManager.getInstance(this).unregisterReceiver(showUpdateDialog);
         LocalBroadcastManager.getInstance(this).unregisterReceiver(restartPokeFly);
+
+        if (Pokefly.isRunning()) {
+            stopService(new Intent(MainActivity.this, Pokefly.class));
+            if (screen != null) {
+                screen.exit();
+            }
+        }
+        // TODO: What if !Pokefly.isRunning()
         super.onDestroy();
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -137,6 +137,7 @@ public class Pokefly extends Service {
     private ScreenShotHelper screenShotHelper;
     private OcrHelper ocr;
     private GoIVSettings settings;
+    private static NotificationManager mNotifyMgr;
 
     private Point[] area = new Point[2];
 
@@ -706,10 +707,17 @@ public class Pokefly extends Service {
                     .setPriority(Notification.PRIORITY_HIGH)
                     .build();
 
-            NotificationManager mNotifyMgr =
+            mNotifyMgr =
                     (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
             mNotifyMgr.notify(NOTIFICATION_REQ_CODE, notification);
         }
+    }
+
+    /**
+     * Cancel the previously generated notification by Pokefly.
+     */
+    public static void cancelNotification() {
+        mNotifyMgr.cancel(NOTIFICATION_REQ_CODE);
     }
 
     /**


### PR DESCRIPTION
Implements the stopping of the Pokefly service if the user swipes the MainActivity away from the Recent Apps screen.

These changes resolve #631