### PR TITLE
Experimental double-letter CP tier

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/clipboard/ClipboardTokenCollection.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboard/ClipboardTokenCollection.java
@@ -3,6 +3,7 @@ package com.kamron.pogoiv.clipboard;
 import com.kamron.pogoiv.clipboard.tokens.BaseStatToken;
 import com.kamron.pogoiv.clipboard.tokens.CpPercentileToken;
 import com.kamron.pogoiv.clipboard.tokens.CpTierToken;
+import com.kamron.pogoiv.clipboard.tokens.ExtendedCpTierToken;
 import com.kamron.pogoiv.clipboard.tokens.HexIVToken;
 import com.kamron.pogoiv.clipboard.tokens.HpToken;
 import com.kamron.pogoiv.clipboard.tokens.IVPercentageToken;
@@ -70,6 +71,8 @@ public class ClipboardTokenCollection {
         // Evaluating scores////////////////////////////////
         tokens.add(new CpTierToken(true)); //Pokemon max evolution  max level CP tier
         tokens.add(new CpTierToken(false)); //pokemon max level cp tier
+        tokens.add(new ExtendedCpTierToken(false)); // Max AA-ZZ cp tier
+        tokens.add(new ExtendedCpTierToken(true)); // Same as above, max evolution
 
         tokens.add(new CpPercentileToken(false));
 

--- a/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/ExtendedCpTierToken.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/ExtendedCpTierToken.java
@@ -1,0 +1,68 @@
+package com.kamron.pogoiv.clipboard.tokens;
+
+import android.content.Context;
+
+import com.kamron.pogoiv.clipboard.ClipboardToken;
+import com.kamron.pogoiv.logic.IVScanResult;
+import com.kamron.pogoiv.logic.PokeInfoCalculator;
+import com.kamron.pogoiv.logic.Pokemon;
+
+/**
+ * Created by Danilo Pianini.
+ * A token which returns a "tier" based on the pokemon max cp, in the AA-ZZ range.
+ */
+
+public class ExtendedCpTierToken extends ClipboardToken {
+
+    /**
+     * Create a clipboard token.
+     * The boolean in the constructor can be set to false if pokemon evolution is not applicable.
+     *
+     * @param maxEv true if the token should change its logic to pretending the pokemon is fully evolved.
+     */
+    public ExtendedCpTierToken(boolean maxEv) {
+        super(maxEv);
+    }
+
+    @Override
+    public int getMaxLength() {
+        return 2;
+    }
+
+    @Override
+    public String getValue(IVScanResult ivs, PokeInfoCalculator pokeInfoCalculator) {
+        Pokemon poke = getRightPokemon(ivs.pokemon, pokeInfoCalculator);
+        double cp = pokeInfoCalculator
+                        .getCpRangeAtLevel(poke, ivs.getHighestIVCombination(), ivs.getHighestIVCombination(), 40)
+                        .getFloatingAvg();
+        return ExtendedTokenTierLogic.getRating(cp, pokeInfoCalculator);
+    }
+
+    @Override
+    public String getPreview() {
+        return "KJ";
+    }
+
+    @Override
+    public String getTokenName(Context context) {
+        return "ExtCPTier";
+    }
+
+    @Override
+    public String getLongDescription(Context context) {
+        return "This token gives you an idea of how powerful this pokemon can become, by measuring the maximum "
+                + "possible CP the pokemon can obtain (considering the maximum possible IV from the scan) and "
+                + "confronting it to the maximum CP of the most powerful IV 100 Pokemon. Values are provided in the "
+                + "AA-ZZ range.";
+    }
+
+    @Override
+    public String getCategory() {
+        return "Evaluation Scores";
+    }
+
+    @Override
+    public boolean changesOnEvolutionMax() {
+        return true;
+    }
+}

--- a/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/ExtendedCpTierToken.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/ExtendedCpTierToken.java
@@ -3,6 +3,7 @@ package com.kamron.pogoiv.clipboard.tokens;
 import android.content.Context;
 
 import com.kamron.pogoiv.clipboard.ClipboardToken;
+import com.kamron.pogoiv.logic.IVCombination;
 import com.kamron.pogoiv.logic.IVScanResult;
 import com.kamron.pogoiv.logic.PokeInfoCalculator;
 import com.kamron.pogoiv.logic.Pokemon;
@@ -31,9 +32,13 @@ public class ExtendedCpTierToken extends ClipboardToken {
 
     @Override
     public String getValue(IVScanResult ivs, PokeInfoCalculator pokeInfoCalculator) {
-        Pokemon poke = getRightPokemon(ivs.pokemon, pokeInfoCalculator);
+        final Pokemon poke = getRightPokemon(ivs.pokemon, pokeInfoCalculator);
+        final IVCombination comb = ivs.getHighestIVCombination();
+        if (comb == null) {
+            return "??";
+        }
         double cp = pokeInfoCalculator
-                        .getCpRangeAtLevel(poke, ivs.getHighestIVCombination(), ivs.getHighestIVCombination(), 40)
+                        .getCpRangeAtLevel(poke, comb, ivs.getHighestIVCombination(), 40)
                         .getFloatingAvg();
         return ExtendedTokenTierLogic.getRating(cp, pokeInfoCalculator);
     }

--- a/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/ExtendedTokenTierLogic.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/ExtendedTokenTierLogic.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.Semaphore;
 
+import static java.lang.Math.max;
+
 /**
  * Created by Danilo Pianini.
  * A class which translates a CP value to a tier string in the AA-ZZ range
@@ -49,7 +51,7 @@ public final class ExtendedTokenTierLogic {
         MUTEX.acquireUninterruptibly();
         if (MAX_IV == 0) {
             for (final Pokemon pokemon: calc.getPokedex()) {
-                MAX_IV = Math.max(MAX_IV, calc.getCpRangeAtLevel(pokemon, MAXIVCOMB, MAXIVCOMB, MAXLEVEL).getFloatingAvg());
+                MAX_IV = max(MAX_IV, calc.getCpRangeAtLevel(pokemon, MAXIVCOMB, MAXIVCOMB, MAXLEVEL).getFloatingAvg());
             }
         }
         MUTEX.release();

--- a/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/ExtendedTokenTierLogic.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/ExtendedTokenTierLogic.java
@@ -1,0 +1,56 @@
+package com.kamron.pogoiv.clipboard.tokens;
+
+import com.kamron.pogoiv.logic.IVCombination;
+import com.kamron.pogoiv.logic.PokeInfoCalculator;
+import com.kamron.pogoiv.logic.Pokemon;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+
+/**
+ * Created by Danilo Pianini.
+ * A class which translates a CP value to a tier string in the AA-ZZ range
+ */
+
+public final class ExtendedTokenTierLogic {
+
+    private static final IVCombination MAXIVCOMB = new IVCombination(15, 15, 15);
+    private static final int MAXLEVEL = 40;
+    private static final Semaphore MUTEX = new Semaphore(1);
+    private static final List<String> RATINGS;
+    private static double MAX_IV;
+
+    static {
+        final char[] alphabet = "abcdefghijklmnopqrstuvwxyz".toUpperCase().toCharArray();
+        final List<String> ratings = new ArrayList<>();
+        for (final char a: alphabet) {
+            for (final char b: alphabet) {
+                ratings.add(Character.toString(a) + Character.toString(b));
+            }
+        }
+        RATINGS = Collections.unmodifiableList(ratings);
+    }
+
+    private ExtendedTokenTierLogic() {
+    }
+
+    /**
+     * Get a string representation of a pokemon rating, for example "A" or "B+".
+     *
+     * @param combatPower the general combatPower to translate to a tier string.
+     * @return A string S,A,B,C,D which might have a plus or minus after.
+     */
+    public static String getRating(final double combatPower, final PokeInfoCalculator calc) {
+        MUTEX.acquireUninterruptibly();
+        if (MAX_IV == 0) {
+            for (final Pokemon pokemon: calc.getPokedex()) {
+                MAX_IV = Math.max(MAX_IV, calc.getCpRangeAtLevel(pokemon, MAXIVCOMB, MAXIVCOMB, MAXLEVEL).getFloatingAvg());
+            }
+        }
+        MUTEX.release();
+        final int ratingIndex = (int) Math.round(Math.max(combatPower, 1) * (RATINGS.size() - 1) / MAX_IV);
+        return RATINGS.get(ratingIndex);
+    }
+}

--- a/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/ExtendedTokenTierLogic.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/ExtendedTokenTierLogic.java
@@ -7,6 +7,7 @@ import com.kamron.pogoiv.logic.Pokemon;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.Semaphore;
 
 /**
@@ -23,7 +24,9 @@ public final class ExtendedTokenTierLogic {
     private static double MAX_IV;
 
     static {
-        final char[] alphabet = "abcdefghijklmnopqrstuvwxyz".toUpperCase().toCharArray();
+        final char[] alphabet = "abcdefghijklmnopqrstuvwxyz"
+                .toUpperCase(Locale.ENGLISH)
+                .toCharArray();
         final List<String> ratings = new ArrayList<>();
         for (final char a: alphabet) {
             for (final char b: alphabet) {


### PR DESCRIPTION
This pull request adds an experimental CP tier clipboard token, which produces an extremely fine grained evaluation for the Pokémon in the AA (worse) to ZZ (best) range, based on the best estimation among the possible IVs.

Evaluations are weighted automatically against the strongest Pokémon available at its best IV. Such upper bound is computed (once per application execution at most), so it should add no maintenance burden.

The system is meant for those who want to use the Pokémon name as a sorting mean to prioritize training the most promising Pokémons CP-wise. The (maybe counterintuitive) choice of assigning ZZ to the best pokémons is due to the IV measure being lexicographically sorting in the same way (with the notable exception of perfect IV and of single-digit IVs).

[![Build Status](https://travis-ci.org/DanySK/GoIV.svg?branch=master)](https://travis-ci.org/DanySK/GoIV)