### PR TITLE
Fix a few auto appraisal phrases for more accuracy

### DIFF
--- a/app/src/main/res/values/appraisals.xml
+++ b/app/src/main/res/values/appraisals.xml
@@ -16,18 +16,18 @@
     <string name="mystic_ivrange1_phrase1">calculations</string>
     <string name="mystic_ivrange1_phrase2">incredible</string>
     <string name="mystic_ivrange2_phrase1">impressed</string>
-    <string name="mystic_ivrange2_phrase2">stats</string>
+    <string name="mystic_ivrange2_phrase2">must</string>
     <string name="mystic_ivrange3_phrase1">noticeably</string>
     <string name="mystic_ivrange3_phrase2">trending</string>
     <string name="mystic_ivrange4_phrase1">norm</string>
-    <string name="mystic_ivrange4_phrase2">opinion</string>
+    <string name="mystic_ivrange4_phrase2">estimation</string>
 
     <string name="valor_percentage1_phrase1">amazes</string>
     <string name="valor_percentage1_phrase2">accomplish</string>
     <string name="valor_percentage2_phrase1">strong</string>
     <string name="valor_percentage2_phrase2">proud</string>
     <string name="valor_percentage3_phrase1">decent</string>
-    <string name="valor_percentage3_phrase2">no_value</string>
+    <string name="valor_percentage3_phrase2">decent</string><!-- no other possible phrase -->
     <string name="valor_percentage4_phrase1">great</string>
     <string name="valor_percentage4_phrase2">still</string>
 
@@ -43,7 +43,7 @@
     <string name="instinct_percentage1_phrase1">battle</string>
     <string name="instinct_percentage1_phrase2">best</string>
     <string name="instinct_percentage2_phrase1">strong</string>
-    <string name="instinct_percentage2_phrase2">no_value</string>
+    <string name="instinct_percentage2_phrase2">strong</string><!-- no other possible phrase -->
     <string name="instinct_percentage3_phrase1">pretty</string>
     <string name="instinct_percentage3_phrase2">decent</string>
     <string name="instinct_percentage4_phrase1">improvement</string>


### PR DESCRIPTION
mystic_ivrange2_phrase2 used the word "stats" which shows up multiple
 times in other phrases.  Changed to "must" to improve accuracy.

mystic_ivrange4_phrase2 used "opinion" but it appears to have changed
to "estimation" since the appraisal feature was released.

There are 2 other phrases in which no appropriate value can be
selected as a 2nd phrase.  Updating the values to align with the
technique (repeat first phrase/word) and comment style from 
values-de/appraisals.xml