### PR TITLE
Update Rayquaza stats

### DIFF
--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -387,7 +387,7 @@
         <item>268</item> <!--Latios-->
         <item>270</item> <!--Kyogre-->
         <item>270</item> <!--Groudon-->
-        <item>312</item> <!--Rayquaza-->
+        <item>284</item> <!--Rayquaza-->
         <item>210</item> <!--Jirachi-->
         <item>144</item> <!--DeoxysDefens-->
         <item>414</item> <!--DeoxysAttack-->
@@ -781,7 +781,7 @@
         <item>228</item> <!--Latios-->
         <item>251</item> <!--Kyogre-->
         <item>251</item> <!--Groudon-->
-        <item>187</item> <!--Rayquaza-->
+        <item>170</item> <!--Rayquaza-->
         <item>210</item> <!--Jirachi-->
         <item>330</item> <!--DeoxysDefens-->
         <item>46</item> <!--DeoxysAttack-->
@@ -1175,7 +1175,7 @@
         <item>160</item> <!--Latios-->
         <item>182</item> <!--Kyogre-->
         <item>182</item> <!--Groudon-->
-        <item>210</item> <!--Rayquaza-->
+        <item>191</item> <!--Rayquaza-->
         <item>200</item> <!--Jirachi-->
         <item>100</item> <!--DeoxysDefens-->
         <item>100</item> <!--DeoxysAttack-->


### PR DESCRIPTION
Stats in latest gamemaster (extracted today)

item_templates {
  template_id: "V0384_POKEMON_RAYQUAZA"
  pokemon_settings {
    pokemon_id: 384
    model_scale: 0.57
    type: POKEMON_TYPE_DRAGON
    type_2: POKEMON_TYPE_FLYING
    camera {
      disk_radius_m: 0.555
      cylinder_radius_m: 2
      cylinder_height_m: 3.5
      cylinder_ground_m: 1
      shoulder_mode_scale: 0.5
    }
    encounter {
      base_capture_rate: 0.02
      base_flee_rate: 0.01
      collision_radius_m: 1
      collision_height_m: 3
      collision_head_radius_m: 0.25
      movement_timer_s: 11
      jump_time_s: 1.1
      attack_timer_s: 20
      attack_probability: 0.1
      dodge_probability: 0.15
      dodge_duration_s: 1
      dodge_distance: 1
      camera_distance: 6
      min_pokemon_action_frequency_s: 0.2
      max_pokemon_action_frequency_s: 1.6
    }
    stats {
      base_stamina: 191
      base_attack: 284
      base_defense: 170
    }