### PR TITLE
Fix crash when targeting Android Oreo (API 26)

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -335,18 +335,24 @@ public class Pokefly extends Service {
     private @NonNull Optional<String> screenShotPath = Optional.absent();
 
 
+    @SuppressWarnings("deprecation")
     private final WindowManager.LayoutParams arcParams = new WindowManager.LayoutParams(
             WindowManager.LayoutParams.WRAP_CONTENT,
             WindowManager.LayoutParams.WRAP_CONTENT,
-            WindowManager.LayoutParams.TYPE_PHONE,
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                    ? WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+                    : WindowManager.LayoutParams.TYPE_PHONE,
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE | WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
             PixelFormat.TRANSLUCENT);
     private int statusBarHeight = 0;
 
+    @SuppressWarnings("deprecation")
     private final WindowManager.LayoutParams layoutParams = new WindowManager.LayoutParams(
             WindowManager.LayoutParams.MATCH_PARENT,
             WindowManager.LayoutParams.WRAP_CONTENT,
-            WindowManager.LayoutParams.TYPE_PHONE,
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                    ? WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+                    : WindowManager.LayoutParams.TYPE_PHONE,
             WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN,
             PixelFormat.TRANSPARENT);
 

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPopupButton.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPopupButton.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.PixelFormat;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.LayerDrawable;
+import android.os.Build;
 import android.support.v4.content.res.ResourcesCompat;
 import android.view.Gravity;
 import android.view.MotionEvent;
@@ -27,10 +28,13 @@ public class IVPopupButton extends android.support.v7.widget.AppCompatButton {
     private WindowManager windowManager;
     private boolean showing = false;
 
+    @SuppressWarnings("deprecation")
     private final WindowManager.LayoutParams ivButtonParams = new WindowManager.LayoutParams(
             WindowManager.LayoutParams.WRAP_CONTENT,
             WindowManager.LayoutParams.WRAP_CONTENT,
-            WindowManager.LayoutParams.TYPE_PHONE,
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                    ? WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+                    : WindowManager.LayoutParams.TYPE_PHONE,
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
             PixelFormat.TRANSLUCENT);
 

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ScreenWatcher.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ScreenWatcher.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.graphics.Color;
 import android.graphics.PixelFormat;
 import android.graphics.Point;
+import android.os.Build;
 import android.os.Handler;
 import android.support.annotation.ColorInt;
 import android.util.DisplayMetrics;
@@ -105,10 +106,13 @@ public class ScreenWatcher {
         screenScanRunnable = new ScreenScan();
 
         touchView = new LinearLayout(pokefly);
+        //noinspection deprecation
         touchViewParams = new WindowManager.LayoutParams(
                 1,
                 1,
-                WindowManager.LayoutParams.TYPE_PHONE,
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+                        ? WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+                        : WindowManager.LayoutParams.TYPE_PHONE,
                 WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
                         | WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL
                         | WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH,


### PR DESCRIPTION
Use correct window type for overlays to avoid crashes when targeting Oreo.
See https://developer.android.com/about/versions/oreo/android-8.0-changes.html#cwt

Please merge immediately after #790.