### PR TITLE
Improve Nidoran gender detection

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -331,7 +331,7 @@ public class Pokefly extends Service {
     private String pokemonName;
     private String pokemonType;
     private String candyName;
-    private Optional<String> pokemonGender = Optional.absent();
+    private Pokemon.Gender pokemonGender = Pokemon.Gender.N;
     private Optional<Integer> pokemonCandy = Optional.absent();
     private Optional<Integer> pokemonCP = Optional.absent();
     private Optional<Integer> pokemonHP = Optional.absent();
@@ -1061,8 +1061,7 @@ public class Pokefly extends Service {
 
 
         IVScanResult ivScanResult = pokeInfoCalculator.getIVPossibilities(pokemon, estimatedPokemonLevelRange.min,
-                estimatedPokemonLevelRange.max,
-                pokemonHP.get(), pokemonCP.get(), pokemonGender);
+                estimatedPokemonLevelRange.max, pokemonHP.get(), pokemonCP.get(), pokemonGender);
 
         refineByAvailableAppraisalInfo(ivScanResult);
         refineByEggRaidInformation(ivScanResult);
@@ -1887,9 +1886,7 @@ public class Pokefly extends Service {
             CopyUtils.copyAssetFolder(getAssets(), "tessdata", extdir + "/tessdata");
         }
 
-        ocr = OcrHelper.init(extdir, displayMetrics.widthPixels, displayMetrics.heightPixels,
-                pokeInfoCalculator.get(28).name,
-                pokeInfoCalculator.get(31).name,
+        ocr = OcrHelper.init(extdir, displayMetrics.widthPixels, displayMetrics.heightPixels, pokeInfoCalculator,
                 settings);
     }
 
@@ -1985,8 +1982,8 @@ public class Pokefly extends Service {
                             (Optional<Integer>) intent.getSerializableExtra(KEY_SEND_INFO_CP);
                     @SuppressWarnings("unchecked") Optional<Integer> lPokemonHP =
                             (Optional<Integer>) intent.getSerializableExtra(KEY_SEND_INFO_HP);
-                    @SuppressWarnings("unchecked") Optional<String> lPokemonGender =
-                            (Optional<String>) intent.getSerializableExtra(KEY_SEND_INFO_GENDER);
+                    @SuppressWarnings("unchecked") Pokemon.Gender lPokemonGender =
+                            (Pokemon.Gender) intent.getSerializableExtra(KEY_SEND_INFO_GENDER);
                     @SuppressWarnings("unchecked") Optional<Integer> lCandyAmount =
                             (Optional<Integer>) intent.getSerializableExtra(KEY_SEND_INFO_CANDY_AMOUNT);
                     @SuppressWarnings("unchecked") Optional<Integer> lCandyUpgradeCost =

--- a/app/src/main/java/com/kamron/pogoiv/clipboardlogic/tokens/PokemonGenderToken.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboardlogic/tokens/PokemonGenderToken.java
@@ -29,7 +29,7 @@ public class PokemonGenderToken extends ClipboardToken {
 
     @Override
     public String getValue(IVScanResult ivScanResult, PokeInfoCalculator pokeInfoCalculator) {
-        return ivScanResult.scannedGender.isPresent() ? ivScanResult.scannedGender.get() : "";
+        return ivScanResult.scannedGender.toString();
     }
 
     @Override

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/AutoAppraisal.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/AutoAppraisal.java
@@ -230,12 +230,12 @@ public class AutoAppraisal {
         if (!match && numRetries < SCANRETRIES) { // If nothing matched and we have not yet reached maximum # of retries
             numRetries++;
             // Nothing matched, so this phrase should be thrown away.
-            ocr.removeEntryFromApprisalCache(hash);
+            ocr.removeEntryFromAppraisalCache(hash);
             // Let's schedule another scan to see if animation has finished.
             scanAppraisalText(RETRYDELAY);
         } else if (!match) { // Nothing matched and we've ran out of retry attempts.
             // Nothing matched, so this phrase should be thrown away.
-            ocr.removeEntryFromApprisalCache(hash);
+            ocr.removeEntryFromAppraisalCache(hash);
         }
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
@@ -137,9 +137,9 @@ public class IVPreviewPrinter {
         PokemonNameCorrector corrector = new PokemonNameCorrector(pokeInfoCalculator);
         Pokemon poke = corrector.getPossiblePokemon(res.getPokemonName(), res.getCandyName(),
                 res.getUpgradeCandyCost(), res.getPokemonType()).pokemon;
-        IVScanResult ivrs = pokeInfoCalculator.getIVPossibilities(poke, res.getEstimatedPokemonLevel().min, res
-                        .getEstimatedPokemonLevel().max,
-                res.getPokemonHP().get(), res.getPokemonCP().get(), res.getPokemonGender());
+        IVScanResult ivrs = pokeInfoCalculator.getIVPossibilities(poke, res.getEstimatedPokemonLevel().min,
+                res.getEstimatedPokemonLevel().max, res.getPokemonHP().get(), res.getPokemonCP().get(),
+                res.getPokemonGender());
         return ivrs;
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/IVScanResult.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/IVScanResult.java
@@ -2,8 +2,6 @@ package com.kamron.pogoiv.scanlogic;
 
 import android.support.annotation.Nullable;
 
-import com.google.common.base.Optional;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -40,7 +38,7 @@ public class IVScanResult {
     public final double estimatedPokemonLevel;
     public int scannedHP = 0;
     public boolean rangeIVScan = false; //is this several levels worth of possible iv combinations?
-    public Optional<String> scannedGender;
+    public Pokemon.Gender scannedGender;
 
     /**
      * Creates a holder object for IV scan results.
@@ -49,7 +47,7 @@ public class IVScanResult {
      * @param pokemonCP             pokemon CP
      * @param estimatedPokemonLevel the estimated pokemon level (should be very low)
      */
-    public IVScanResult(Pokemon pokemon, double estimatedPokemonLevel, int pokemonCP, Optional<String> pokemonGender) {
+    public IVScanResult(Pokemon pokemon, double estimatedPokemonLevel, int pokemonCP, Pokemon.Gender pokemonGender) {
         this.pokemon = pokemon;
         this.estimatedPokemonLevel = estimatedPokemonLevel;
         this.scannedCP = pokemonCP;

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -1,8 +1,6 @@
 package com.kamron.pogoiv.scanlogic;
 
 
-import com.google.common.base.Optional;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -206,7 +204,7 @@ public class PokeInfoCalculator {
      */
     public IVScanResult getIVPossibilities(Pokemon selectedPokemon, double estimatedPokemonLevelMin,
                                            double estimatedPokemonLevelMax, int pokemonHP,
-                                           int pokemonCP, Optional<String> pokemonGender) {
+                                           int pokemonCP, Pokemon.Gender pokemonGender) {
 
         if (estimatedPokemonLevelMax == estimatedPokemonLevelMin) {
             return getSingleLevelIVPossibility(selectedPokemon, estimatedPokemonLevelMax, pokemonHP, pokemonCP,
@@ -238,8 +236,7 @@ public class PokeInfoCalculator {
      * many possibilities.
      */
     private IVScanResult getSingleLevelIVPossibility(Pokemon selectedPokemon, double estimatedPokemonLevel,
-                                                     int pokemonHP,
-                                                     int pokemonCP, Optional<String> pokemonGender) {
+                                                     int pokemonHP, int pokemonCP, Pokemon.Gender pokemonGender) {
         int baseAttack = selectedPokemon.baseAttack;
         int baseDefense = selectedPokemon.baseDefense;
         int baseStamina = selectedPokemon.baseStamina;

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/Pokemon.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/Pokemon.java
@@ -8,6 +8,23 @@ import java.util.List;
  */
 
 public class Pokemon {
+
+    public enum Gender {
+        M("♂"),
+        F("♀"),
+        N("");
+
+        private String symbol;
+
+        Gender(String symbol) {
+            this.symbol = symbol;
+        }
+
+        @Override public String toString() {
+            return symbol;
+        }
+    }
+
     /**
      * Evolutions of this Pokemon, sorted in alphabetical order.
      * Try to avoid assumptions that only hold for Gen. I Pokemon: evolutions can have smaller

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanContainer.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanContainer.java
@@ -1,7 +1,5 @@
 package com.kamron.pogoiv.scanlogic;
 
-import com.google.common.base.Optional;
-
 import java.util.ArrayList;
 
 /**
@@ -26,7 +24,7 @@ public class ScanContainer {
      * Create a new IVScanResult and updates the scanContainer singleton.
      */
     public static IVScanResult createIVScanResult(Pokemon pokemon, double estimatedPokemonLevel, int pokemonCP,
-                                                  Optional<String> pokemonGender) {
+                                                  Pokemon.Gender pokemonGender) {
         IVScanResult res = new IVScanResult(pokemon, estimatedPokemonLevel, pokemonCP, pokemonGender);
         scanContainer.addNewScan(res);
         return res;

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanResult.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanResult.java
@@ -13,7 +13,7 @@ public class ScanResult {
     private final LeveLRange estimatedPokemonLevelRange;
     private final String pokemonName;
     private final String pokemonType;
-    private final Optional<String> pokemonGender;
+    private final Pokemon.Gender pokemonGender;
     private final String candyName;
     private final Optional<Integer> pokemonHP;
     private final Optional<Integer> pokemonCP;
@@ -24,7 +24,7 @@ public class ScanResult {
     private final String uniqueID;
 
     public ScanResult(LeveLRange estimatedPokemonLevel, String pokemonName, String pokemonType, String candyName,
-                      Optional<String> pokemonGender,
+                      Pokemon.Gender pokemonGender,
                       Optional<Integer> pokemonHP, Optional<Integer> pokemonCP,
                       Optional<Integer> pokemonCandyAmount, Optional<Integer> upgradeCandyCost,
                       Optional<Integer> powerUpStardustCost, Optional<Integer> powerUpCandyCost, String uniqueID) {
@@ -54,7 +54,7 @@ public class ScanResult {
         return pokemonType;
     }
 
-    public Optional<String> getPokemonGender() {
+    public Pokemon.Gender getPokemonGender() {
         return pokemonGender;
     }
 


### PR DESCRIPTION
Use scanned pokemon gender to better identify Nidoran♀ and Nidoran♂.

Use new Pokemon.Gender enum (values M, F, N) instead of Optional<String> to represent gender information.

Fixes #750 and #812 