### PR TITLE
Remove unnecessary bitmap.recycle() calls

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1914,7 +1914,6 @@ public class Pokefly extends Service {
             return;
         }
         scanPokemon(bmp, Optional.<String>absent());
-        bmp.recycle();
     }
 
     /**
@@ -1947,7 +1946,6 @@ public class Pokefly extends Service {
             }
 
             scanPokemon(bitmap, screenShotPath);
-            bitmap.recycle();
         }
     };
 

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
@@ -426,7 +426,6 @@ public class OcrHelper {
             if (isNidoranName(pokemonName)) {
                 pokemonName = getNidoranGenderName(pokemonImage);
             }
-            name.recycle();
             ocrCache.put(hash, pokemonName);
         }
         return pokemonName;
@@ -454,7 +453,6 @@ public class OcrHelper {
             type = replaceColors(type, true, 68, 105, 108, Color.WHITE, 200, true);
             tesseract.setImage(type);
             pokemonType = tesseract.getUTF8Text();
-            type.recycle();
             ocrCache.put(hash, pokemonType);
         }
         return pokemonType;
@@ -553,7 +551,6 @@ public class OcrHelper {
             tesseract.setImage(candy);
             candyName = fixOcrNumsToLetters(
                     removeFirstOrLastWord(tesseract.getUTF8Text().trim().replace("-", " "), candyWordFirst));
-            candy.recycle();
             if (isNidoranName(candyName)) {
                 candyName = getNidoranGenderName(pokemonImage);
             }
@@ -585,7 +582,6 @@ public class OcrHelper {
             pokemonHPStr = tesseract.getUTF8Text();
             ocrCache.put(hash, pokemonHPStr);
         }
-        hp.recycle();
 
         if (pokemonHPStr.contains("/")) {
             try {
@@ -774,7 +770,6 @@ public class OcrHelper {
             pokemonCandyStr = tesseract.getUTF8Text();
             ocrCache.put(hash, pokemonCandyStr);
         }
-        candyAmount.recycle();
 
         if (pokemonCandyStr.length() > 0) {
             try {
@@ -851,7 +846,6 @@ public class OcrHelper {
             appraisalCache.put(hash, appraisalText);
             settings.saveAppraisalCache(appraisalCache.snapshot());
         }
-        bottom.recycle();
 
         return hash + "#" + appraisalText;
 


### PR DESCRIPTION
bitmap.recycle is only needed on android 3 and below, in later android versions, bitmaps are correctly handled automatically by the java garbage collector.