### PR TITLE
Fix InputFraction pokemon level seek bar max value

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/fractions/InputFraction.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/fractions/InputFraction.java
@@ -205,21 +205,27 @@ public class InputFraction extends Fraction {
 
     @OnClick(R.id.btnDecrementLevel)
     public void decrementLevel() {
-        pokefly.estimatedPokemonLevelRange.dec();
-        adjustArcPointerBar(pokefly.estimatedPokemonLevelRange.min);
+        if (pokefly.estimatedPokemonLevelRange.min > Data.MINIMUM_POKEMON_LEVEL) {
+            pokefly.estimatedPokemonLevelRange.dec();
+            adjustArcPointerBar(pokefly.estimatedPokemonLevelRange.min);
+        }
     }
 
     @OnClick(R.id.btnIncrementLevel)
     public void incrementLevel() {
-        pokefly.estimatedPokemonLevelRange.inc(pokefly.getTrainerLevel());
-        adjustArcPointerBar(pokefly.estimatedPokemonLevelRange.min);
+        if (Data.maxPokeLevelToIndex(pokefly.estimatedPokemonLevelRange.min) < arcAdjustBar.getMax()) {
+            pokefly.estimatedPokemonLevelRange.inc();
+            adjustArcPointerBar(pokefly.estimatedPokemonLevelRange.min);
+        }
     }
 
     /**
      * Creates the arc adjuster used to move the arc pointer in the scan screen.
      */
     private void createArcAdjuster() {
-        arcAdjustBar.setMax(Data.trainerLevelToMaxPokeLevelIndex(pokefly.getTrainerLevel()));
+        // The max seek bar value will be the maximum wild pokemon level or the trainer max capture level if higher
+        arcAdjustBar.setMax(Math.max(Data.maxPokeLevelToIndex(Data.MAXIMUM_WILD_POKEMON_LEVEL),
+                Data.trainerLevelToMaxPokeLevelIndex(pokefly.getTrainerLevel())));
 
         arcAdjustBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override

--- a/app/src/main/java/com/kamron/pogoiv/utils/LevelRange.java
+++ b/app/src/main/java/com/kamron/pogoiv/utils/LevelRange.java
@@ -1,7 +1,5 @@
 package com.kamron.pogoiv.utils;
 
-import android.support.annotation.Nullable;
-
 import com.kamron.pogoiv.scanlogic.Data;
 
 /**
@@ -63,14 +61,8 @@ public class LevelRange {
      * before: lower:5 - higher:7,
      * after-> lower:5.5 - higher: 5.5.
      */
-    public void inc(@Nullable Integer trainerLevel) {
-        final double maxPossible;
-        if (trainerLevel != null) {
-            maxPossible = Data.trainerLevelToMaxPokeLevel(trainerLevel);
-        } else {
-            maxPossible = Data.MAXIMUM_POKEMON_LEVEL;
-        }
-        min = Math.min(min + 0.5, maxPossible);
+    public void inc() {
+        min = Math.min(min + 0.5, Data.MAXIMUM_POKEMON_LEVEL);
         max = min;
     }
 


### PR DESCRIPTION
Allow to input pokemon levels higher than the current maximum allowed for the user's trainer level