### PR TITLE
Fix HP prediction when there are multiple possible IV combinations

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/CPRange.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/CPRange.java
@@ -28,6 +28,6 @@ public class CPRange {
      * @return Double average of this CP range.
      */
     public double getFloatingAvg() {
-        return (low + high) / 2.0;
+        return (low + high) / 2f;
     }
 }

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -169,7 +169,7 @@ public class PokeInfoCalculator {
     }
 
     /**
-     * Gets the needed required candy and stardust to hit max level (relative to trainer level)
+     * Gets the needed required candy and stardust to hit max level (relative to trainer level).
      *
      * @param goalLevel             The level to reach
      * @param estimatedPokemonLevel The estimated level of hte pokemon
@@ -410,9 +410,8 @@ public class PokeInfoCalculator {
         int highHp = (int) Math.max(
                 Math.floor((selectedPokemon.baseStamina + scanResult.getIVStaminaHigh()) * lvlScalar), 10);
         int lowHp = (int) Math.max(
-                Math.floor((selectedPokemon.baseStamina + scanResult.getIVStaminaHigh()) * lvlScalar), 10);
-        int averageHP = Math.round(highHp + lowHp) / 2;
-        return averageHP;
+                Math.floor((selectedPokemon.baseStamina + scanResult.getIVStaminaLow()) * lvlScalar), 10);
+        return Math.round((highHp + lowHp) / 2f);
     }
 
     public String getTypeName(int typeNameNum) {


### PR DESCRIPTION
Fix a copy-paste error from 2 years ago that made the HP estimation always compute the HP with the highest possible stamina, with some other minor cleanups