### PR TITLE
Tweaks color for tesseract preperation

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
@@ -212,9 +212,9 @@ public class OcrHelper {
         //clean the image
         //the dark color used for text in pogo is approximately rgb 76,112,114 if you can afford evo
         //and the red color is rgb 255 95 100 when you cant afford the evolution
-        Bitmap evolutionCostImageCanAfford = replaceColors(evolutionCostImage, false, 68, 105, 108, Color.WHITE, 28,
+        Bitmap evolutionCostImageCanAfford = replaceColors(evolutionCostImage, false, 68, 105, 108, Color.WHITE, 30,
                 false);
-        Bitmap evolutionCostImageCannotAfford = replaceColors(evolutionCostImage, false, 255, 95, 100, Color.WHITE, 17,
+        Bitmap evolutionCostImageCannotAfford = replaceColors(evolutionCostImage, false, 255, 115, 115, Color.WHITE, 40,
                 false);
 
         boolean affordIsBlank = isOnlyWhite(evolutionCostImageCanAfford);


### PR DESCRIPTION
When testing on my samsung galaxy S7 running game tumer (comes
pre-installed, lowers resolution to save battery) the scan fails to read
the evolution cost. This tweaks the numbers so the scan succeeds for
both full & lowered resolution.