### PR TITLE
Refactor pokefly attempt - Andrew's contributions

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPopupButton.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPopupButton.java
@@ -3,7 +3,6 @@ package com.kamron.pogoiv.pokeflycomponents;
 import android.content.Context;
 import android.graphics.PixelFormat;
 import android.support.v4.content.res.ResourcesCompat;
-import android.util.DisplayMetrics;
 import android.view.Gravity;
 import android.view.MotionEvent;
 import android.view.View;
@@ -78,13 +77,13 @@ public class IVPopupButton extends android.support.v7.widget.AppCompatButton {
     /**
      * resets the visual look of the button to its default state.
      */
-    private void resetButtonLook() {
+    public void resetButtonLook() {
         setBackgroundResource(R.drawable.iv_button);
-
+        setWidth(dpToPx(60));
         setText("");
         ivButtonParams.gravity = Gravity.BOTTOM | Gravity.START;
-        ivButtonParams.x = dpToPx(15);
-        ivButtonParams.y = dpToPx(15);
+        ivButtonParams.x = dpToPx(16);
+        ivButtonParams.y = dpToPx(14);
         setLayoutParams(ivButtonParams);
 
         //setTypeface(null, Typeface.BOLD);
@@ -109,6 +108,8 @@ public class IVPopupButton extends android.support.v7.widget.AppCompatButton {
             setText(ivrs.pokemon.name + "\nIV: " + low + " - " + high + "%");
         }
 
+        setBackgroundResource(R.drawable.iv_button_background);
+        setWidth(dpToPx(120));
         setBackgroundGradient(ivrs);
         setTextColorFromIVs(ivrs);
 
@@ -116,20 +117,21 @@ public class IVPopupButton extends android.support.v7.widget.AppCompatButton {
     }
 
     private void setTextColorFromIVs(IVScanResult ivrs) {
-        int blue = ResourcesCompat.getColor(getResources(), R.color.p_blue, null);
-        int green = ResourcesCompat.getColor(getResources(), R.color.p_green, null);
-        int yellow = ResourcesCompat.getColor(getResources(), R.color.p_yellow, null);
-        int red = ResourcesCompat.getColor(getResources(), R.color.p_red, null);
+        int blue = ResourcesCompat.getColor(getResources(), R.color.p_text_blue, null);
+        int green = ResourcesCompat.getColor(getResources(), R.color.p_text_green, null);
+        int yellow = ResourcesCompat.getColor(getResources(), R.color.p_text_yellow, null);
+        int orange = ResourcesCompat.getColor(getResources(), R.color.p_text_orange, null);
+        int red = ResourcesCompat.getColor(getResources(), R.color.p_text_red, null);
 
         int percent = ivrs.getAveragePercent();
         if (percent < 51) {
             setTextColor(red);
         } else if (percent < 66) {
-            setTextColor(yellow);
+            setTextColor(orange);
         } else if (percent < 82) {
-            setTextColor(green);
+            setTextColor(yellow);
         } else if (percent < 101) {
-            setTextColor(blue);
+            setTextColor(green);
         }
     }
 
@@ -140,33 +142,44 @@ public class IVPopupButton extends android.support.v7.widget.AppCompatButton {
      */
     private void setBackgroundGradient(IVScanResult ivrs) {
 
+        int background = ResourcesCompat.getColor(getResources(), R.color.p_background, null);
+        int green = ResourcesCompat.getColor(getResources(), R.color.p_green, null);
+        int yellow = ResourcesCompat.getColor(getResources(), R.color.p_yellow, null);
+        int orange = ResourcesCompat.getColor(getResources(), R.color.p_orange, null);
+        int red = ResourcesCompat.getColor(getResources(), R.color.p_red, null);
+
         int low = ivrs.getLowestIVCombination().percentPerfect;
         int high = ivrs.getHighestIVCombination().percentPerfect;
 
+//        if (low < 51 && high < 51) {
+//            setBackgroundResource(R.drawable.preview_button_0_50);
+//        } else if (low < 51 && high < 66) {
+//            setBackgroundResource(R.drawable.preview_button_0_65);
+//        } else if (low < 51 && high < 82) {
+//            setBackgroundResource(R.drawable.preview_button_0_81);
+//        } else if (low < 51 && high < 101) {
+//            setBackgroundResource(R.drawable.preview_button_0_100);
+//        } else if (low < 66 && high < 66) {
+//            setBackgroundResource(R.drawable.preview_button_51_65);
+//        } else if (low < 66 && high < 82) {
+//            setBackgroundResource(R.drawable.preview_button_51_81);
+//        } else if (low < 66 && high < 101) {
+//            setBackgroundResource(R.drawable.preview_button_51_100);
+//        } else if (low < 82 && high < 82) {
+//            setBackgroundResource(R.drawable.preview_button_66_81);
+//        } else if (low < 82 && high < 101) {
+//            setBackgroundResource(R.drawable.preview_button_66_100);
+//        } else if (low < 101 && high < 101) {
+//            setBackgroundResource(R.drawable.preview_button_82_100);
+//        }
 
-        if (low < 51 && high < 51) {
-            setBackgroundResource(R.drawable.preview_button_0_50);
-        } else if (low < 51 && high < 66) {
-            setBackgroundResource(R.drawable.preview_button_0_65);
-        } else if (low < 51 && high < 82) {
-            setBackgroundResource(R.drawable.preview_button_0_81);
-        } else if (low < 51 && high < 101) {
-            setBackgroundResource(R.drawable.preview_button_0_100);
-        } else if (low < 66 && high < 66) {
-            setBackgroundResource(R.drawable.preview_button_51_65);
-        } else if (low < 66 && high < 82) {
-            setBackgroundResource(R.drawable.preview_button_51_81);
-        } else if (low < 66 && high < 101) {
-            setBackgroundResource(R.drawable.preview_button_51_100);
-        } else if (low < 82 && high < 82) {
-            setBackgroundResource(R.drawable.preview_button_66_81);
-        } else if (low < 82 && high < 101) {
-            setBackgroundResource(R.drawable.preview_button_66_100);
-        } else if (low < 101 && high < 101) {
-            setBackgroundResource(R.drawable.preview_button_82_100);
-        }
-
-
+//        View minIndicatorView = findViewById(R.id.ivPreviewMinIndicator);
+//        int[] colors = {red, background};
+//
+//        GradientDrawable gradientDrawable = new GradientDrawable(
+//                GradientDrawable.Orientation.LEFT_RIGHT, colors);
+//
+//        minIndicatorView.setBackground(gradientDrawable);
     }
 
     /**
@@ -174,6 +187,8 @@ public class IVPopupButton extends android.support.v7.widget.AppCompatButton {
      * navigate away from the screen and showing old IV preview would be missgiving.
      */
     public void outsideScreenClicked() {
+        setBackgroundResource(R.drawable.iv_button_background);
+        setWidth(dpToPx(60));
         setText("...");
     }
 
@@ -202,7 +217,7 @@ public class IVPopupButton extends android.support.v7.widget.AppCompatButton {
 
 
     private int dpToPx(int dp) {
-        return Math.round(dp * (getContext().getResources().getDisplayMetrics().xdpi / DisplayMetrics.DENSITY_DEFAULT));
+        return Math.round(dp * (getContext().getResources().getDisplayMetrics().density));
     }
 
 }

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
@@ -65,7 +65,8 @@ public class IVPreviewPrinter {
         public void run() {
             boolean succeeded = runQuickScan();
             if (!succeeded) {
-                Toast.makeText(pokefly, "Touch screen to retry", Toast.LENGTH_SHORT).show();
+                Toast.makeText(pokefly, "Touch screen to retry quick scan.", Toast.LENGTH_SHORT).show();
+                ivButton.resetButtonLook();
             }
         }
 

--- a/app/src/main/res/drawable/iv_button_background.xml
+++ b/app/src/main/res/drawable/iv_button_background.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Shadow -->
-    <item android:left="0dp"
-        android:right="0dp">
+    <item>
         <shape android:shape="rectangle">
             <size
                 android:width="60dp"
@@ -24,16 +23,18 @@
     </item>
 
     <!--Colored Ring-->
-    <item android:left="6dp"
+    <item
+        android:id="@+id/ivButtonRing"
+        android:left="6dp"
         android:right="6dp"
         android:bottom="6dp"
         android:top="6dp">
         <shape android:shape="rectangle">
             <corners android:radius="1000dp"/>
             <gradient
-            android:angle="270"
-            android:endColor="#68F0CE"
-            android:startColor="#AFFFAF"/>
+                android:angle="0"
+                android:endColor="#68F0CE"
+                android:startColor="#AFFFAF"/>
         </shape>
     </item>
 
@@ -48,52 +49,41 @@
         </shape>
     </item>
 
-
-
-    <!-- I -->
+    <!--Left Highlighted Color-->
     <item
-        android:bottom="18dp"
-        android:left="18dp"
-        android:right="39.2dp"
-        android:top="18dp">
+        android:id="@+id/ivPreviewMinIndicator"
+        android:left="8dp"
+        android:right="90dp"
+        android:bottom="8dp"
+        android:top="8dp">
         <shape android:shape="rectangle">
-            <corners android:radius="1000dp"/>
+            <corners
+                android:topLeftRadius="1000dp"
+                android:bottomLeftRadius="1000dp"/>
             <gradient
-                android:endColor="#A7FDB3"
-                android:startColor="#AFFFAF"/>
+                android:angle="0"
+                android:endColor="@color/p_background"
+                android:startColor="@color/p_background"/>
         </shape>
     </item>
 
-    <!-- V Left -->
+    <!--Right Highlighted Color-->
     <item
-        android:bottom="17.5dp"
-        android:left="29dp"
-        android:right="28dp"
-        android:top="17.5dp">
-        <rotate android:fromDegrees="-20">
-            <shape android:shape="rectangle">
-                <corners android:radius="1000dp"/>
-                <gradient
-                    android:endColor="#7DF4C5"
-                    android:startColor="#9DFBB7"/>
-            </shape>
-        </rotate>
+        android:id="@+id/ivPreviewMaxIndicator"
+        android:left="90dp"
+        android:right="8dp"
+        android:bottom="8dp"
+        android:top="8dp">
+        <shape android:shape="rectangle">
+            <corners
+                android:topRightRadius="1000dp"
+                android:bottomRightRadius="1000dp"/>
+            <gradient
+                android:angle="0"
+                android:endColor="@color/p_background"
+                android:startColor="@color/p_background"/>
+        </shape>
     </item>
 
-    <!-- V Right -->
-    <item
-        android:bottom="17.5dp"
-        android:left="37dp"
-        android:right="20dp"
-        android:top="17.5dp">
-        <rotate android:fromDegrees="20">
-            <shape android:shape="rectangle">
-                <corners android:radius="1000dp"/>
-                <gradient
-                    android:endColor="#68F0CE"
-                    android:startColor="#8AF7BF"/>
-            </shape>
-        </rotate>
-    </item>
 
 </layer-list>

--- a/app/src/main/res/values/preview_button_colors.xml
+++ b/app/src/main/res/values/preview_button_colors.xml
@@ -2,9 +2,16 @@
 
 <resources>
 
+    <color name="p_background">#1C8796</color>
+    <color name="p_red">#ff0000</color>
+    <color name="p_orange">#ff9800</color>
+    <color name="p_yellow">#ffeb56</color>
+    <color name="p_green">#40ff00</color>
+    <color name="p_blue">#0059ff</color>
 
-    <color name="p_red">#ffafaf</color>
-    <color name="p_yellow">#ffdfb0</color>
-    <color name="p_green">#c3ffac</color>
-    <color name="p_blue">#bcfdff</color>
+    <color name="p_text_red">#ff5f5f</color>
+    <color name="p_text_orange">#ffb74d</color>
+    <color name="p_text_yellow">#fff080</color>
+    <color name="p_text_green">#83ff5a</color>
+    <color name="p_text_blue">#508dff</color>
 </resources>


### PR DESCRIPTION
Good morning @nahojjjen,

This PR is intended to be a merge into your refactorPokeflyAttempt branch.  It is based off of that branch and should merge cleanly.

Major updates here are:
 - Fix the IV Button "big" issue.  Rewrote the iv_button.xml file to utilize rectangle shapes rather than ovals.  I took a real hard look at the exact pixel/dp alignment of the Pokemon Go buttons so that I could recreate the button accurately utilizing "dp" sizing.  I had to remove the width/height from many of the layers so that it would size correctly.  The width/height is now only defined on the "shadow" and then all other layers  resize accordingly.
 - Created a new "iv_button_background.xml" to be used for the quick preview functionality (ie: empty button with no "IV" characters/shapes).
 - dpToPix modified slightly... During my testing I found that the screen density formula in GoIV was not accurately calculating the actual density of my screen.  I think this was one of the factors leading to the incorrect size of the IV button and it being in the wrong place.
 - I tweaked the text coloring to be a scale of "red-orange-yellow-green", to hopefully make it easier to tell at a glance.  Also created 2 sets of colors, a lighter set for text and a darker set for the left and right shaded regions.


Feature still in progress:
 - I'm trying to get an additional coloring to only show up in the far left and far right of the IV quick preview button.  See screenshots below.   The only issue is that I'm having a hard time getting the code to work to be able to replace the Gradient startColor and endColor dynamically during run-time.

At this time, the below screenshots were created by hard-coding the color values in there just for the purpose of taking the screenshot.

![screenshot_20170719-015849](https://user-images.githubusercontent.com/3922705/28354805-e23b6c72-6c26-11e7-803c-4591cda3c374.png)
![screenshot_20170719-020422](https://user-images.githubusercontent.com/3922705/28354806-e248c570-6c26-11e7-8fcc-0a8b7de04f71.png)
![screenshot_20170719-020945](https://user-images.githubusercontent.com/3922705/28354964-914c05be-6c27-11e7-9130-af3cb725ff74.png)


