### PR TITLE
Add alternate "white" for pixels[0] location

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -572,7 +572,8 @@ public class Pokefly extends Service {
 
         if (pixels != null) {
             boolean shouldShow =
-                    pixels[0] == Color.rgb(250, 250, 250) && pixels[1] == Color.rgb(28, 135, 150);
+                    ( pixels[0] == Color.rgb(250, 250, 250) || pixels[0] == Color.rgb(249, 249, 249) )
+                            && pixels[1] == Color.rgb(28, 135, 150);
             setIVButtonDisplay(shouldShow);
             return shouldShow;
         }


### PR DESCRIPTION
A screenshot submitted in issue #635 seemed to indicate that some
phones might display the white area of the Pokemon screen in more than
one color of white.  Specifically, that screenshot had #fafafa and #f9f9f9.

Adding the alternative color observed, rgb(249,249,249).