### PR TITLE
Remove cancelNotification, add TODO for proper implementation later

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -507,9 +507,8 @@ public class MainActivity extends AppCompatActivity {
             if (screen != null) {
                 screen.exit();
             }
-        } else { // If Pokefly is not running, we probably have a Paused Notification to clear away
-            Pokefly.cancelNotification();
         }
+        //TODO: if !Pokefly.isRunning(), clear the "paused" notification
         super.onDestroy();
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -724,13 +724,6 @@ public class Pokefly extends Service {
     }
 
     /**
-     * Cancel the previously generated notification by Pokefly.
-     */
-    public static void cancelNotification() {
-        mNotifyMgr.cancel(NOTIFICATION_REQ_CODE);
-    }
-
-    /**
      * Undeprecated version of getDrawable using the most appropriate underlying API.
      *
      * @param id ID of drawable to get


### PR DESCRIPTION
The previously added and merged cancelNotification didn't seem to
work as intended, and caused a GoIV crash when the user pressed the
Back button from the main GoIV screen.  Replaced with a TODO for
further investigation and proper implementation at a later date.