### PR TITLE
Fix auto update for android version24

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -136,6 +136,16 @@
             android:label="@string/title_activity_credits"
             android:theme="@style/AppTheme.NoActionBar">
         </activity>
+        
+        <provider
+            android:authorities="${applicationId}.provider"
+            android:name="android.support.v4.content.FileProvider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+            android:name="android.support.FILE_PROVIDER_PATHS"
+            android:resource="@xml/provider_paths"/>
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/kamron/pogoiv/updater/DownloadUpdateService.java
+++ b/app/src/main/java/com/kamron/pogoiv/updater/DownloadUpdateService.java
@@ -10,6 +10,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.Environment;
 import android.os.IBinder;
+import android.support.v4.content.FileProvider;
 
 import java.io.File;
 
@@ -59,8 +60,15 @@ public class DownloadUpdateService extends Service {
                                 //open the downloaded file
                                 Intent install = new Intent(Intent.ACTION_VIEW);
                                 install.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                                install.setDataAndType(downloadUri,
+//                                install.setDataAndType(downloadUri,
+//                                        manager.getMimeTypeForDownloadedFile(startedDownloadId));
+                                Uri apkUri = FileProvider.getUriForFile(
+                                        ctxt,
+                                        ctxt.getApplicationContext()
+                                                .getPackageName() + ".provider", newApkFile);
+                                install.setDataAndType(apkUri,
                                         manager.getMimeTypeForDownloadedFile(startedDownloadId));
+                                install.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
                                 ctxt.startActivity(install);
                             } else if (status == DownloadManager.STATUS_FAILED) {
                                 if (newApkFile.exists()) {

--- a/app/src/main/java/com/kamron/pogoiv/updater/DownloadUpdateService.java
+++ b/app/src/main/java/com/kamron/pogoiv/updater/DownloadUpdateService.java
@@ -17,7 +17,7 @@ import java.io.File;
 public class DownloadUpdateService extends Service {
 
     public static final String FILE_NAME = "GoIV_new.apk";
-    public static final String DOWNLOAD_UPDATE_TITLE = "Updating GoIV.apk";
+    public static final String DOWNLOAD_UPDATE_TITLE = "Updating GoIV";
     public static final String KEY_DOWNLOAD_URL = "downloadURL";
 
     @Override

--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="external_files" path="."/>
+</paths>


### PR DESCRIPTION
Fix Auto-Update for SDK Version 24

[History, Explanation and Solution](https://inthecheesefactory.com/blog/how-to-share-access-to-file-with-fileprovider-on-android-nougat/en)

"Summarily, file:// is not allowed to attach with Intent anymore or it will throw FileUriExposedException which may cause your app crash immediately called."

GoIV has been updated as shown from this posting, implementing
FileProvider to work for version 24 and above (and still backwards
compatible with prior versions).
