### PR TITLE
Add superscript number support to IVPercentageToken

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/clipboard/ClipboardTokenCollection.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboard/ClipboardTokenCollection.java
@@ -100,6 +100,9 @@ public class ClipboardTokenCollection {
         tokens.add(new IVPercentageToken(IVPercentageTokenMode.MIN));
         tokens.add(new IVPercentageToken(IVPercentageTokenMode.AVG));
         tokens.add(new IVPercentageToken(IVPercentageTokenMode.MAX));
+        tokens.add(new IVPercentageToken(IVPercentageTokenMode.MIN_SUP));
+        tokens.add(new IVPercentageToken(IVPercentageTokenMode.AVG_SUP));
+        tokens.add(new IVPercentageToken(IVPercentageTokenMode.MAX_SUP));
 
         //Sum
         tokens.add(new IVSum(true));

--- a/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/IVPercentageTokenMode.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboard/tokens/IVPercentageTokenMode.java
@@ -7,5 +7,19 @@ package com.kamron.pogoiv.clipboard.tokens;
 public enum IVPercentageTokenMode {
     MIN,
     AVG,
-    MAX
+    MAX,
+    MIN_SUP,
+    AVG_SUP,
+    MAX_SUP;
+
+    public boolean isSuperscript() {
+        switch (this) {
+            case MIN_SUP:
+            case AVG_SUP:
+            case MAX_SUP:
+                return true;
+            default:
+                return false;
+        }
+    }
 }


### PR DESCRIPTION
This is a proposed solution for #717.

Three more IV% tokens get added to the grid, so it clutters the ClipboardModifierActivity.
I'm open to suggestions on how to improve this!