### PR TITLE
Service lives

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -501,14 +501,6 @@ public class MainActivity extends AppCompatActivity {
         LocalBroadcastManager.getInstance(this).unregisterReceiver(pokeflyStateChanged);
         LocalBroadcastManager.getInstance(this).unregisterReceiver(showUpdateDialog);
         LocalBroadcastManager.getInstance(this).unregisterReceiver(restartPokeFly);
-
-        if (Pokefly.isRunning()) {
-            stopService(new Intent(MainActivity.this, Pokefly.class));
-            if (screen != null) {
-                screen.exit();
-            }
-        }
-        // TODO: What if !Pokefly.isRunning()
         super.onDestroy();
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/MainActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/MainActivity.java
@@ -508,7 +508,7 @@ public class MainActivity extends AppCompatActivity {
                 screen.exit();
             }
         }
-        //TODO: if !Pokefly.isRunning(), clear the "paused" notification
+        // TODO: What if !Pokefly.isRunning()
         super.onDestroy();
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -137,7 +137,6 @@ public class Pokefly extends Service {
     private ScreenShotHelper screenShotHelper;
     private OcrHelper ocr;
     private GoIVSettings settings;
-    private static NotificationManager mNotifyMgr;
 
     private Point[] area = new Point[2];
 
@@ -717,7 +716,7 @@ public class Pokefly extends Service {
                     .setPriority(Notification.PRIORITY_HIGH)
                     .build();
 
-            mNotifyMgr =
+            NotificationManager mNotifyMgr =
                     (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
             mNotifyMgr.notify(NOTIFICATION_REQ_CODE, notification);
         }


### PR DESCRIPTION
I don't think the Pokefly service should be killed when the activity is killed. It doesn't work well for mid/low tier phones. It also goes against the general app behavior expectations.