### PR TITLE
Fixes crash on out-of-bounds level dot check

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
@@ -205,32 +205,29 @@ public class OcrHelper {
             return -1;
         }
 
-        //try-catch the pixel check, to prevent the distance going off-screen and crashing.
-        try {
-            int d = 0; // Distance we have successfully searched for white pixels.
-            while (true) {
-                // If any pixel this distance is not white, return our successful search distance
-                if (pokemonImage.getPixel(x + d, y) != Color.WHITE
-                        || pokemonImage.getPixel(x - d, y) != Color.WHITE
-                        || pokemonImage.getPixel(x, y + d) != Color.WHITE
-                        || pokemonImage.getPixel(x, y - d) != Color.WHITE) {
-                    return d;
-                }
 
-                d++;
-                if (x - d < 0 || y - d < 0
-                        || x + d > pokemonImage.getWidth() || y + d > pokemonImage.getHeight()) {
-                    // If the level indicator is on white background, we need to break it before it loops off screen.
-                    // Happens very rarely.
-                    break;
-                }
+        int d = 0; // Distance we have successfully searched for white pixels.
+        while (true) {
+            //Check to see if we're out of bounds.
+            if (x - d <= 0 || y - d <= 0
+                    || x + d > pokemonImage.getWidth() || y + d > pokemonImage.getHeight()) {
+                // If the level indicator is on white background, we need to break it before it loops off screen.
+                // Happens very rarely.
+                break;
             }
-            return d;
-        } catch (IllegalArgumentException e) {
-            return -1;
-        }
 
+            // If any pixel this distance is not white, return our successful search distance
+            if (pokemonImage.getPixel(x + d, y) != Color.WHITE
+                    || pokemonImage.getPixel(x - d, y) != Color.WHITE
+                    || pokemonImage.getPixel(x, y + d) != Color.WHITE
+                    || pokemonImage.getPixel(x, y - d) != Color.WHITE) {
+                return d;
+            }
+            d++;
+        }
+        return d;
     }
+
 
     /**
      * Get the evolution cost for a pokemon, like getPokemonEvolutionCostFromImg, but without caching.

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
@@ -205,25 +205,31 @@ public class OcrHelper {
             return -1;
         }
 
-        int d = 0; // Distance we have successfully searched for white pixels.
-        while (true) {
-            // If any pixel this distance is not white, return our successful search distance
-            if (pokemonImage.getPixel(x + d, y) != Color.WHITE
-                    || pokemonImage.getPixel(x - d, y) != Color.WHITE
-                    || pokemonImage.getPixel(x, y + d) != Color.WHITE
-                    || pokemonImage.getPixel(x, y - d) != Color.WHITE) {
-                return d;
-            }
+        //try-catch the pixel check, to prevent the distance going off-screen and crashing.
+        try {
+            int d = 0; // Distance we have successfully searched for white pixels.
+            while (true) {
+                // If any pixel this distance is not white, return our successful search distance
+                if (pokemonImage.getPixel(x + d, y) != Color.WHITE
+                        || pokemonImage.getPixel(x - d, y) != Color.WHITE
+                        || pokemonImage.getPixel(x, y + d) != Color.WHITE
+                        || pokemonImage.getPixel(x, y - d) != Color.WHITE) {
+                    return d;
+                }
 
-            d++;
-            if (x - d < 0 || y - d < 0
-                    || x + d > pokemonImage.getWidth() || y + d > pokemonImage.getHeight()) {
-                // If the level indicator is on white background, we need to break it before it loops off screen.
-                // Happens very rarely.
-                break;
+                d++;
+                if (x - d < 0 || y - d < 0
+                        || x + d > pokemonImage.getWidth() || y + d > pokemonImage.getHeight()) {
+                    // If the level indicator is on white background, we need to break it before it loops off screen.
+                    // Happens very rarely.
+                    break;
+                }
             }
+            return d;
+        } catch (IllegalArgumentException e) {
+            return -1;
         }
-        return d;
+
     }
 
     /**

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
@@ -210,7 +210,7 @@ public class OcrHelper {
         while (true) {
             //Check to see if we're out of bounds.
             if (x - d <= 0 || y - d <= 0
-                    || x + d > pokemonImage.getWidth() || y + d > pokemonImage.getHeight()) {
+                    || x + d >= pokemonImage.getWidth() || y + d >= pokemonImage.getHeight()) {
                 // If the level indicator is on white background, we need to break it before it loops off screen.
                 // Happens very rarely.
                 break;


### PR DESCRIPTION
When the background of the pokemon is white, or the pokemon overlaps the dot and is white, the "level up dot" can appear to the program to go out of screen, as it cannot find the edge.