### PR TITLE
Prevent trainer level number picker from obtaining focus

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -34,6 +34,7 @@
             android:layout_height="100dp"
             android:gravity="end"
             android:inputType="number"
+            android:descendantFocusability="blocksDescendants"
             android:textAlignment="center"/>
 
         <Spinner


### PR DESCRIPTION
Removing the ability for the numbers within the trainer level picker
from being selected.  Sometimes this would additionally cause the
Android Cut/Copy/Paste menu to appear on screen.

Using blockDescendants prevents the numbers from being selected or
edited directly.
(cherry picked from commit e9d5cf1)