### PR TITLE
Fix Auto-Update for SDK Version 24

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,7 +62,7 @@ android {
      * Update (both Gradle and local SDK) whenever possible
      */
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion '25.0.0'
 
     /**
      * Build configurations for APK

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -136,6 +136,16 @@
             android:label="@string/title_activity_credits"
             android:theme="@style/AppTheme.NoActionBar">
         </activity>
+        
+        <provider
+            android:authorities="${applicationId}.provider"
+            android:name="android.support.v4.content.FileProvider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+            android:name="android.support.FILE_PROVIDER_PATHS"
+            android:resource="@xml/provider_paths"/>
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/kamron/pogoiv/updater/DownloadUpdateService.java
+++ b/app/src/main/java/com/kamron/pogoiv/updater/DownloadUpdateService.java
@@ -17,7 +17,7 @@ import java.io.File;
 public class DownloadUpdateService extends Service {
 
     public static final String FILE_NAME = "GoIV_new.apk";
-    public static final String DOWNLOAD_UPDATE_TITLE = "Updating GoIV.apk";
+    public static final String DOWNLOAD_UPDATE_TITLE = "Updating GoIV";
     public static final String KEY_DOWNLOAD_URL = "downloadURL";
 
     @Override

--- a/app/src/main/java/com/kamron/pogoiv/updater/DownloadUpdateService.java
+++ b/app/src/main/java/com/kamron/pogoiv/updater/DownloadUpdateService.java
@@ -10,13 +10,14 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.Environment;
 import android.os.IBinder;
+import android.support.v4.content.FileProvider;
 
 import java.io.File;
 
 public class DownloadUpdateService extends Service {
 
     public static final String FILE_NAME = "GoIV_new.apk";
-    public static final String DOWNLOAD_UPDATE_TITLE = "Updating GoIV";
+    public static final String DOWNLOAD_UPDATE_TITLE = "Updating GoIV.apk";
     public static final String KEY_DOWNLOAD_URL = "downloadURL";
 
     @Override
@@ -59,8 +60,15 @@ public class DownloadUpdateService extends Service {
                                 //open the downloaded file
                                 Intent install = new Intent(Intent.ACTION_VIEW);
                                 install.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                                install.setDataAndType(downloadUri,
+//                                install.setDataAndType(downloadUri,
+//                                        manager.getMimeTypeForDownloadedFile(startedDownloadId));
+                                Uri apkUri = FileProvider.getUriForFile(
+                                        ctxt,
+                                        ctxt.getApplicationContext()
+                                                .getPackageName() + ".provider", newApkFile);
+                                install.setDataAndType(apkUri,
                                         manager.getMimeTypeForDownloadedFile(startedDownloadId));
+                                install.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
                                 ctxt.startActivity(install);
                             } else if (status == DownloadManager.STATUS_FAILED) {
                                 if (newApkFile.exists()) {

--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="."/>
+</paths>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Aug 18 00:35:18 IST 2016
+#Fri Jun 30 21:50:01 CDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
[History, Explanation and Solution](https://inthecheesefactory.com/blog/how-to-share-access-to-file-with-fileprovider-on-android-nougat/en)

"Summarily, file:// is not allowed to attach with Intent anymore or it will throw FileUriExposedException which may cause your app crash immediately called."

GoIV's Auto Updater code has been updated as shown from this posting, 
implementing FileProvider to work for version 24 and above (and still backwards
compatible with prior versions).