### PR TITLE
Fix hard coded Nidoran name for OCR multilingualization

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/OcrHelper.java
@@ -387,7 +387,7 @@ public class OcrHelper {
             name = replaceColors(name, true, 68, 105, 108, Color.WHITE, 200, true);
             tesseract.setImage(name);
             pokemonName = fixOcrNumsToLetters(tesseract.getUTF8Text().replace(" ", ""));
-            if (pokemonName.toLowerCase().contains("nidora")) {
+            if (isNidoranName(pokemonName)) {
                 pokemonName = getNidoranGenderName(pokemonImage);
             }
             name.recycle();
@@ -447,6 +447,14 @@ public class OcrHelper {
         }
     }
 
+    private boolean isNidoranName(String pokemonName) {
+        if (pokemonName.toLowerCase().contains(nidoFemale.toLowerCase().replace("♀", ""))) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     @NonNull
     private static String removeFirstOrLastWord(String src, boolean removeFirst) {
         if (removeFirst) {
@@ -478,9 +486,10 @@ public class OcrHelper {
             candy = replaceColors(candy, true, 68, 105, 108, Color.WHITE, 200, true);
             tesseract.setImage(candy);
             candyName = fixOcrNumsToLetters(
-                    removeFirstOrLastWord(tesseract.getUTF8Text().trim().replace("-", " "), candyWordFirst));
+                    removeFirstOrLastWord(tesseract.getUTF8Text().replace(" ", "").trim().replace("-", " "),
+                            candyWordFirst));
             candy.recycle();
-            if (candyName.toLowerCase().contains("nidora")) {
+            if (isNidoranName(candyName)) {
                 candyName = getNidoranGenderName(pokemonImage);
             }
             ocrCache.put(hash, candyName);
@@ -728,7 +737,7 @@ public class OcrHelper {
             name = replaceColors(name, true, 68, 105, 108, Color.WHITE, 200, true);
             tesseract.setImage(name);
             pokemonName = fixOcrNumsToLetters(tesseract.getUTF8Text().replace(" ", ""));
-            if (pokemonName.toLowerCase().contains("nidora")) {
+            if (isNidoranName(pokemonName)) {
                 pokemonName = getNidoranGenderName(pokemonImage);
             }
             name.recycle();
@@ -773,9 +782,10 @@ public class OcrHelper {
             candy = replaceColors(candy, true, 68, 105, 108, Color.WHITE, 200, true);
             tesseract.setImage(candy);
             candyName = fixOcrNumsToLetters(
-                    removeFirstOrLastWord(tesseract.getUTF8Text().trim().replace("-", " "), candyWordFirst));
+                    removeFirstOrLastWord(tesseract.getUTF8Text().replace(" ", "").trim().replace("-", " "),
+                            candyWordFirst));
             candy.recycle();
-            if (candyName.toLowerCase().contains("nidora")) {
+            if (isNidoranName(candyName)) {
                 candyName = getNidoranGenderName(pokemonImage);
             }
             ocrCache.put(hash, candyName);


### PR DESCRIPTION
Hi, I try and test to use GoIV for Japanese Pokémon GO game app.
https://github.com/udnp/GoIV_JP

This PR is one of some tips I noticed for OCR multilingualization,
used Nidoran name from resource string instead of hard coded.

Could you check this? 
Thanks.