### PR TITLE
Add new IVSum Token

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/clipboard/ClipboardTokenCollection.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboard/ClipboardTokenCollection.java
@@ -8,6 +8,7 @@ import com.kamron.pogoiv.clipboard.tokens.HexIVToken;
 import com.kamron.pogoiv.clipboard.tokens.HpToken;
 import com.kamron.pogoiv.clipboard.tokens.IVPercentageToken;
 import com.kamron.pogoiv.clipboard.tokens.IVPercentageTokenMode;
+import com.kamron.pogoiv.clipboard.tokens.IVSum;
 import com.kamron.pogoiv.clipboard.tokens.LevelToken;
 import com.kamron.pogoiv.clipboard.tokens.LevelUnicodeToken;
 import com.kamron.pogoiv.clipboard.tokens.PerfectionCPPercentageToken;
@@ -85,6 +86,9 @@ public class ClipboardTokenCollection {
         tokens.add(new IVPercentageToken(IVPercentageTokenMode.MIN));
         tokens.add(new IVPercentageToken(IVPercentageTokenMode.AVG));
         tokens.add(new IVPercentageToken(IVPercentageTokenMode.MAX));
+
+        //Sum
+        tokens.add(new IVSum(true));
 
         //Unicode iv representations
         tokens.add(new UnicodeToken(false)); //Unicode iv circled numbers not filled in ex ⑦⑦⑦

--- a/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/IVSum.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/IVSum.java
@@ -1,0 +1,75 @@
+package com.kamron.pogoiv.clipboard.tokens;
+
+import android.content.Context;
+
+import com.kamron.pogoiv.clipboard.ClipboardToken;
+import com.kamron.pogoiv.logic.IVCombination;
+import com.kamron.pogoiv.logic.IVScanResult;
+import com.kamron.pogoiv.logic.PokeInfoCalculator;
+
+import java.util.Locale;
+
+/**
+ * Created by Danilo Pianini.
+ * A token which returns a "tier" based on the pokemon max cp, in the AA-ZZ range.
+ */
+
+public class IVSum extends ClipboardToken {
+
+    private final boolean best;
+
+    /**
+     * Create a clipboard token.
+     * The boolean in the constructor can be set to false if pokemon evolution is not applicable.
+     *
+     * @param best true if the token should display the best combination, false for the worst.
+     */
+    public IVSum(boolean best) {
+        super(false);
+        this.best = best;
+    }
+
+    @Override
+    public int getMaxLength() {
+        return 2;
+    }
+
+    @Override
+    public String getValue(IVScanResult ivs, PokeInfoCalculator pokeInfoCalculator) {
+        final IVCombination combination = best ? ivs.getHighestIVCombination() : ivs.getLowestIVCombination();
+        if (combination == null) {
+            return "??";
+        }
+        return String.format(Locale.ENGLISH, "%02d", combination.getTotal());
+    }
+
+    @Override
+    public String getPreview() {
+        return "34";
+    }
+
+    @Override
+    public String getTokenName(Context context) {
+        return "IV-" + getType() + "-sum";
+    }
+
+    private String getType() {
+        return best ? "best" : "worst";
+    }
+
+    @Override
+    public String getLongDescription(Context context) {
+        return "This token returns the sum of the " + getType() + " possible IV stats for this pokemon"
+                + ". Ranges in 00-45. Always returns two digits.";
+    }
+
+    @Override
+    public String getCategory() {
+        return "IV Info";
+    }
+
+    @Override
+    public boolean changesOnEvolutionMax() {
+        return false;
+    }
+}


### PR DESCRIPTION
This very trivial token returns an IV evaluation in the most natural format: two digit number in 00-45. It just operates the sum of the single IV values. Solves the lexicographic sorting issues of the classic IV evaluation in 0-100 (single digit numbers and iv perfect get sorted badly).