### PR TITLE
Introduce dogfood flavor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,28 +75,42 @@ android {
         targetSdkVersion 24 /*Dont change this unless you know why*/
         versionCode 27
         versionName "3.6.0"
+        applicationId "com.swanberg.pogoiv"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }
 
     /**
      * Product flavors
+     * Dogfood - Internal test builds, no Internet permission and disable Crashlytics
      * Offline - No Internet permission and disable Crashlytics
      * Online - Internet permission and enable Crashlytics
      */
     productFlavors {
+        dogfood {
+            applicationIdSuffix ".dogfood"
+            buildConfigField "boolean", "isInternetAvailable", "false"
+            resValue "string", "app_name", "GoIV Dogfood"
+            ext.enableCrashlytics = false
+        }
+
         offline {
-            applicationId "com.swanberg.pogoiv.nointernet"
+            applicationIdSuffix ".nointernet"
             buildConfigField "boolean", "isInternetAvailable", "false"
             resValue "string", "app_name", "GoIV Offline"
             ext.enableCrashlytics = false
         }
 
         online {
-            applicationId "com.swanberg.pogoiv"
             buildConfigField "boolean", "isInternetAvailable", "true"
             resValue "string", "app_name", "GoIV"
             ext.enableCrashlytics = true
+        }
+    }
+
+    variantFilter { variant ->
+        if (variant.getFlavors().get(0).name == 'dogfood' && variant.buildType.name == 'release') {
+            setIgnore(true) // Shouldn't ever release a dogfood build in production!
         }
     }
 

--- a/app/src/dogfood/java/com/kamron/pogoiv/CrashlyticsWrapper.java
+++ b/app/src/dogfood/java/com/kamron/pogoiv/CrashlyticsWrapper.java
@@ -1,0 +1,24 @@
+package com.kamron.pogoiv;
+
+import android.content.Context;
+
+import timber.log.Timber;
+
+public class CrashlyticsWrapper {
+
+    public static void init(Context context) {
+        // there is no crashlytics in offline builds
+    }
+
+    public static class CrashReportingTree extends Timber.Tree {
+
+        public CrashReportingTree(Context context) {
+        }
+
+        @Override
+        protected void log(int priority, String tag, String message, Throwable t) {
+            // there is no online logging of crash reports in offline builds
+            CommonLogger.log(priority, tag, message, t);
+        }
+    }
+}

--- a/app/src/dogfood/java/com/kamron/pogoiv/updater/AppUpdateUtil.java
+++ b/app/src/dogfood/java/com/kamron/pogoiv/updater/AppUpdateUtil.java
@@ -1,0 +1,25 @@
+package com.kamron.pogoiv.updater;
+
+import android.content.Context;
+import android.support.v7.app.AlertDialog;
+
+import com.kamron.pogoiv.activities.MainActivity;
+
+/**
+ * Stub for AppUpdateUtil in offline builds.
+ * Created by pgiarrusso on 6/9/2016.
+ */
+public class AppUpdateUtil {
+    public static void checkForUpdate(final @SuppressWarnings("unused") Context context) {
+        //No update check here.
+    }
+
+    public static AlertDialog getAppUpdateDialog(final @SuppressWarnings("unused") Context context,
+                                                 final @SuppressWarnings("unused") AppUpdate update) {
+        throw new IllegalStateException("Can't get update dialog in dogfood build");
+    }
+
+
+    public static void deletePreviousApkFile(@SuppressWarnings("unused") MainActivity mainActivity) {
+    }
+}


### PR DESCRIPTION
This commit adds a new build flavor that can be used to build internal
releases for developers and testers.

Having a dedicate flavor with a different package name allow us to
install multiple flavors on a single device at the same time.