### PR TITLE
Fix media store compression

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/PoGoApplication.java
+++ b/app/src/main/java/com/kamron/pogoiv/PoGoApplication.java
@@ -3,6 +3,8 @@ package com.kamron.pogoiv;
 import android.app.Application;
 import android.support.v7.app.AppCompatDelegate;
 
+import com.kamron.pogoiv.utils.FontsOverride;
+
 import timber.log.Timber;
 
 public class PoGoApplication extends Application {

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -73,6 +73,8 @@ import com.kamron.pogoiv.scanlogic.PokemonShareHandler;
 import com.kamron.pogoiv.scanlogic.ScanContainer;
 import com.kamron.pogoiv.scanlogic.ScanResult;
 import com.kamron.pogoiv.scanlogic.UpgradeCost;
+import com.kamron.pogoiv.utils.CopyUtils;
+import com.kamron.pogoiv.utils.GuiUtil;
 import com.kamron.pogoiv.widgets.PokemonSpinnerAdapter;
 import com.kamron.pogoiv.widgets.recyclerviews.adapters.IVResultsAdapter;
 

--- a/app/src/main/java/com/kamron/pogoiv/activities/OcrCalibrationResultActivity.java
+++ b/app/src/main/java/com/kamron/pogoiv/activities/OcrCalibrationResultActivity.java
@@ -13,7 +13,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
-import android.provider.MediaStore;
 import android.support.v7.app.AppCompatActivity;
 import android.util.DisplayMetrics;
 import android.view.View;
@@ -31,6 +30,7 @@ import com.kamron.pogoiv.pokeflycomponents.ocrhelper.ScanArea;
 import com.kamron.pogoiv.pokeflycomponents.ocrhelper.ScanFieldAutomaticLocator;
 import com.kamron.pogoiv.pokeflycomponents.ocrhelper.ScanFieldResults;
 import com.kamron.pogoiv.pokeflycomponents.ocrhelper.ScanPoint;
+import com.kamron.pogoiv.utils.MediaStoreUtils;
 
 import java.util.List;
 
@@ -214,8 +214,8 @@ public class OcrCalibrationResultActivity extends AppCompatActivity {
                 getWindowManager().getDefaultDisplay().getRealMetrics(realDisplayMetrics);
 
 
-                String pathofBmp = MediaStore.Images.Media.insertImage(getContentResolver(),
-                        sCalibrationImage, "goivdebugimgremovable", null);
+                String pathofBmp = MediaStoreUtils.insertPngImage(getContentResolver(),
+                        sCalibrationImage, "goivdebugimgremovable.png");
                 Uri bmpUri = Uri.parse(pathofBmp);
 
                 final String os;

--- a/app/src/main/java/com/kamron/pogoiv/utils/CommonLogger.java
+++ b/app/src/main/java/com/kamron/pogoiv/utils/CommonLogger.java
@@ -1,4 +1,4 @@
-package com.kamron.pogoiv;
+package com.kamron.pogoiv.utils;
 
 import android.util.Log;
 

--- a/app/src/main/java/com/kamron/pogoiv/utils/CopyUtils.java
+++ b/app/src/main/java/com/kamron/pogoiv/utils/CopyUtils.java
@@ -1,4 +1,4 @@
-package com.kamron.pogoiv;
+package com.kamron.pogoiv.utils;
 
 import android.content.res.AssetManager;
 
@@ -14,7 +14,7 @@ import timber.log.Timber;
  * Created by pgiarrusso on 4/9/2016.
  */
 public class CopyUtils {
-    static boolean copyAssetFolder(AssetManager assetManager, String fromAssetPath, String toPath) {
+    public static boolean copyAssetFolder(AssetManager assetManager, String fromAssetPath, String toPath) {
 
         String[] files = new String[0];
 

--- a/app/src/main/java/com/kamron/pogoiv/utils/DevMethods.java
+++ b/app/src/main/java/com/kamron/pogoiv/utils/DevMethods.java
@@ -1,4 +1,4 @@
-package com.kamron.pogoiv;
+package com.kamron.pogoiv.utils;
 
 import android.graphics.Bitmap;
 import android.os.Environment;

--- a/app/src/main/java/com/kamron/pogoiv/utils/FontsOverride.java
+++ b/app/src/main/java/com/kamron/pogoiv/utils/FontsOverride.java
@@ -1,4 +1,4 @@
-package com.kamron.pogoiv;
+package com.kamron.pogoiv.utils;
 
 import android.content.Context;
 import android.graphics.Typeface;

--- a/app/src/main/java/com/kamron/pogoiv/utils/GuiUtil.java
+++ b/app/src/main/java/com/kamron/pogoiv/utils/GuiUtil.java
@@ -1,4 +1,4 @@
-package com.kamron.pogoiv;
+package com.kamron.pogoiv.utils;
 
 import android.content.Context;
 import android.graphics.Color;

--- a/app/src/main/java/com/kamron/pogoiv/utils/MediaStoreUtils.java
+++ b/app/src/main/java/com/kamron/pogoiv/utils/MediaStoreUtils.java
@@ -1,0 +1,123 @@
+package com.kamron.pogoiv.utils;
+
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.ContentValues;
+import android.graphics.Bitmap;
+import android.graphics.Matrix;
+import android.net.Uri;
+import android.provider.MediaStore;
+import android.util.Log;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static android.provider.MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+
+public class MediaStoreUtils {
+
+    public static final String TAG = "MediaStoreUtils";
+
+    /**
+     * Insert an image and create a thumbnail for it.
+     *
+     * COPIED AND CUSTOMIZED FROM MediaStore.Images.Media.insertImage(...)
+     *
+     * @param cr The content resolver to use
+     * @param source The stream to use for the image
+     * @param title The name of the image
+     * @return The URL to the newly created image, or <code>null</code> if the image failed to be stored
+     *              for any reason.
+     */
+    public static String insertPngImage(ContentResolver cr, Bitmap source, String title) {
+        ContentValues values = new ContentValues();
+        values.put(MediaStore.Images.Media.TITLE, title);
+        values.put(MediaStore.Images.Media.DISPLAY_NAME, title);
+        values.put(MediaStore.Images.Media.MIME_TYPE, "image/png");
+        long now = System.currentTimeMillis();
+        values.put(MediaStore.Images.Media.DATE_TAKEN, now);
+        values.put(MediaStore.Images.Media.DATE_ADDED, now);
+
+        Uri url = null;
+        String stringUrl = null;    /* value to be returned */
+
+        try {
+            url = cr.insert(EXTERNAL_CONTENT_URI, values);
+
+            if (source != null) {
+                OutputStream imageOut = cr.openOutputStream(url);
+                try {
+                    source.compress(Bitmap.CompressFormat.PNG, 100, imageOut);
+                } finally {
+                    imageOut.close();
+                }
+
+                long id = ContentUris.parseId(url);
+                // Wait until MINI_KIND thumbnail is generated.
+                Bitmap miniThumb = MediaStore.Images.Thumbnails.getThumbnail(cr, id,
+                        MediaStore.Images.Thumbnails.MINI_KIND, null);
+                // This is for backward compatibility.
+                Bitmap microThumb = storeThumbnail(cr, miniThumb, id, 50F, 50F,
+                        MediaStore.Images.Thumbnails.MICRO_KIND);
+            } else {
+                Log.e(TAG, "Failed to create thumbnail, removing original");
+                cr.delete(url, null, null);
+                url = null;
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to insert image", e);
+            if (url != null) {
+                cr.delete(url, null, null);
+                url = null;
+            }
+        }
+
+        if (url != null) {
+            stringUrl = url.toString();
+        }
+
+        return stringUrl;
+    }
+
+    private static Bitmap storeThumbnail(
+            ContentResolver cr,
+            Bitmap source,
+            long id,
+            float width, float height,
+            int kind) {
+        // create the matrix to scale it
+        Matrix matrix = new Matrix();
+
+        float scaleX = width / source.getWidth();
+        float scaleY = height / source.getHeight();
+
+        matrix.setScale(scaleX, scaleY);
+
+        Bitmap thumb = Bitmap.createBitmap(source, 0, 0,
+                source.getWidth(),
+                source.getHeight(), matrix,
+                true);
+
+        ContentValues values = new ContentValues(4);
+        values.put(MediaStore.Images.Thumbnails.KIND,     kind);
+        values.put(MediaStore.Images.Thumbnails.IMAGE_ID, (int)id);
+        values.put(MediaStore.Images.Thumbnails.HEIGHT,   thumb.getHeight());
+        values.put(MediaStore.Images.Thumbnails.WIDTH,    thumb.getWidth());
+
+        Uri url = cr.insert(MediaStore.Images.Thumbnails.EXTERNAL_CONTENT_URI, values);
+
+        try {
+            OutputStream thumbOut = cr.openOutputStream(url);
+
+            thumb.compress(Bitmap.CompressFormat.JPEG, 100, thumbOut);
+            thumbOut.close();
+            return thumb;
+        } catch (FileNotFoundException ex) {
+            return null;
+        } catch (IOException ex) {
+            return null;
+        }
+    }
+
+}

--- a/app/src/main/java/com/kamron/pogoiv/widgets/PokemonSpinnerAdapter.java
+++ b/app/src/main/java/com/kamron/pogoiv/widgets/PokemonSpinnerAdapter.java
@@ -7,7 +7,7 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.TextView;
 
-import com.kamron.pogoiv.GuiUtil;
+import com.kamron.pogoiv.utils.GuiUtil;
 import com.kamron.pogoiv.scanlogic.Pokemon;
 
 import java.util.ArrayList;

--- a/app/src/main/java/com/kamron/pogoiv/widgets/recyclerviews/adapters/IVResultsAdapter.java
+++ b/app/src/main/java/com/kamron/pogoiv/widgets/recyclerviews/adapters/IVResultsAdapter.java
@@ -8,7 +8,7 @@ import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import com.kamron.pogoiv.GuiUtil;
+import com.kamron.pogoiv.utils.GuiUtil;
 import com.kamron.pogoiv.Pokefly;
 import com.kamron.pogoiv.R;
 import com.kamron.pogoiv.scanlogic.IVCombination;

--- a/app/src/offline/java/com/kamron/pogoiv/CrashlyticsWrapper.java
+++ b/app/src/offline/java/com/kamron/pogoiv/CrashlyticsWrapper.java
@@ -2,6 +2,8 @@ package com.kamron.pogoiv;
 
 import android.content.Context;
 
+import com.kamron.pogoiv.utils.CommonLogger;
+
 import timber.log.Timber;
 
 public class CrashlyticsWrapper {

--- a/app/src/online/java/com/kamron/pogoiv/CrashlyticsWrapper.java
+++ b/app/src/online/java/com/kamron/pogoiv/CrashlyticsWrapper.java
@@ -5,6 +5,7 @@ import android.text.TextUtils;
 
 import com.crashlytics.android.Crashlytics;
 import com.crashlytics.android.core.CrashlyticsCore;
+import com.kamron.pogoiv.utils.CommonLogger;
 
 import io.fabric.sdk.android.Fabric;
 import timber.log.Timber;


### PR DESCRIPTION
This move some utility classes to a separate sub-package and save the failed calibration screenshots uncompressed.