### PR TITLE
Fix missing Travis License Agreement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ android:
   components:
     - tools
     - platform-tools-24.0.2
-    - build-tools-24.0.2
+    - build-tools-25.0.0
     - android-24
     - extra-android-m2repository
 before_cache:


### PR DESCRIPTION
Android SDK Build-Tools were updated to version 25.0.0.
This commit adds the required license agreement in Travis
configuration file for that specific version of the component.

Resolves: #711