### PR TITLE
Makes cp vs max iv update per level

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1454,7 +1454,7 @@ public class Pokefly extends Service {
 
         setEstimateCpTextBox(ivScanResult, selectedLevel, selectedPokemon);
         setEstimateHPTextBox(ivScanResult, selectedLevel, selectedPokemon);
-        setPokemonPerfectionPercentageText(ivScanResult, selectedPokemon);
+        setPokemonPerfectionPercentageText(ivScanResult, selectedLevel, selectedPokemon);
         setEstimateCostTextboxes(ivScanResult, selectedLevel, selectedPokemon);
         exResLevel.setText(String.valueOf(selectedLevel));
         setEstimateLevelTextColor(selectedLevel);
@@ -1466,13 +1466,15 @@ public class Pokefly extends Service {
      * Sets the pokemon perfection % text in the powerup and evolution results box.
      *
      * @param ivScanResult    The object containing the ivs to base current pokemon on.
+     * @param selectedLevel   Which level the prediction should me made for.
      * @param selectedPokemon The pokemon to compare selected iv with max iv to.
      */
-    private void setPokemonPerfectionPercentageText(IVScanResult ivScanResult, Pokemon selectedPokemon) {
+    private void setPokemonPerfectionPercentageText(IVScanResult ivScanResult, double selectedLevel, Pokemon selectedPokemon) {
         CPRange cpRange = pokeInfoCalculator.getCpRangeAtLevel(selectedPokemon,
-                ivScanResult.getCombinationLowIVs(), ivScanResult.getCombinationHighIVs(), 40);
+                ivScanResult.getCombinationLowIVs(), ivScanResult.getCombinationHighIVs(),
+                selectedLevel);
         double maxCP = pokeInfoCalculator.getCpRangeAtLevel(selectedPokemon,
-                IVCombination.MAX, IVCombination.MAX, 40).high;
+                IVCombination.MAX, IVCombination.MAX, selectedLevel).high;
         double perfection = (100.0 * cpRange.getFloatingAvg()) / maxCP;
         int difference = (int) (cpRange.getFloatingAvg() - maxCP);
         DecimalFormat df = new DecimalFormat("#.#");
@@ -1853,7 +1855,8 @@ public class Pokefly extends Service {
 
     private <T> String optionalIntToString(Optional<T> src) {
         return src.transform(new Function<T, String>() {
-            @Override public String apply(T input) {
+            @Override
+            public String apply(T input) {
                 return input.toString();
             }
         }).or("");

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1469,7 +1469,8 @@ public class Pokefly extends Service {
      * @param selectedLevel   Which level the prediction should me made for.
      * @param selectedPokemon The pokemon to compare selected iv with max iv to.
      */
-    private void setPokemonPerfectionPercentageText(IVScanResult ivScanResult, double selectedLevel, Pokemon selectedPokemon) {
+    private void setPokemonPerfectionPercentageText(IVScanResult ivScanResult,
+                                                    double selectedLevel, Pokemon selectedPokemon) {
         CPRange cpRange = pokeInfoCalculator.getCpRangeAtLevel(selectedPokemon,
                 ivScanResult.getCombinationLowIVs(), ivScanResult.getCombinationHighIVs(),
                 selectedLevel);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,7 +141,7 @@
     <string name="hp_expanded_box">HP</string>
     <string name="cp_vs_iv" formatted="false">% CP vs max IV</string>
     <string name="alert_explanation_title">Explanation</string>
-    <string name="perfection_explainer">The percentage shows how big the difference is between your monster and a monster of the same species which has perfect IVs and is level 40.\n\nSo for example, if it says 92 percent, then your Pokémon maxes out at 8 percent less CP compared to the same species with maximum IVs.</string>
+    <string name="perfection_explainer">The percentage shows how big the difference is between your monster and a monster of the same species which has perfect IVs.\n\nSo for example, if it says 92 percent, then your Pokémon maxes out at 8 percent less CP compared to the same species with maximum IVs.</string>
     <string name="pokespam">PokéSpam</string>
     <string name="pokespam_formatted_message">%1$d (%2$d rows + %3$d more)</string>
     <string name="candy">Candy</string>


### PR DESCRIPTION
When the user drags the level slider in the estimate box, now the cp vs max iv will show the IV for each level, instead of only level 40.