### PR TITLE
Change default setting false for pokespam and appraisalexpand

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
+++ b/app/src/main/java/com/kamron/pogoiv/GoIVSettings.java
@@ -267,11 +267,11 @@ public class GoIVSettings {
     }
 
     public boolean isPokeSpamEnabled() {
-        return prefs.getBoolean(POKESPAM_ENABLED, true);
+        return prefs.getBoolean(POKESPAM_ENABLED, false);
     }
 
     public boolean shouldAutoOpenExpandedAppraise() {
-        return prefs.getBoolean(AUTO_OPEN_APPRAISE_DIALOGUE, true);
+        return prefs.getBoolean(AUTO_OPEN_APPRAISE_DIALOGUE, false);
     }
 
     public boolean shouldReplaceQuickIvPreviewWithClipboard() {

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -62,7 +62,7 @@
             android:title="@string/copy_to_clip_show_toast_setting"/>
 
         <SwitchPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:key="pokeSpamEnabled"
             android:summary="@string/pokespam_setting_summary"
             android:title="@string/pokespam_setting_title"/>


### PR DESCRIPTION
Pokespam is now off by default - It's a useful feature, but its also confusing for users to see candy # as input if they dont know about the feature, and it clutters up the UI.

Appraisal expand by default was an option that was set to open by default when the two views were not yet  divided into two different panels. The setting used to make both panels visible, but now it no longer makes sense.