### PR TITLE
Enhance AutoAppraisal sequencing and user experience

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -280,18 +280,20 @@ public class Pokefly extends Service {
 
 
     // Refine by appraisal
-    @BindView(R.id.appraisalRangeGroup)
-    RadioGroup appraisalRangeGroup;
+    @BindView(R.id.appraisalIVRangeGroup)
+    RadioGroup appraisalIVRangeGroup;
 
-    @BindView(R.id.appraisalRange4)
-    RadioButton appraisalRange4;
-    @BindView(R.id.appraisalRange3)
-    RadioButton appraisalRange3;
-    @BindView(R.id.appraisalRange2)
-    RadioButton appraisalRange2;
-    @BindView(R.id.appraisalRange1)
-    RadioButton appraisalRange1;
+    @BindView(R.id.appraisalIVRange4)
+    RadioButton appraisalIVRange4;
+    @BindView(R.id.appraisalIVRange3)
+    RadioButton appraisalIVRange3;
+    @BindView(R.id.appraisalIVRange2)
+    RadioButton appraisalIVRange2;
+    @BindView(R.id.appraisalIVRange1)
+    RadioButton appraisalIVRange1;
 
+    @BindView (R.id.attDefStaLayout)
+    LinearLayout attDefStaLayout;
     @BindView(R.id.attCheckbox)
     CheckBox attCheckbox;
     @BindView(R.id.defCheckbox)
@@ -299,8 +301,8 @@ public class Pokefly extends Service {
     @BindView(R.id.staCheckbox)
     CheckBox staCheckbox;
 
-    @BindView(R.id.appraisalStatGroup)
-    RadioGroup appraisalStatGroup;
+    @BindView(R.id.appraisalStatsGroup)
+    RadioGroup appraisalStatsGroup;
 
     @BindView(R.id.appraisalStat4)
     RadioButton appraisalStat4;
@@ -471,9 +473,9 @@ public class Pokefly extends Service {
             if (!batterySaver) {
                 screen = ScreenGrabber.getInstance();
                 watchScreen();
-                autoAppraisal = new AutoAppraisal(screen, ocr, this,
+                autoAppraisal = new AutoAppraisal(screen, ocr, this, attDefStaLayout,
                         attCheckbox, defCheckbox, staCheckbox,
-                        appraisalRangeGroup, appraisalStatGroup);
+                        appraisalIVRangeGroup, appraisalStatsGroup);
             } else {
                 screenShotHelper = ScreenShotHelper.start(Pokefly.this);
             }
@@ -532,13 +534,19 @@ public class Pokefly extends Service {
         touchView.setOnTouchListener(new View.OnTouchListener() {
             @Override
             public boolean onTouch(View v, MotionEvent event) {
-                if (event.getActionMasked() == MotionEvent.ACTION_OUTSIDE) {
-                    screenScanHandler.removeCallbacks(screenScanRunnable);
-                    screenScanHandler.postDelayed(screenScanRunnable, SCREEN_SCAN_DELAY_MS);
-                    screenScanRetries = SCREEN_SCAN_RETRIES;
-
+                if (event.getActionMasked() == MotionEvent.ACTION_OUTSIDE) { // Touch event outside of GoIV UI
+                    // Let's check first to see if the user is performing an Appraisal
                     if (!batterySaver && appraisalBox.getVisibility() == View.VISIBLE) {
+                        // Let autoAppraisal know that the user has touched the PokemonGo app while the
+                        // appraisalBox was Visible.  This is our indication that the user has started a Pogo appraisal
                         autoAppraisal.screenTouched();
+                    } else {
+                        // Not appraising, let's check to see if they're looking at a pokemon screen.
+                        // The postDelayed will wait SCREEN_SCAN_DELAY_MS after the user touches the screen before
+                        // performing a scan of the screen to detect the pixels associated with a Pokemon screen.
+                        screenScanHandler.removeCallbacks(screenScanRunnable);
+                        screenScanHandler.postDelayed(screenScanRunnable, SCREEN_SCAN_DELAY_MS);
+                        screenScanRetries = SCREEN_SCAN_RETRIES;
                     }
                 }
                 return false;
@@ -987,10 +995,10 @@ public class Pokefly extends Service {
 
         //Load the correct phrases from the text resources depending on what team is stored in app settings
         if (settings.playerTeam() == 0) { //mystic
-            appraisalRange4.setText(R.string.mv4);
-            appraisalRange3.setText(R.string.mv3);
-            appraisalRange2.setText(R.string.mv2);
-            appraisalRange1.setText(R.string.mv1);
+            appraisalIVRange4.setText(R.string.mv4);
+            appraisalIVRange3.setText(R.string.mv3);
+            appraisalIVRange2.setText(R.string.mv2);
+            appraisalIVRange1.setText(R.string.mv1);
 
             appraisalStat1.setText(R.string.ms1);
             appraisalStat2.setText(R.string.ms2);
@@ -999,10 +1007,10 @@ public class Pokefly extends Service {
 
         } else if (settings.playerTeam() == 1) { //valor
 
-            appraisalRange4.setText(R.string.vv4);
-            appraisalRange3.setText(R.string.vv3);
-            appraisalRange2.setText(R.string.vv2);
-            appraisalRange1.setText(R.string.vv1);
+            appraisalIVRange4.setText(R.string.vv4);
+            appraisalIVRange3.setText(R.string.vv3);
+            appraisalIVRange2.setText(R.string.vv2);
+            appraisalIVRange1.setText(R.string.vv1);
 
             appraisalStat1.setText(R.string.vs1);
             appraisalStat2.setText(R.string.vs2);
@@ -1010,10 +1018,10 @@ public class Pokefly extends Service {
             appraisalStat4.setText(R.string.vs4);
         } else { //instinct
 
-            appraisalRange4.setText(R.string.iv4);
-            appraisalRange3.setText(R.string.iv3);
-            appraisalRange2.setText(R.string.iv2);
-            appraisalRange1.setText(R.string.iv1);
+            appraisalIVRange4.setText(R.string.iv4);
+            appraisalIVRange3.setText(R.string.iv3);
+            appraisalIVRange2.setText(R.string.iv2);
+            appraisalIVRange1.setText(R.string.iv1);
 
             appraisalStat1.setText(R.string.is1);
             appraisalStat2.setText(R.string.is2);
@@ -1342,16 +1350,16 @@ public class Pokefly extends Service {
      * @return a number corresponding to which appraisalrange is selected.
      */
     private int getSelectedAppraiseIVRangeValue() {
-        if (appraisalRange1.isChecked()) {
+        if (appraisalIVRange1.isChecked()) {
             return 1;
         }
-        if (appraisalRange2.isChecked()) {
+        if (appraisalIVRange2.isChecked()) {
             return 2;
         }
-        if (appraisalRange3.isChecked()) {
+        if (appraisalIVRange3.isChecked()) {
             return 3;
         }
-        if (appraisalRange4.isChecked()) {
+        if (appraisalIVRange4.isChecked()) {
             return 4;
         }
         return 0;
@@ -1776,9 +1784,9 @@ public class Pokefly extends Service {
         defCheckbox.setChecked(false);
         staCheckbox.setChecked(false);
 
-        appraisalRangeGroup.clearCheck();
+        appraisalIVRangeGroup.clearCheck();
 
-        appraisalStatGroup.clearCheck();
+        appraisalStatsGroup.clearCheck();
     }
 
 

--- a/app/src/main/res/drawable/highlight_rectangle.xml
+++ b/app/src/main/res/drawable/highlight_rectangle.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+android:shape="rectangle">
+<stroke
+    android:width="2dp"
+    android:color="@color/appraisalHighlight" />
+<corners android:radius="6dp" />
+</shape>

--- a/app/src/main/res/layout/dialog_input_appraisal.xml
+++ b/app/src/main/res/layout/dialog_input_appraisal.xml
@@ -13,7 +13,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="horizontal"
-        android:id="@+id/appraisalRangeGroup"
+        android:id="@+id/appraisalIVRangeGroup"
         android:paddingBottom="2dp"
         android:paddingStart="2dp"
         android:paddingEnd="2dp">
@@ -24,7 +24,7 @@
             android:text="@string/mv4"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:id="@+id/appraisalRange4"
+            android:id="@+id/appraisalIVRange4"
             android:layout_weight="1"
             android:textScaleX=".9"
             android:maxLines="2"
@@ -38,7 +38,7 @@
             android:text="@string/mv3"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:id="@+id/appraisalRange3"
+            android:id="@+id/appraisalIVRange3"
             android:layout_weight="1"
             android:textScaleX=".9"
             android:maxLines="2"
@@ -52,7 +52,7 @@
             android:text="@string/mv2"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:id="@+id/appraisalRange2"
+            android:id="@+id/appraisalIVRange2"
             android:layout_weight="1"
             android:textScaleX=".9"
             android:maxLines="2"
@@ -66,7 +66,7 @@
             android:text="@string/mv1"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:id="@+id/appraisalRange1"
+            android:id="@+id/appraisalIVRange1"
             android:layout_weight="1"
             android:textScaleX=".9"
             android:maxLines="2"
@@ -81,6 +81,7 @@
     <LinearLayout
         android:layout_height="wrap_content"
         android:orientation="horizontal"
+        android:id="@+id/attDefStaLayout"
         android:layout_width="match_parent"
         android:layoutDirection="ltr"
         android:padding="2dp">
@@ -144,7 +145,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="horizontal"
-        android:id="@+id/appraisalStatGroup"
+        android:id="@+id/appraisalStatsGroup"
         android:padding="2dp">
 
         <RadioButton

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="red">#FF0000</color>
     <color name="buttonText">#E4FFDE</color>
     <color name="orange">#FAA61A</color>
+    <color name="appraisalHighlight">#bb3e50b3</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,8 @@
     <string name="too_many_iv_combinations">Too many IV combinations</string>
     <string name="refining_instructions">Increase IV calculation precision by leveling up and comparing two scans of the same Pokémon</string>
     <string name="appraisal_refining">Appraisal Refining</string>
+    <string name="autoappraisal_start">Auto Appraisal Started</string>
+    <string name="autoappraisal_finish">Auto Appraisal Finished</string>
     <string name="attack">Attack</string>
     <string name="defense">Defense</string>
     <string name="stamina_hp">HP</string>


### PR DESCRIPTION


This update aims to provide a refined sequence of events and user
interface cues throughout the AutoAppraisal process.

**Pokefly.onTouch logic order swap**
    This change swaps the logical order of events when a user touches
the screen.  The new order is for the app to first check if the
Appraisal dialog window is VISIBLE, and if so, go straight to
the AutoAppraisal.screenTouched() method, bypassing the normal
Pokefly screenScanHandler.  But, if the appraisal dialog is not
visible, proceed to Pokefly screenScanHandler without engaging
AutoAppraisal code.

**AutoAppraisal Rescan if phrase doesn't match.**
    This change implements an automatic rescan of the screen if the
AutoAppraisal process is not able to match the scanned phrase.  If
PoGo is still animating the text when the first scan is performed,
this feature allows the AutoAppraisal to rescan up to 3 times at 50ms
intervals to see if the full phrase is eventually able to be seen.

**AutoAppraisal visual highlights during appraisal process**
    This change adds a rounded rectangle to the Appraisal Dialog box to
highlight the current set of checkboxes that GoIV is currently
looking to populate.  The intent is for this to serve as a visual cue
that GoIV is doing something and to provide some context if/when a
phrase does not scan correctly.
    As part of this change, the flow of "addInfoFromAppraiseText" has
been updated to more accurately track which sections have been
completed and where we should be focusing the appraise phrase matching.

**Refactoring of RadioGroup/Checkboxes and related methods/variables**
    This change aligns the naming of the variables, methods and
elements related to the Appraisal RadioGroups and Checkboxes.


APK with these changes : https://goo.gl/jhb98P

