### PR TITLE
Changes !"quickscan failed" toast to button look

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPopupButton.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPopupButton.java
@@ -1,6 +1,7 @@
 package com.kamron.pogoiv.pokeflycomponents;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.graphics.PixelFormat;
 import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.LayerDrawable;
@@ -83,6 +84,7 @@ public class IVPopupButton extends android.support.v7.widget.AppCompatButton {
      * resets the visual look of the button to its default state.
      */
     private void resetButtonLook() {
+        setTextColor(Color.WHITE);
         setBackgroundResource(R.drawable.iv_button);
         setWidth(dpToPx(60));
         setText("");
@@ -90,6 +92,7 @@ public class IVPopupButton extends android.support.v7.widget.AppCompatButton {
         ivButtonParams.x = dpToPx(16);
         ivButtonParams.y = dpToPx(14);
         setLayoutParams(ivButtonParams);
+        setTextAlignment(TEXT_ALIGNMENT_CENTER);
         setGravity(Gravity.CENTER_VERTICAL);
     }
 
@@ -195,6 +198,21 @@ public class IVPopupButton extends android.support.v7.widget.AppCompatButton {
     public void outsideScreenClicked() {
         setText("...");
         setGradientColor(0, 0); //makes gradient invisible
+        setBackgroundResource(R.drawable.preview_button_0_100);
+
+        int black = ResourcesCompat.getColor(getResources(), R.color.p_loading, null);
+        setGradientColor(black, black);
+    }
+
+    public void showError() {
+        resetButtonLook();
+
+        setBackgroundResource(R.drawable.preview_button_0_100);
+        int black = ResourcesCompat.getColor(getResources(), R.color.p_error, null);
+        setGradientColor(black, black);
+
+        setText("?");
+
     }
 
     /**

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
@@ -6,7 +6,6 @@ import android.widget.Toast;
 
 import com.kamron.pogoiv.GoIVSettings;
 import com.kamron.pogoiv.Pokefly;
-import com.kamron.pogoiv.R;
 import com.kamron.pogoiv.ScreenGrabber;
 import com.kamron.pogoiv.pokeflycomponents.ocrhelper.OcrHelper;
 import com.kamron.pogoiv.scanlogic.IVScanResult;
@@ -42,6 +41,7 @@ public class IVPreviewPrinter {
     /**
      * Shows a toast message that displays either a short message about the pokemon currently on the screen, or the
      * users clipboard setting about the pokemon currently on the screen.
+     *
      * @param ivButton The ivButton to change the look of.
      */
     public void printIVPreview(IVPopupButton ivButton) {

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
@@ -73,8 +73,10 @@ public class IVPreviewPrinter {
             boolean succeeded = runQuickScan();
             Pokefly pokefly = pokeflyRef.get();
             if (!succeeded && pokefly != null) {
-                ivButtonRef.get().showError();
-                //Toast.makeText(pokefly, R.string.touch_screen_quick_iv_scan, Toast.LENGTH_SHORT).show();
+                IVPopupButton ivButton = ivButtonRef.get();
+                if (ivButton != null) {
+                    ivButtonRef.get().showError();
+                }
             }
         }
 

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
@@ -73,7 +73,8 @@ public class IVPreviewPrinter {
             boolean succeeded = runQuickScan();
             Pokefly pokefly = pokeflyRef.get();
             if (!succeeded && pokefly != null) {
-                Toast.makeText(pokefly, R.string.touch_screen_quick_iv_scan, Toast.LENGTH_SHORT).show();
+                ivButtonRef.get().showError();
+                //Toast.makeText(pokefly, R.string.touch_screen_quick_iv_scan, Toast.LENGTH_SHORT).show();
             }
         }
 

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
@@ -71,8 +71,7 @@ public class IVPreviewPrinter {
         @Override
         public void run() {
             boolean succeeded = runQuickScan();
-            Pokefly pokefly = pokeflyRef.get();
-            if (!succeeded && pokefly != null) {
+            if (!succeeded) {
                 IVPopupButton ivButton = ivButtonRef.get();
                 if (ivButton != null) {
                     ivButtonRef.get().showError();

--- a/app/src/main/res/values/preview_button_colors.xml
+++ b/app/src/main/res/values/preview_button_colors.xml
@@ -7,6 +7,8 @@
     <color name="p_yellow">#fdd835</color>
     <color name="p_green">#76ff03</color>
     <color name="p_blue">#87ffff</color>
+    <color name="p_error">#00861612</color>
+    <color name="p_loading">#c8d1c5</color>
     <color name="iv_button_base">#1C8796</color>
     <color name="iv_button_shadow">#20000000</color>
     <color name="iv_text_color">#b8f5b8</color>


### PR DESCRIPTION
Button now shows "?" instead of toasting an error message when pokemon could not be scanned.

Also fixed some formating issues with the button caused by the buttonreset not covering all aspects.