### PR TITLE
Refines logic for matching appraisal phrases and updates for Valor/Instinct

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/AutoAppraisal.java
+++ b/app/src/main/java/com/kamron/pogoiv/AutoAppraisal.java
@@ -148,10 +148,7 @@ public class AutoAppraisal {
      * @param hash the hash of the bitmap used by ocr
      */
     private void addInfoFromAppraiseText(String appraiseText, String hash) {
-        boolean match = false;
-        if (appraisalRangeGroup.getCheckedRadioButtonId() == -1) {
-            match = setIVRangeWith(appraiseText);
-        }
+        boolean match = setIVRangeWith(appraiseText);
         if (!match) {
             match = setHighestStatsWith(appraiseText);
         }

--- a/app/src/main/java/com/kamron/pogoiv/AutoAppraisal.java
+++ b/app/src/main/java/com/kamron/pogoiv/AutoAppraisal.java
@@ -148,7 +148,10 @@ public class AutoAppraisal {
      * @param hash the hash of the bitmap used by ocr
      */
     private void addInfoFromAppraiseText(String appraiseText, String hash) {
-        boolean match = setIVRangeWith(appraiseText);
+        boolean match = false;
+        if (appraisalRangeGroup.getCheckedRadioButtonId() == -1) {
+            match = setIVRangeWith(appraiseText);
+        }
         if (!match) {
             match = setHighestStatsWith(appraiseText);
         }

--- a/app/src/main/res/values/appraisals.xml
+++ b/app/src/main/res/values/appraisals.xml
@@ -24,11 +24,11 @@
 
     <string name="valor_percentage1_phrase1">amazes</string>
     <string name="valor_percentage1_phrase2">accomplish</string>
-    <string name="valor_percentage2_phrase1">strong</string>
+    <string name="valor_percentage2_phrase1">strong </string><!-- "strongest" in stats -->
     <string name="valor_percentage2_phrase2">proud</string>
     <string name="valor_percentage3_phrase1">decent</string>
     <string name="valor_percentage3_phrase2">decent</string><!-- no other possible phrase -->
-    <string name="valor_percentage4_phrase1">great</string>
+    <string name="valor_percentage4_phrase1">great </string><!-- "greatness" in stats rank -->
     <string name="valor_percentage4_phrase2">still</string>
 
     <string name="valor_ivrange1_phrase1">blown</string>
@@ -41,7 +41,7 @@
     <string name="valor_ivrange4_phrase2">greatness</string>
 
     <string name="instinct_percentage1_phrase1">battle</string>
-    <string name="instinct_percentage1_phrase2">best</string>
+    <string name="instinct_percentage1_phrase2">best of</string><!-- Spark says best too much -->
     <string name="instinct_percentage2_phrase1">strong</string>
     <string name="instinct_percentage2_phrase2">strong</string><!-- no other possible phrase -->
     <string name="instinct_percentage3_phrase1">pretty</string>

--- a/app/src/main/res/values/appraisals.xml
+++ b/app/src/main/res/values/appraisals.xml
@@ -42,8 +42,8 @@
 
     <string name="instinct_percentage1_phrase1">battle</string>
     <string name="instinct_percentage1_phrase2">best of</string><!-- Spark says best too much -->
-    <string name="instinct_percentage2_phrase1">strong</string>
-    <string name="instinct_percentage2_phrase2">strong</string><!-- no other possible phrase -->
+    <string name="instinct_percentage2_phrase1">is really strong</string>
+    <string name="instinct_percentage2_phrase2">is really strong</string><!-- no other phrase -->
     <string name="instinct_percentage3_phrase1">pretty</string>
     <string name="instinct_percentage3_phrase2">decent</string>
     <string name="instinct_percentage4_phrase1">improvement</string>
@@ -51,7 +51,7 @@
 
     <string name="instinct_ivrange1_phrase1">best</string>
     <string name="instinct_ivrange1_phrase2">doubt</string>
-    <string name="instinct_ivrange2_phrase1">strong</string>
+    <string name="instinct_ivrange2_phrase1">stats are really</string>
     <string name="instinct_ivrange2_phrase2">impressive</string>
     <string name="instinct_ivrange3_phrase1">definitely</string>
     <string name="instinct_ivrange3_phrase2">good</string>


### PR DESCRIPTION
Instinct appraisal phrases use the word "best" quite often.  Due to
this, addInfoFromAppraisalText is updated to only try to match
IVRange when appraisalRangeGroup is not already checked. Also change
"best" to "best of" in instinct_percentage1_phrase2.
-- Tested with Instinct account and all matches seem to be accurate now.

In addition, some match-words for Valor are subsets of other words
(strong/strongest, great/greatness).  This change adds a space after
strong and great so as to prevent matching strongest/greatness.
-- Has not actually been tested against a live Valor account yet.