### PR TITLE
Adjust appraisal input window padding to reduce vertical height

### DIFF
--- a/app/src/main/res/layout/dialog_input.xml
+++ b/app/src/main/res/layout/dialog_input.xml
@@ -214,7 +214,7 @@
     </LinearLayout>
 
     <include layout="@layout/dialog_input_appraisal"
-        android:visibility="visible"
+        android:visibility="gone"
         android:id="@+id/appraisalBox"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_input.xml
+++ b/app/src/main/res/layout/dialog_input.xml
@@ -148,7 +148,7 @@
 
     <Space
         android:layout_width="match_parent"
-        android:layout_height="10dp"/>
+        android:layout_height="2dp"/>
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -207,14 +207,14 @@
             android:paddingTop="0dp"
             android:paddingLeft="8dp"
             android:paddingRight="60dp"
-            android:paddingBottom="16dp"
+            android:paddingBottom="4dp"
             android:drawableRight="@drawable/ic_keyboard_arrow_right_blue_18dp"
             android:textSize="18sp"
             android:layout_gravity="center" />
     </LinearLayout>
 
     <include layout="@layout/dialog_input_appraisal"
-        android:visibility="gone"
+        android:visibility="visible"
         android:id="@+id/appraisalBox"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_input.xml
+++ b/app/src/main/res/layout/dialog_input.xml
@@ -207,10 +207,11 @@
             android:paddingTop="0dp"
             android:paddingLeft="8dp"
             android:paddingRight="60dp"
-            android:paddingBottom="4dp"
+            android:paddingBottom="0dp"
             android:drawableRight="@drawable/ic_keyboard_arrow_right_blue_18dp"
             android:textSize="18sp"
-            android:layout_gravity="center" />
+            android:layout_gravity="center"
+            android:layout_marginBottom="6dp"/>
     </LinearLayout>
 
     <include layout="@layout/dialog_input_appraisal"

--- a/app/src/main/res/layout/dialog_input_appraisal.xml
+++ b/app/src/main/res/layout/dialog_input_appraisal.xml
@@ -14,7 +14,9 @@
         android:layout_height="match_parent"
         android:orientation="horizontal"
         android:id="@+id/appraisalRangeGroup"
-        android:padding="2dp">
+        android:paddingBottom="2dp"
+        android:paddingStart="2dp"
+        android:paddingEnd="2dp">
 
         <RadioButton
             android:textColor="@color/importantText"

--- a/app/src/main/res/layout/dialog_input_appraisal.xml
+++ b/app/src/main/res/layout/dialog_input_appraisal.xml
@@ -5,7 +5,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="12dp">
+    android:layout_marginBottom="4dp">
 
 
 


### PR DESCRIPTION
Padding and Margins of a few key components adjusted so as to reduce
the overall height of the appraisal/input window to ensure that the
"Appraise" option within PokemonGo is visible beneath the Appraisal
Input window.

This is open for further review and discussion as to whether this is the
right way to address this issue.