### PR TITLE
Fix hard coded pokemon type names for eeveelution correction

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -454,7 +454,8 @@ public class Pokefly extends Service {
                 getResources().getIntArray(R.array.stamina),
                 getResources().getIntArray(R.array.devolutionNumber),
                 getResources().getIntArray(R.array.evolutionCandyCost),
-                getResources().getIntArray(R.array.candyNames));
+                getResources().getIntArray(R.array.candyNames),
+                getResources().getStringArray(R.array.typeName));
         displayMetrics = this.getResources().getDisplayMetrics();
         initOcr();
         windowManager = (WindowManager) getSystemService(WINDOW_SERVICE);

--- a/app/src/main/java/com/kamron/pogoiv/logic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/PokeInfoCalculator.java
@@ -14,6 +14,7 @@ public class PokeInfoCalculator {
     private static PokeInfoCalculator instance;
 
     private ArrayList<Pokemon> pokedex = new ArrayList<>();
+    private String[] typeNamesArray;
 
     /**
      * Pokemons that aren't evolutions of any other one.
@@ -32,10 +33,10 @@ public class PokeInfoCalculator {
     public static PokeInfoCalculator getInstance(String[] namesArray, String[] displayNamesArray,
                                                  int[] attackArray, int[] defenceArray, int[] staminaArray,
                                                  int[] devolutionArray, int[] evolutionCandyCostArray,
-                                                 int[] candyNamesArray) {
+                                                 int[] candyNamesArray, String[] typeNamesArray) {
         if (instance == null) {
             instance = new PokeInfoCalculator(namesArray, displayNamesArray, attackArray, defenceArray,
-                    staminaArray, devolutionArray, evolutionCandyCostArray, candyNamesArray);
+                    staminaArray, devolutionArray, evolutionCandyCostArray, candyNamesArray, typeNamesArray);
         }
         return instance;
     }
@@ -59,12 +60,14 @@ public class PokeInfoCalculator {
      * @param staminaArray      array of all pokemon base stam stat
      * @param devolutionArray   array of what the pokemon evolved from, -1 if no devolution
      * @param candyNamesArray   array of base pokemon and their associated candy pokemon, -1 if non-base pokemon
+     * @param typeNamesArray    string array of all pokemon type names
      */
     private PokeInfoCalculator(String[] namesArray, String[] displayNamesArray, int[] attackArray,
                                int[] defenceArray, int[] staminaArray, int[] devolutionArray,
-                               int[] evolutionCandyCostArray, int[] candyNamesArray) {
+                               int[] evolutionCandyCostArray, int[] candyNamesArray, String[] typeNamesArray) {
         populatePokemon(namesArray, displayNamesArray, attackArray, defenceArray, staminaArray, devolutionArray,
                 evolutionCandyCostArray, candyNamesArray);
+        this.typeNamesArray = typeNamesArray;
     }
 
     public List<Pokemon> getPokedex() {
@@ -367,5 +370,9 @@ public class PokeInfoCalculator {
                 10);
         int averageHP = Math.round(highHp + lowHp) / 2;
         return averageHP;
+    }
+
+    public String getTypeName(int typeNameNum) {
+        return typeNamesArray[typeNameNum];
     }
 }

