### PR TITLE
Percentage to perfection clipboard token

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/clipboardlogic/ClipboardTokenCollection.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboardlogic/ClipboardTokenCollection.java
@@ -9,6 +9,7 @@ import com.kamron.pogoiv.clipboardlogic.tokens.CustomSeparatorToken;
 import com.kamron.pogoiv.clipboardlogic.tokens.ExtendedCpTierToken;
 import com.kamron.pogoiv.clipboardlogic.tokens.HexIVToken;
 import com.kamron.pogoiv.clipboardlogic.tokens.HpToken;
+import com.kamron.pogoiv.clipboardlogic.tokens.IVPercentageToPerfectionToken;
 import com.kamron.pogoiv.clipboardlogic.tokens.IVPercentageToken;
 import com.kamron.pogoiv.clipboardlogic.tokens.IVPercentageTokenMode;
 import com.kamron.pogoiv.clipboardlogic.tokens.IVSum;
@@ -94,6 +95,8 @@ public class ClipboardTokenCollection {
         tokens.add(new WorthTrainingToken(true, true)); // As above, max evolution
 
         tokens.add(new CpPercentileToken(false));
+
+        tokens.add(new IVPercentageToPerfectionToken(false));
 
         tokens.add(new PerfectionCPPercentageToken(true)); //how close your poke max evolved on lvl 40 cp is to 100% iv
         tokens.add(new PerfectionCPPercentageToken(false));//how close your poke on lvl 40 cp is to 100% iv

--- a/app/src/main/java/com/kamron/pogoiv/clipboardlogic/tokens/CpPercentileToken.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboardlogic/tokens/CpPercentileToken.java
@@ -25,7 +25,7 @@ public class CpPercentileToken extends ClipboardToken {
 
     @Override
     public int getMaxLength() {
-        return 4;
+        return 3;
     }
 
     private static int compositionLookup(int total) {

--- a/app/src/main/java/com/kamron/pogoiv/clipboardlogic/tokens/IVPercentageToPerfectionToken.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboardlogic/tokens/IVPercentageToPerfectionToken.java
@@ -1,0 +1,68 @@
+package com.kamron.pogoiv.clipboardlogic.tokens;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+
+import com.kamron.pogoiv.R;
+import com.kamron.pogoiv.clipboardlogic.ClipboardToken;
+import com.kamron.pogoiv.scanlogic.IVCombination;
+import com.kamron.pogoiv.scanlogic.IVScanResult;
+import com.kamron.pogoiv.scanlogic.PokeInfoCalculator;
+
+/**
+ * Token representing how far in IVs % your pokemon is to perfect.
+ */
+
+public class IVPercentageToPerfectionToken extends ClipboardToken {
+    /**
+     * Create a clipboard token.
+     * The boolean in the constructor can be set to false if pokemon evolution is not applicable.
+     *
+     * @param maxEv true if the token should change its logic to pretending the pokemon is fully evolved.
+     */
+    public IVPercentageToPerfectionToken(boolean maxEv) {
+        super(maxEv);
+    }
+
+    @Override
+    public int getMaxLength() {
+        return 3;
+    }
+
+    @SuppressLint("DefaultLocale") @Override
+    public String getValue(IVScanResult ivScanResult, PokeInfoCalculator pokeInfoCalculator) {
+        IVCombination combination = ivScanResult.getHighestIVCombination();
+        if (combination != null) {
+            int result = 100 - combination.percentPerfect;
+            return String.format("%02d", result);
+        } else {
+            return "";
+        }
+    }
+
+    @Override
+    public String getPreview() {
+        return "03";
+    }
+
+
+    @Override
+    public String getTokenName(Context context) {
+        return "IV% to top";
+    }
+
+    @Override
+    public String getLongDescription(Context context) {
+        return context.getString(R.string.token_msg_iv_perc_to_top);
+    }
+
+    @Override
+    public Category getCategory() {
+        return Category.EVALUATION;
+    }
+
+    @Override
+    public boolean changesOnEvolutionMax() {
+        return false;
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -337,6 +337,7 @@
     <string name="token_msg_worthTra_msg1">"This token returns an evaluation of how worth it is to train this monster, based both on the base stats and the "</string>
     <string name="token_msg_worthTra_msg2" formatted="false">" possible IV stats. For instance, a 96% IV Alakazam will get a score higher than a 20% Tyranitar, regardless the fact that the maximum possible CP for the latter is higher: since the probability of getting better Tyranitar is higher than the one of getting better Alakazams, the second represents a much better stardust investment. Ranges in 00–99. Always returns two digits."</string>
     <string name="token_msg_train">Train</string>
+    <string name="token_msg_iv_perc_to_top">"Get the difference in percentage between the maximum and the perfect IV combination. For example, if the max IV combination percentage is 97, this token will return 03."</string>
     <string name="go_back_to_goiv">Go back to GoIV</string>
     <string name="go_back">Go back</string>
     <string name="send_email_to_devs_recalibration">If GoIV failed recalibrating when it should have worked, please press the button below to generate an automatic bug report email.</string>


### PR DESCRIPTION
As requested on Discord #dev channel, add a token that tells you how much your pokémon max IV combination differs from the perfection in percentage.
Since it's made for sorting purposes, adds leading zeroes if the result is lower than 10.
I.e. on a 93% IV pokemon results 07.

Also correct a small imprecision in CpPercentileToken.