### PR TITLE
Fix regression on candy name detection due to incorrect whitespace replacement

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
@@ -547,7 +547,7 @@ public class OcrHelper {
             candy = replaceColors(candy, true, 68, 105, 108, Color.WHITE, 200, true);
             tesseract.setImage(candy);
             candyName = fixOcrNumsToLetters(
-                    removeFirstOrLastWord(tesseract.getUTF8Text().replace(" ", ""), candyWordFirst));
+                    removeFirstOrLastWord(tesseract.getUTF8Text().trim().replace("-", " "), candyWordFirst));
             candy.recycle();
             if (isNidoranName(candyName)) {
                 candyName = getNidoranGenderName(pokemonImage);


### PR DESCRIPTION
The method `removeFirstOrLastWord` needs the whitespace that divide the 'mon family name from the "candy" word to split the input string and pick the 'mon family name.

A regression introduced in 154ffb0322eccaf319e9549b6853ee4dada94adc also removes whitespaces in the middle of the detected text, making it impossible to correctly detetect the candy name.