--- a/app/src/main/java/com/kamron/pogoiv/logic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/logic/PokemonNameCorrector.java
@@ -66,16 +66,23 @@ public class PokemonNameCorrector {
         //3.  check correction for Eevee’s Evolution using it's Pokemon Type
         if (guess.pokemon == null && candytext.toLowerCase().contains(pokeInfoCalculator.get(132).name.toLowerCase())) {
             HashMap<String, String> eeveelutionCorrection = new HashMap<>();
-            // It might be good to move this to a resource at some point
-            eeveelutionCorrection.put("WATER", pokeInfoCalculator.get(133).name); //Vaporeon
-            eeveelutionCorrection.put("ELECTRIC", pokeInfoCalculator.get(134).name); //Jolteon
-            eeveelutionCorrection.put("FIRE", pokeInfoCalculator.get(135).name); //Flareon
-            eeveelutionCorrection.put("PSYCHIC", pokeInfoCalculator.get(195).name); //Espeon
-            eeveelutionCorrection.put("DARK", pokeInfoCalculator.get(196).name); //Umbreon
+            eeveelutionCorrection.put(pokeInfoCalculator.getTypeName(2), //WATER
+                    pokeInfoCalculator.get(133).name); //Vaporeon
+            eeveelutionCorrection.put(pokeInfoCalculator.getTypeName(3), //ELECTRIC
+                    pokeInfoCalculator.get(134).name); //Jolteon
+            eeveelutionCorrection.put(pokeInfoCalculator.getTypeName(1), //FIRE
+                    pokeInfoCalculator.get(135).name); //Flareon
+            eeveelutionCorrection.put(pokeInfoCalculator.getTypeName(10), //PSYCHIC
+                    pokeInfoCalculator.get(195).name); //Espeon
+            eeveelutionCorrection.put(pokeInfoCalculator.getTypeName(15), //DARK
+                    pokeInfoCalculator.get(196).name); //Umbreon
             // Preparing for the future....
-            // eeveelutionCorrection.put("GRASS", pokeInfoCalculator.get(469).name); //Leafeon
-            // eeveelutionCorrection.put("ICE", pokeInfoCalculator.get(470).name); //Glaceon
-            // eeveelutionCorrection.put("FAIRY", pokeInfoCalculator.get(699).name); //Sylveon
+            // eeveelutionCorrection.put(pokeInfoCalculator.getTypeName(4), //GRASS
+            //         pokeInfoCalculator.get(469).name); //Leafeon
+            // eeveelutionCorrection.put(pokeInfoCalculator.getTypeName(5), //ICE
+            //         pokeInfoCalculator.get(470).name); //Glaceon
+            // eeveelutionCorrection.put(pokeInfoCalculator.getTypeName(17), //FAIRY
+            //         pokeInfoCalculator.get(699).name); //Sylveon
             if (eeveelutionCorrection.containsKey(pokemonType)) {
                 poketext = eeveelutionCorrection.get(pokemonType);
                 guess = new PokeDist(pokeInfoCalculator.get(poketext), 0);

--- a/app/src/main/res/values-it/pokemons.xml
+++ b/app/src/main/res/values-it/pokemons.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="typeName">
+        <!--  0   normal --> <item>NORMALE</item>
+        <!--  1     fire --> <item>FUOCO</item>
+        <!--  2    water --> <item>ACQUA</item>
+        <!--  3 electric --> <item>ELETTRO</item>
+        <!--  4    grass --> <item>ERBA</item>
+        <!--  5      ice --> <item>GHIACCIO</item>
+        <!--  6 fighting --> <item>LOTTA</item>
+        <!--  7   poison --> <item>VELENO</item>
+        <!--  8   ground --> <item>TERRA</item>
+        <!--  9   flying --> <item>VOLANTE</item>
+        <!-- 10  psychic --> <item>PSICO</item>
+        <!-- 11      bug --> <item>COLEOTTERO</item>
+        <!-- 12     rock --> <item>ROCCIA</item>
+        <!-- 13    ghost --> <item>SPETTRO</item>
+        <!-- 14   dragon --> <item>DRAGO</item>
+        <!-- 15     dark --> <item>BUIO</item>
+        <!-- 16    steel --> <item>ACCIAIO</item>
+        <!-- 17    fairy --> <item>FOLLETTO</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/pokemons.xml
+++ b/app/src/main/res/values/pokemons.xml
@@ -255,7 +255,7 @@
         <item>Ho-oh</item>
         <item>Celebi</item>
     </string-array>
-    <string-array name="type">
+    <string-array name="typeName">
         <item>NORMAL</item>
         <item>FIRE</item>
         <item>WATER</item>

--- a/app/src/main/res/values/pokemons.xml
+++ b/app/src/main/res/values/pokemons.xml
@@ -255,4 +255,24 @@
         <item>Ho-oh</item>
         <item>Celebi</item>
     </string-array>
+    <string-array name="type">
+        <item>NORMAL</item>
+        <item>FIRE</item>
+        <item>WATER</item>
+        <item>ELECTRIC</item>
+        <item>GRASS</item>
+        <item>ICE</item>
+        <item>FIGHTING</item>
+        <item>POISON</item>
+        <item>GROUND</item>
+        <item>FLYING</item>
+        <item>PSYCHIC</item>
+        <item>BUG</item>
+        <item>ROCK</item>
+        <item>GHOST</item>
+        <item>DRAGON</item>
+        <item>DARK</item>
+        <item>STEEL</item>
+        <item>FAIRY</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/pokemons.xml
+++ b/app/src/main/res/values/pokemons.xml
@@ -256,23 +256,23 @@
         <item>Celebi</item>
     </string-array>
     <string-array name="typeName">
-        <item>NORMAL</item>
-        <item>FIRE</item>
-        <item>WATER</item>
-        <item>ELECTRIC</item>
-        <item>GRASS</item>
-        <item>ICE</item>
-        <item>FIGHTING</item>
-        <item>POISON</item>
-        <item>GROUND</item>
-        <item>FLYING</item>
-        <item>PSYCHIC</item>
-        <item>BUG</item>
-        <item>ROCK</item>
-        <item>GHOST</item>
-        <item>DRAGON</item>
-        <item>DARK</item>
-        <item>STEEL</item>
-        <item>FAIRY</item>
+        <!--  0   normal --> <item>NORMAL</item>
+        <!--  1     fire --> <item>FIRE</item>
+        <!--  2    water --> <item>WATER</item>
+        <!--  3 electric --> <item>ELECTRIC</item>
+        <!--  4    grass --> <item>GRASS</item>
+        <!--  5      ice --> <item>ICE</item>
+        <!--  6 fighting --> <item>FIGHTING</item>
+        <!--  7   poison --> <item>POISON</item>
+        <!--  8   ground --> <item>GROUND</item>
+        <!--  9   flying --> <item>FLYING</item>
+        <!-- 10  psychic --> <item>PSYCHIC</item>
+        <!-- 11      bug --> <item>BUG</item>
+        <!-- 12     rock --> <item>ROCK</item>
+        <!-- 13    ghost --> <item>GHOST</item>
+        <!-- 14   dragon --> <item>DRAGON</item>
+        <!-- 15     dark --> <item>DARK</item>
+        <!-- 16    steel --> <item>STEEL</item>
+        <!-- 17    fairy --> <item>FAIRY</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Hi GoIV team.

This PR fixes hard coded pokemon type names for eeveelution correction.
So eeveelution correction is able to work on non English language also.
This is tested on English and Italiano (and my local Japanese fork build).

But now, to work this fix on other languages(eg de, fr,...),
you have to add localized pokemon type names to your locale `pokemons.xml`,
[like Italiano(it) in this patch](https://github.com/farkam135/GoIV/compare/master...udnp:pr/m17n-eeveelution-correction?expand=1#diff-5c3da1c320986525d8e5971ffde60920).

It seems that eeveelution correction sometimes fails in my test emvironment.
But it is because pokemon type OCR result is wrong(eg `PS**Y**CHIC` is `PS**V**CHIC`).
So I think this problem is caused by OCR error, not by my this PR.

Could you check this?
Thanks.  