### PR TITLE
[Suggestion] Pokedex number view in scan result

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -225,6 +225,8 @@ public class Pokefly extends Service {
     TextView exResCandy;
     @BindView(R.id.exResLevel)
     TextView exResLevel;
+    @BindView(R.id.resultsPokedexNumber)
+    TextView resultPokedexNumber;
     @BindView(R.id.resultsPokemonName)
     TextView resultsPokemonName;
     @BindView(R.id.resultsCombinations)
@@ -1336,6 +1338,7 @@ public class Pokefly extends Service {
      * Shows the name and level of the pokemon in the results dialog.
      */
     private void populateResultsHeader(IVScanResult ivScanResult) {
+        resultPokedexNumber.setText("#" + (ivScanResult.pokemon.number + 1));
         resultsPokemonName.setText(ivScanResult.pokemon.toString());
         resultsPokemonLevel.setText(getString(R.string.level_num, ivScanResult.estimatedPokemonLevel.toString()));
     }

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1338,7 +1338,7 @@ public class Pokefly extends Service {
      * Shows the name and level of the pokemon in the results dialog.
      */
     private void populateResultsHeader(IVScanResult ivScanResult) {
-        resultPokedexNumber.setText("#" + (ivScanResult.pokemon.pokedexNumber));
+        resultPokedexNumber.setText("#" + ivScanResult.pokemon.pokedexNumber);
         resultsPokemonName.setText(ivScanResult.pokemon.toString());
         resultsPokemonLevel.setText(getString(R.string.level_num, ivScanResult.estimatedPokemonLevel.toString()));
     }

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -1338,7 +1338,7 @@ public class Pokefly extends Service {
      * Shows the name and level of the pokemon in the results dialog.
      */
     private void populateResultsHeader(IVScanResult ivScanResult) {
-        resultPokedexNumber.setText("#" + (ivScanResult.pokemon.number + 1));
+        resultPokedexNumber.setText("#" + (ivScanResult.pokemon.pokedexNumber));
         resultsPokemonName.setText(ivScanResult.pokemon.toString());
         resultsPokemonLevel.setText(getString(R.string.level_num, ivScanResult.estimatedPokemonLevel.toString()));
     }

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPopupButton.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPopupButton.java
@@ -107,9 +107,9 @@ public class IVPopupButton extends android.support.v7.widget.AppCompatButton {
         int low = ivrs.getLowestIVCombination().percentPerfect;
         int high = ivrs.getHighestIVCombination().percentPerfect;
         if (ivrs.getCount() == 1 || high == low) { // display something like "IV: 98%"
-            setText(ivrs.pokemon.name + "\nIV: " + low + "%");
+            setText("#" + (ivrs.pokemon.number + 1) + " " + ivrs.pokemon.name + "\nIV: " + low + "%");
         } else { // display something like "IV: 55 - 87%"
-            setText(ivrs.pokemon.name + "\nIV: " + low + " - " + high + "%");
+            setText("#" + (ivrs.pokemon.number + 1) + " " + ivrs.pokemon.name + "\nIV: " + low + " - " + high + "%");
         }
         if (ivrs.rangeIVScan) {
             setText(getText() + "*");

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPopupButton.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPopupButton.java
@@ -107,9 +107,9 @@ public class IVPopupButton extends android.support.v7.widget.AppCompatButton {
         int low = ivrs.getLowestIVCombination().percentPerfect;
         int high = ivrs.getHighestIVCombination().percentPerfect;
         if (ivrs.getCount() == 1 || high == low) { // display something like "IV: 98%"
-            setText("#" + (ivrs.pokemon.number + 1) + " " + ivrs.pokemon.name + "\nIV: " + low + "%");
+            setText("#" + ivrs.pokemon.pokedexNumber + " " + ivrs.pokemon.name + "\nIV: " + low + "%");
         } else { // display something like "IV: 55 - 87%"
-            setText("#" + (ivrs.pokemon.number + 1) + " " + ivrs.pokemon.name + "\nIV: " + low + " - " + high + "%");
+            setText("#" + ivrs.pokemon.pokedexNumber + " " + ivrs.pokemon.name + "\nIV: " + low + " - " + high + "%");
         }
         if (ivrs.rangeIVScan) {
             setText(getText() + "*");

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPopupButton.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPopupButton.java
@@ -107,9 +107,9 @@ public class IVPopupButton extends android.support.v7.widget.AppCompatButton {
         int low = ivrs.getLowestIVCombination().percentPerfect;
         int high = ivrs.getHighestIVCombination().percentPerfect;
         if (ivrs.getCount() == 1 || high == low) { // display something like "IV: 98%"
-            setText("#" + ivrs.pokemon.pokedexNumber + " " + ivrs.pokemon.name + "\nIV: " + low + "%");
+            setText(String.format("#%d %s\nIV: %d%%", ivrs.pokemon.pokedexNumber, ivrs.pokemon.name, low));
         } else { // display something like "IV: 55 - 87%"
-            setText("#" + ivrs.pokemon.pokedexNumber + " " + ivrs.pokemon.name + "\nIV: " + low + " - " + high + "%");
+            setText(String.format("#%d %s\nIV: %d - %d%%", ivrs.pokemon.pokedexNumber, ivrs.pokemon.name, low, high));
         }
         if (ivrs.rangeIVScan) {
             setText(getText() + "*");

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/Pokemon.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/Pokemon.java
@@ -51,6 +51,7 @@ public class Pokemon {
     private final String displayName;
 
     public final int number; //index number in resources, pokedex number - 1
+    public final int pokedexNumber;
     public final int baseAttack;
     public final int baseDefense;
     public final int baseStamina;
@@ -62,6 +63,7 @@ public class Pokemon {
         this.name = name;
         this.displayName = displayName;
         this.number = number;
+        this.pokedexNumber = number + 1;
         this.baseAttack = baseAttack;
         this.baseDefense = baseDefense;
         this.baseStamina = baseStamina;

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonShareHandler.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonShareHandler.java
@@ -22,7 +22,7 @@ public class PokemonShareHandler {
     public void spreadResultIntent(Pokefly pokefly, IVScanResult ivScan,String uniquePokemonID) {
         JSONObject jsonPokemon = new JSONObject();
         try {
-            jsonPokemon.put("PokemonId", ivScan.pokemon.number + 1);
+            jsonPokemon.put("PokemonId", ivScan.pokemon.pokedexNumber);
             jsonPokemon.put("AtkMin", ivScan.lowAttack);
             jsonPokemon.put("AtkMax", ivScan.highAttack);
             jsonPokemon.put("DefMin", ivScan.lowDefense);

--- a/app/src/main/java/com/kamron/pogoiv/widgets/PokemonSpinnerAdapter.java
+++ b/app/src/main/java/com/kamron/pogoiv/widgets/PokemonSpinnerAdapter.java
@@ -64,7 +64,7 @@ public class PokemonSpinnerAdapter extends ArrayAdapter<Pokemon> {
 
         TextView row = (TextView) inflater.inflate(textViewResourceId, parent, false);
         Pokemon pokemon = pokemons.get(position);
-        String text = String.format("#%d %s", pokemon.number + 1, pokemon.toString());
+        String text = String.format("#%d %s", pokemon.pokedexNumber, pokemon.toString());
 
         int padding = GuiUtil.dpToPixels(5, context);
         row.setPadding(padding, 0, 0, padding);

--- a/app/src/main/res/layout/dialog_results.xml
+++ b/app/src/main/res/layout/dialog_results.xml
@@ -24,7 +24,6 @@
             android:textSize="18sp"
             android:textColor="#888"
             android:text="#ddd"
-            android:layout_marginStart="6dp"
             android:layout_marginEnd="6dp"/>
 
         <TextView

--- a/app/src/main/res/layout/dialog_results.xml
+++ b/app/src/main/res/layout/dialog_results.xml
@@ -18,6 +18,16 @@
         android:baselineAligned="true">
 
         <TextView
+            android:id="@+id/resultsPokedexNumber"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="18sp"
+            android:textColor="#888"
+            android:text="#ddd"
+            android:layout_marginStart="6dp"
+            android:layout_marginEnd="6dp"/>
+
+        <TextView
             android:id="@+id/resultsPokemonName"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Hi GoIV pj team.

I have a small suggestion for GoIV.
I think it is useful that the pokedex number is displayed in a scan result.

In Pokemon Go game app, as you know, 
we can use pokedex numbers for filtering pokemons, like following:
![device-2018-02-06-002643](https://user-images.githubusercontent.com/17121615/35821596-de8bac26-0aec-11e8-994b-4c22c6698f1f.png)

If GoIV displays the pokedex number simply and quickly in a scan result,
we can select specific pokemon by this number without going back from Pokedex menu
or switching app and visiting other pokedex info web site.
That's useful, I think.

So with this PR, I suggest the way to display the pokedex number in a scan result.
In my implementation, pokedex number is placed before the pokemon name.

What do you think about this suggestion?
Would you tell me your good idea?

Screen images are following: