### PR TITLE
Add extra copy to clipboard format for monsters with perfect IV's

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
+++ b/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
@@ -36,6 +36,7 @@ public class GoIVSettings {
     public static final String DELETE_SCREENSHOTS = "deleteScreenshots";
     public static final String COPY_TO_CLIPBOARD = "copyToClipboard";
     public static final String COPY_TO_CLIPBOARD_SINGLE = "copyToClipboardSingle";
+    public static final String COPY_TO_CLIPBOARD_PERFECTIV = "copyToClipboardPerfectIv";
     public static final String SEND_CRASH_REPORTS = "sendCrashReports";
     public static final String AUTO_UPDATE_ENABLED = "autoUpdateEnabled";
     public static final String POKESPAM_ENABLED = "pokeSpamEnabled";
@@ -43,6 +44,7 @@ public class GoIVSettings {
     public static final String APPRAISAL_WINDOW_POSITION = "appraisalWindowPosition";
     public static final String GOIV_CLIPBOARDSETTINGS = "GoIV_ClipboardSettings";
     public static final String GOIV_CLIPBOARDSINGLESETTINGS = "GoIV_ClipboardSingleSettings";
+    public static final String GOIV_CLIPBOARDPERFECTIVSETTINGS = "GoIV_ClipboardPerfectIvSettings";
     public static final String SHOW_TRANSLATED_POKEMON_NAME = "showTranslatedPokemonName";
     public static final String HAS_WARNED_USER_NO_SCREENREC = "GOIV_hasWarnedUserNoScreenRec";
     public static final String COPY_TO_CLIPBOARD_SHOW_TOAST = "copyToClipboardShowToast";
@@ -166,20 +168,6 @@ public class GoIVSettings {
         return ClipboardTokenHandler.tokenListToRepresentation(defaultTokens);
     }
 
-    public void setClipboardPreference(String tokenListRepresentation) {
-        SharedPreferences.Editor editor = prefs.edit();
-        editor.putString(GoIVSettings.GOIV_CLIPBOARDSETTINGS, tokenListRepresentation);
-        editor.apply();
-    }
-
-    public void setClipboardSinglePreference(String tokenListRepresentation) {
-        //Clipboard single is the add-on setting if you want different clipboards for 1 or many results
-        SharedPreferences.Editor editor = prefs.edit();
-
-        editor.putString(GoIVSettings.GOIV_CLIPBOARDSINGLESETTINGS, tokenListRepresentation);
-        editor.apply();
-    }
-
     public String getClipboardSinglePreference() {
         String prefValue = prefs.getString(GOIV_CLIPBOARDSINGLESETTINGS, "");
         if (!Strings.isNullOrEmpty(prefValue)) {
@@ -196,6 +184,40 @@ public class GoIVSettings {
         return ClipboardTokenHandler.tokenListToRepresentation(defaultTokens);
     }
 
+    public String getClipboardPerfectIvPreference() {
+        String prefValue = prefs.getString(GOIV_CLIPBOARDPERFECTIVSETTINGS, "");
+        if (!Strings.isNullOrEmpty(prefValue)) {
+            return prefValue;
+        }
+
+        //Below code gets the string representation of the "default" perfect IV clipboard setting
+        ArrayList<ClipboardToken> defaultTokens = new ArrayList<>();
+        // Name (7 char) + average IV (should be 100%)
+        defaultTokens.add(new PokemonNameToken(false, 5));
+        defaultTokens.add(new IVPercentageToken(IVPercentageTokenMode.AVG));
+
+        return ClipboardTokenHandler.tokenListToRepresentation(defaultTokens);
+    }
+
+    public void setClipboardPreference(String tokenListRepresentation) {
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putString(GOIV_CLIPBOARDSETTINGS, tokenListRepresentation);
+        editor.apply();
+    }
+
+    public void setClipboardSinglePreference(String tokenListRepresentation) {
+        //Clipboard single is the add-on setting if you want different clipboards for 1 or many results
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putString(GOIV_CLIPBOARDSINGLESETTINGS, tokenListRepresentation);
+        editor.apply();
+    }
+
+    public void setClipboardPerfectIvPreference(String tokenListRepresentation) {
+        //Clipboard single is the add-on setting if you want different clipboards for 1 or many results
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putString(GOIV_CLIPBOARDPERFECTIVSETTINGS, tokenListRepresentation);
+        editor.apply();
+    }
 
     public boolean hasShownNoScreenRecWarning() {
         return prefs.getBoolean(HAS_WARNED_USER_NO_SCREENREC, false);
@@ -215,6 +237,10 @@ public class GoIVSettings {
 
     public boolean shouldCopyToClipboardSingle() {
         return prefs.getBoolean(COPY_TO_CLIPBOARD_SINGLE, false);
+    }
+
+    public boolean shouldCopyToClipboardPerfectIV() {
+        return prefs.getBoolean(COPY_TO_CLIPBOARD_PERFECTIV, false);
     }
 
     public boolean shouldSendCrashReports() {

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -87,6 +87,7 @@ import butterknife.OnClick;
 import io.apptik.widget.MultiSlider;
 
 import static com.kamron.pogoiv.GoIVSettings.APPRAISAL_WINDOW_POSITION;
+import static com.kamron.pogoiv.clipboardlogic.ClipboardResultMode.SINGLE_RESULT;
 
 /**
  * Currently, the central service in Pokemon Go, dealing with everything except
@@ -1208,7 +1209,7 @@ public class Pokefly extends Service {
         IVScanResult singleIVScanResult = new IVScanResult(ivScanResult.pokemon, ivScanResult.estimatedPokemonLevel,
                 ivScanResult.scannedCP, ivScanResult.scannedGender);
         singleIVScanResult.addIVCombination(ivCombination.att, ivCombination.def, ivCombination.sta);
-        clipResult = clipboardTokenHandler.getResults(singleIVScanResult, pokeInfoCalculator, true);
+        clipResult = clipboardTokenHandler.getResults(singleIVScanResult, pokeInfoCalculator, SINGLE_RESULT);
 
 
         Toast toast = Toast.makeText(this, String.format(getString(R.string.clipboard_copy_toast), clipResult),
@@ -1389,6 +1390,8 @@ public class Pokefly extends Service {
     }
 
     /**
+     * Calculate the seekbar progress from a pokemon level.
+     *
      * @param level a valid pokemon level (hence <= 40).
      * @return a seekbar progress index.
      */
@@ -1397,7 +1400,7 @@ public class Pokefly extends Service {
     }
 
     /**
-     * Sets the growth estimate text boxes to correpond to the
+     * Sets the growth estimate text boxes to correspond to the
      * pokemon evolution and level set by the user.
      */
     private void populateAdvancedInformation(IVScanResult ivScanResult) {
@@ -1964,6 +1967,4 @@ public class Pokefly extends Service {
             }
         }
     };
-
-
 }

--- a/app/src/main/java/com/kamron/pogoiv/activities/ClipboardModifierFragment.java
+++ b/app/src/main/java/com/kamron/pogoiv/activities/ClipboardModifierFragment.java
@@ -22,6 +22,7 @@ import android.widget.Toast;
 
 import com.google.common.base.Strings;
 import com.kamron.pogoiv.R;
+import com.kamron.pogoiv.clipboardlogic.ClipboardResultMode;
 import com.kamron.pogoiv.widgets.recyclerviews.adapters.TokensPreviewAdapter;
 import com.kamron.pogoiv.widgets.recyclerviews.adapters.TokensShowcaseAdapter;
 import com.kamron.pogoiv.widgets.recyclerviews.decorators.MarginItemDecorator;
@@ -58,7 +59,7 @@ public class ClipboardModifierFragment
     FloatingActionButton btnMaxEvolution;
 
 
-    private boolean singleResultMode;
+    private ClipboardResultMode resultMode;
     private boolean maxEvolutionVariant = true;
     private TokensPreviewAdapter tokenPreviewAdapter;
     private TokensShowcaseAdapter tokenShowcaseAdapter;
@@ -66,9 +67,9 @@ public class ClipboardModifierFragment
     private ClipboardTokenHandler cth;
 
 
-    public static ClipboardModifierFragment newInstance(boolean singleResultMode) {
+    public static ClipboardModifierFragment newInstance(ClipboardResultMode resultMode) {
         Bundle args = new Bundle();
-        args.putBoolean(ARG_SINGLE_RESULT_MODE, singleResultMode);
+        args.putSerializable(ARG_SINGLE_RESULT_MODE, resultMode);
         ClipboardModifierFragment f = new ClipboardModifierFragment();
         f.setArguments(args);
         return f;
@@ -80,7 +81,7 @@ public class ClipboardModifierFragment
 
     @Override public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        singleResultMode = getArguments().getBoolean(ARG_SINGLE_RESULT_MODE, false);
+        resultMode = (ClipboardResultMode) getArguments().get(ARG_SINGLE_RESULT_MODE);
         cth = new ClipboardTokenHandler(getContext());
     }
 
@@ -115,7 +116,7 @@ public class ClipboardModifierFragment
                 updateMaxLength();
             }
         });
-        tokenPreviewAdapter.setData(cth.getTokens(singleResultMode));
+        tokenPreviewAdapter.setData(cth.getTokens(resultMode));
         tokenPreviewRecyclerView.setHasFixedSize(false);
         tokenPreviewRecyclerView.setLayoutManager(new LinearLayoutManager(getContext(), HORIZONTAL, false));
         tokenPreviewRecyclerView.addItemDecoration(new MarginItemDecorator(2, 0, 2, 0));
@@ -160,7 +161,7 @@ public class ClipboardModifierFragment
     }
 
     public void saveConfiguration() {
-        cth.setTokenList(tokenPreviewAdapter.getData(), singleResultMode);
+        cth.setTokenList(tokenPreviewAdapter.getData(), resultMode);
     }
 
     /**
@@ -169,7 +170,7 @@ public class ClipboardModifierFragment
      * @return true if there are unsaved changes
      */
     public boolean hasUnsavedChanges() {
-        return !cth.savedConfigurationEquals(tokenPreviewAdapter.getData(), singleResultMode);
+        return !cth.savedConfigurationEquals(tokenPreviewAdapter.getData(), resultMode);
     }
 
     /**

--- a/app/src/main/java/com/kamron/pogoiv/clipboardlogic/ClipboardResultMode.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboardlogic/ClipboardResultMode.java
@@ -1,0 +1,22 @@
+package com.kamron.pogoiv.clipboardlogic;
+
+/**
+ * The clipboard result mode.
+ */
+public enum ClipboardResultMode {
+    /**
+     * The general clipboard result mode. Used when there are multiple results or none of the other result modes have
+     * been enabled.
+     */
+    GENERAL_RESULT,
+
+    /**
+     * Clipboard result mode used when the scan yields a single result.
+     */
+    SINGLE_RESULT,
+
+    /**
+     * Clipboard result mode used when the scan yields a result with perfect IV's (100%).
+     */
+    PERFECT_IV_RESULT
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -224,7 +224,7 @@
     <string name="discard_unsaved_changes">Hay cambios sin guardar.\n¿Estás seguro de descartar los cambios?</string>
     <string name="configuration_saved">¡Configuración guardada!</string>
     <string name="no_token_selected">Ninguna ficha seleccionada</string>
-    <string name="token_max_evolution">\n\nEsta ficha es una variante de máx. evolución, significa que devolverá el resultado como si su monstruo ya estuviera evolucionado al máximo, lo que podría ser interesante en muchos casos.</string>
+    <string name="token_max_evolution">%1$s\n\nEsta ficha es una variante de máx. evolución, significa que devolverá el resultado como si su monstruo ya estuviera evolucionado al máximo, lo que podría ser interesante en muchos casos.</string>
     <string name="token_max_characters">(%1$d/12 caracteres)</string>
     <string name="token_show_max_evo_variant">Mostrar fichas de variantes máx. evolución</string>
     <string name="token_show_standard">Mostrar fichas estándar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,6 +170,8 @@
     <string name="no_clipboard_preview">No preview available</string>
     <string name="copy_to_clip_single_setting">Copy differently on single result</string>
     <string name="copy_to_clip_single_setting_summary">Allows you to define another setting for Copy to clipboard in Edit which will show a different result when a scan returns a single possibility.</string>
+    <string name="copy_to_clip_perfectiv_setting">Copy differently when is IV 100%</string>
+    <string name="copy_to_clip_perfectiv_setting_summary">Allows you to define another setting for Copy to clipboard in Edit which will show a different result when a scan returns a 100% result.</string>
     <string name="view_credits">View credits</string>
     <string name="view_credits_summary">View application credits, used open source projects and thanks</string>
     <string name="title_activity_credits">CreditsActivity</string>
@@ -235,7 +237,7 @@
     <string name="discard_unsaved_changes">There are unsaved changes.\nDo you really want to discard them?</string>
     <string name="configuration_saved">Configuration saved!</string>
     <string name="no_token_selected">No token selected</string>
-    <string name="token_max_evolution">\n\nThis token is a max evolution variant, meaning that it will return a result as if your monster was already fully evolved, which might be more interesting in a lot of cases.</string>
+    <string name="token_max_evolution">%1$s\n\nThis token is a max evolution variant, meaning that it will return a result as if your monster was already fully evolved, which might be more interesting in a lot of cases.</string>
     <string name="token_max_characters">(%1$d/12 characters)</string>
     <string name="token_show_max_evo_variant">Show tokens max evolution variant</string>
     <string name="token_show_standard">Show standard tokens</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -48,6 +48,13 @@
             android:title="@string/copy_to_clip_single_setting"/>
 
         <SwitchPreference
+            android:defaultValue="false"
+            android:dependency="@string/copy_to_clipboard_setting_key"
+            android:key="copyToClipboardPerfectIv"
+            android:summary="@string/copy_to_clip_perfectiv_setting_summary"
+            android:title="@string/copy_to_clip_perfectiv_setting"/>
+
+        <SwitchPreference
             android:defaultValue="true"
             android:dependency="@string/copy_to_clipboard_setting_key"
             android:key="copyToClipboardShowToast"

--- a/checkstyle/checkstyle-rules.xml
+++ b/checkstyle/checkstyle-rules.xml
@@ -56,7 +56,10 @@
         <module name="NeedBraces">
             <property name="id" value="NeedBraces"/>
         </module>
-        <module name="LeftCurly"/>
+        <module name="LeftCurly">
+            <property name="maxLineLength" value="120"/>
+        </module>
+        <module name="RightCurly"/>
         <module name="RightCurly">
             <property name="option" value="alone"/>
             <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT"/>

--- a/checkstyle/checkstyle-rules.xml
+++ b/checkstyle/checkstyle-rules.xml
@@ -56,10 +56,7 @@
         <module name="NeedBraces">
             <property name="id" value="NeedBraces"/>
         </module>
-        <module name="LeftCurly">
-            <property name="maxLineLength" value="120"/>
-        </module>
-        <module name="RightCurly"/>
+        <module name="LeftCurly"/>
         <module name="RightCurly">
             <property name="option" value="alone"/>
             <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO, STATIC_INIT, INSTANCE_INIT"/>


### PR DESCRIPTION
I've added an extra clipboard copy format for monsters which have perfect IV's, as I find showing both the percentage and the individual IV's a bit redundant.

- Add a ClipboardResultMode enum to differentiate between clipboard copy
  modes. This replaces the singleResultMode boolean
- Add extra tab so the user can configure a format for monsters with
  perfect IV's
- Change the logic which determines which clipboard result mode to use
- Removed maxLineLength property from LeftCurly Checkstyle rule, it is
  no longer valid
- Small improvements in JavaDoc as suggested by Checkstyle