### PR TITLE
Move WorthTrainingToken to the correct category

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/WorthTrainingToken.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/WorthTrainingToken.java
@@ -128,7 +128,7 @@ public class WorthTrainingToken extends ClipboardToken {
 
     @Override
     public String getCategory() {
-        return "IV Info";
+        return "Evaluation Scores";
     }
 
     @Override


### PR DESCRIPTION
WorthTrainingToken was incorrectly put into the "IV Info" category.
Since it is used for 'mons evaluations, move it into "Evaluation Scores" instead!