### PR TITLE
Fix Typhlosion and Feraligatr spelling

### DIFF
--- a/app/src/main/res/values/pokemons.xml
+++ b/app/src/main/res/values/pokemons.xml
@@ -159,10 +159,10 @@
         <item>Meganium</item>
         <item>Cyndaquil</item>
         <item>Quilava</item>
-        <item>Typhlosio</item>
+        <item>Typhlosion</item>
         <item>Totodile</item>
         <item>Croconaw</item>
-        <item>Feraligat</item>
+        <item>Feraligatr</item>
         <item>Sentret</item>
         <item>Furret</item>
         <item>Hoothoot</item>


### PR DESCRIPTION
Added "n" for Typhlosion
Added "r" fpr Feraligatr

Fixes #664