### PR TITLE
Do not use alpha attribute since it's not supported on API < 23

### DIFF
--- a/app/src/main/res/color/goiv_btn_colored_borderless_text_material.xml
+++ b/app/src/main/res/color/goiv_btn_colored_borderless_text_material.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_enabled="false" android:color="?android:attr/textColorSecondary" android:alpha="?android:attr/disabledAlpha"/>
+    <item android:state_enabled="false" android:color="?android:attr/textColorSecondary" />
     <item android:color="@color/colorPrimary"/>
 </selector>


### PR DESCRIPTION
Remove an attribute that made the app crash when inflating borderless Button on Android < 23.