### PR TITLE
Weather level pokemon

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -624,7 +624,7 @@ public class Pokefly extends Service {
      * @param pokeLevel The pokemon level to set the arc pointer to.
      */
     private void setArcPointer(double pokeLevel) {
-        int index = Data.levelToLevelIdx(pokeLevel);
+        int index = Data.maxPokeLevelToIndex(pokeLevel);
         arcParams.x = Data.arcX[index] - arcParams.width / 2;
         arcParams.y = Data.arcY[index] - arcParams.height / 2 - statusBarHeight;
         //That is, (int) (arcCenter + (radius * Math.cos(angleInRadians))) and
@@ -636,7 +636,7 @@ public class Pokefly extends Service {
      * Creates the arc adjuster used to move the arc pointer in the scan screen.
      */
     private void createArcAdjuster() {
-        arcAdjustBar.setMax(Data.trainerLevelToMaxPokeLevelIdx(trainerLevel));
+        arcAdjustBar.setMax(Data.trainerLevelToMaxPokeLevelIndex(trainerLevel));
 
         arcAdjustBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override
@@ -973,7 +973,7 @@ public class Pokefly extends Service {
 
     private void adjustArcPointerBar(double estimatedPokemonLevel) {
         setArcPointer(estimatedPokemonLevel);
-        arcAdjustBar.setProgress(Data.levelToLevelIdx(estimatedPokemonLevel));
+        arcAdjustBar.setProgress(Data.maxPokeLevelToIndex(estimatedPokemonLevel));
     }
 
     @OnClick(R.id.btnDecrementLevel)
@@ -1578,7 +1578,7 @@ public class Pokefly extends Service {
     /**
      * Sets the text color of the level next to the slider in the estimate box to normal or orange depending on if
      * the user can level up the pokemon that high with his current trainer level. For example, if the user has
-     * trainer level 20, then his pokemon can reach a max level of 21.5 - so any goalLevel above 21.5 would become
+     * trainer level 20, then his pokemon can reach a max level of 22 - so any goalLevel above 22 would become
      * orange.
      *
      * @param selectedLevel The level to reach.

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -624,7 +624,13 @@ public class Pokefly extends Service {
      * @param pokeLevel The pokemon level to set the arc pointer to.
      */
     private void setArcPointer(double pokeLevel) {
+
         int index = Data.maxPokeLevelToIndex(pokeLevel);
+
+        //If the pokemon is overleveled (Raid catch or weather modifier the arc indicator will be stuck at max)
+        if (index >= Data.arcX.length) {
+            index = Data.arcX.length - 1;
+        }
         arcParams.x = Data.arcX[index] - arcParams.width / 2;
         arcParams.y = Data.arcY[index] - arcParams.height / 2 - statusBarHeight;
         //That is, (int) (arcCenter + (radius * Math.cos(angleInRadians))) and
@@ -637,6 +643,7 @@ public class Pokefly extends Service {
      */
     private void createArcAdjuster() {
         arcAdjustBar.setMax(Data.trainerLevelToMaxPokeLevelIndex(trainerLevel));
+        arcAdjustBar.setMax(Data.trainerLevelToMaxPokeLevelIndex(40));
 
         arcAdjustBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
@@ -170,7 +170,7 @@ public class OcrHelper {
         double previousEstPokemonLevel = estimatedPokemonLevel + 0.5; // Initial value out of range
         int previousLevelDistance = -1; // Initial value indicating no found white pixels
         for (double estPokemonLevel = estimatedPokemonLevel; estPokemonLevel >= 1.0; estPokemonLevel -= 0.5) {
-            int index = Data.levelToLevelIdx(estPokemonLevel);
+            int index = Data.maxPokeLevelToIndex(estPokemonLevel);
             int x = Data.arcX[index];
             int y = Data.arcY[index];
             int whiteLineDistance = getCardinalWhiteLineDistFromImg(pokemonImage, x, y);

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/Data.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/Data.java
@@ -34,20 +34,22 @@ public class Data {
      */
     public static void setupArcPoints(ScanPoint arcInit, int arcRadius, int trainerLevel) {
         /*
-         * Pokemon levels go from 1 to trainerLevel + 1.5, in increments of 0.5.
+         * Pokemon levels go from 1 to trainerLevel + 2, in increments of 0.5.
          * Here we use levelIdx for levels that are doubled and shifted by - 2; after this adjustment,
          * the level can be used to index CpM, arcX and arcY.
          */
-        int maxPokeLevelIdx = trainerLevelToMaxPokeLevelIdx(trainerLevel);
-        arcX = new int[maxPokeLevelIdx + 1]; //We access entries [0..maxPokeLevelIdx], hence + 1.
-        arcY = new int[maxPokeLevelIdx + 1];
+        int maxPokeLevelIndex = (trainerLevelToMaxPokeLevelIndex(trainerLevel));
+        arcX = new int[maxPokeLevelIndex + 1]; //We access entries [0..maxPokeLevelIndex], hence + 1.
+        arcY = new int[maxPokeLevelIndex + 1];
 
         double baseCpM = CpM[0];
-        //TODO: debug this formula when we get to the end of CpM (that is, levels 39/40).
-        double maxPokeCpMDelta = CpM[Math.min(maxPokeLevelIdx + 1, CpM.length - 1)] - baseCpM;
 
-        //pokeLevelIdx <= maxPokeLevelIdx ensures we never overflow CpM/arc/arcY.
-        for (int pokeLevelIdx = 0; pokeLevelIdx <= maxPokeLevelIdx; pokeLevelIdx++) {
+
+        //amount of possible levels: level*2 + 3
+        double maxPokeCpMDelta = CpM[Math.min(maxPokeLevelIndex, CpM.length - 1)] - baseCpM;
+
+        //pokeLevelIdx <= maxPokeLevelIndex ensures we never overflow CpM/arc/arcY
+        for (int pokeLevelIdx = 0; pokeLevelIdx <= maxPokeLevelIndex; pokeLevelIdx++) {
             double pokeCurrCpMDelta = CpM[pokeLevelIdx] - baseCpM;
             double arcRatio = pokeCurrCpMDelta / maxPokeCpMDelta;
             double angleInRadians = (arcRatio + 1) * Math.PI;
@@ -62,16 +64,17 @@ public class Data {
      * The mapping is invertible, but level indexes can be used to index an array (like Data.CpM), or seekbars.
      * <p/>
      * Pokemon levels go from 1 to trainerLevelToMaxPokeLevel(trainerLevel), in increments of 0.5.
-     * Level indexes go from 0 to trainerLevelToMaxPokeLevelIdx(trainerLevel) in increments of 1.
+     * Level indexes go from 0 to trainerLevelToMaxPokeLevelIndex(trainerLevel) in increments of 1.
      * This method adjusts a level to a <em>level index</em> (<code>levelIdx</code>), by doubling it
      * and subtracting 2.
      */
-    public static int levelToLevelIdx(double level) {
+    public static int maxPokeLevelToIndex(double level) {
+
         return (int) ((level - 1) * 2);
     }
 
     /**
-     * Convert a <em>level index</em> back to a level. Inverse of levelToLevelIdx, see explanations
+     * Convert a <em>level index</em> back to a level. Inverse of maxPokeLevelToIndex, see explanations
      * there for rationale.
      */
     public static double levelIdxToLevel(int levelIdx) {
@@ -80,31 +83,31 @@ public class Data {
 
     /**
      * Return CpM (CP Multiplier) for a given pokemon level. Levels are described as documented for
-     * Data.levelToLevelIdx.
+     * Data.maxPokeLevelToIndex.
      *
      * @param level The desired level.
      * @return Associated CpM.
      */
     public static double getLevelCpM(double level) {
-        return CpM[levelToLevelIdx(level)];
+        return CpM[maxPokeLevelToIndex(level)];
     }
 
     /**
-     * Maximum pokemon level for a trainer, from the trainer level. That's usually trainerLevel + 1.5, but
-     * the maximum is 40 (http://pokemongo.gamepress.gg/power-up-costs).
+     * Maximum pokemon level for a trainer, from the trainer level. This is 2 levels above trainer level.
+     * It used to be 1.5, but was changed around december 2017.
      */
     public static double trainerLevelToMaxPokeLevel(int trainerLevel) {
-        return Math.min(trainerLevel + 1.5, 40);
+        return Math.min(trainerLevel + 2, 40);
     }
 
     /*
-     * Pokemon levels go from 1 to trainerLevel + 1.5, in increments of 0.5.
+     * Pokemon levels go from 1 to trainerLevel + 2, in increments of 0.5.
      * Here we use levelIdx for levels that are doubled and shifted by - 2; after this adjustment,
      * the level can be used to index CpM, arcX and arcY.
      */
-    public static int trainerLevelToMaxPokeLevelIdx(int trainerLevel) {
-        // This is Math.min(2 * trainerLevel + 1, 78).
-        return levelToLevelIdx(trainerLevelToMaxPokeLevel(trainerLevel));
+    public static int trainerLevelToMaxPokeLevelIndex(int trainerLevel) {
+        // This is Math.min(2 * trainerLevel + 1, 79).
+        return maxPokeLevelToIndex(trainerLevelToMaxPokeLevel(trainerLevel));
     }
 
     // should be pretty fast https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#Java


### PR DESCRIPTION
In the input screen, you can now drag the level bar up to 40, regardless of what level you are. This change is introduced since weather catches makes it more common to catch pokemon that are higher level than you're supposed to be able to own.

This PR is based on the +2 level bug branch, if that one doesnt get accepted, ill remake this PR. Im doing this to avoid merge conflicts.