### PR TITLE
fix vital lint errors in release builds by removing unused strings

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -195,7 +195,6 @@
 
 
     <string name="notification_title_goiv_stopped">GoIV s\'est arrêtée</string>
-    <string name="notification_title_increment_level">Niveau +1</string>
     <string name="notification_title_tap_to_open">Touchez pour ouvrir GoIV</string>
     <string name="token_pokemonname">Nom du Pokémon</string>
     <string name="copy_to_clipboard_setting_summary_new">Copier automatiquement les infos scannées vers le presse-papier de copier-coller</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -182,7 +182,6 @@
     <string name="hp_expanded_box">PS</string>
     <string name="notification_title_goiv_stopped">"GoIV "</string>
     <string name="pause_goiv_notification">Pausa</string>
-    <string name="notification_title_increment_level">Livello +1</string>
     <string name="notification_title_tap_to_open">Tocca per aprire GoIV.</string>
     <string name="no_clipboard_preview">Anteprima non disponibile</string>
     <string name="perfection_explainer" formatted="false">La percentuale mostra quanto è ampia la differenza tra il tuo mostro e un mostro della stessa specie che ha IV perfetti e livello 40. Quindi, per esempio, se risulta 92% allora il tuo mostro al massimo avrà l\'8% in meno di PL in confronto ad un altro della stessa specie con IV massimi.</string>


### PR DESCRIPTION
Currently running `./gradlew clean assembleOfflineRelease` is throwing with this error: 

```
/Users/lark/src/GoIV/app/src/main/res/values-fr/strings.xml:198: Error: "notification_title_increment_level" is translated here but not found in default locale [ExtraTranslation]
    <string name="notification_title_increment_level">Niveau +1</string>
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /Users/lark/src/GoIV/app/src/main/res/values-it/strings.xml:185: Also translated here

   Explanation for issues of type "ExtraTranslation":
   If a string appears in a specific language translation file, but there is
   no corresponding string in the default locale, then this string is probably
   unused. (It's technically possible that your application is only intended
   to run in a specific locale, but it's still a good idea to provide a
   fallback.).

   Note that these strings can lead to crashes if the string is looked up on
   any locale not providing a translation, so it's important to clean them
   up.

1 errors, 0 warnings
:app:lintVitalOfflineRelease FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:lintVitalOfflineRelease'.
> Lint found fatal errors while assembling a release target.

  To proceed, either fix the issues identified by lint, or modify your build script as follows:
  ...
  android {
      lintOptions {
          checkReleaseBuilds false
          // Or, if you prefer, you can continue to check for errors in release builds,
          // but continue the build even when errors are found:
          abortOnError false
      }
  }
  ...
```

It appears that string isn't used, removing it makes lint happy again