### PR TITLE
Definitively fix code style in WorthTrainingToken.java

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/WorthTrainingToken.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/WorthTrainingToken.java
@@ -98,7 +98,7 @@ public class WorthTrainingToken extends ClipboardToken {
     }
 
     private static double normalize(final double v, final double min, final double max) {
-        return (v - min) / (max -min);
+        return (v - min) / (max - min);
     }
 
     @Override


### PR DESCRIPTION
Because of a small oversight, my previous pull request didn't solve the code style issues completely, sorry for that.
Please merge this, @nahojjjen 

PS: The checkstyle plugin seems not working on Android Studio 2.3.3.
I had to run style checks with `./gradlew checkstyle`. Anyone noticed the same behavior?