### PR TITLE
Avoid system bars during recalibration

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -135,7 +135,7 @@
         <activity
             android:name=".activities.CreditsActivity"
             android:label="@string/title_activity_credits"
-            android:theme="@style/AppTheme.NoActionBar.Blue"
+            android:theme="@style/AppTheme.NoActionBar"
             android:parentActivityName=".activities.SettingsActivity"/>
 
         <provider

--- a/app/src/main/java/com/kamron/pogoiv/utils/WindowManagerUtils.java
+++ b/app/src/main/java/com/kamron/pogoiv/utils/WindowManagerUtils.java
@@ -2,13 +2,26 @@ package com.kamron.pogoiv.utils;
 
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.Point;
+import android.graphics.Rect;
+import android.support.annotation.NonNull;
+import android.support.annotation.Px;
 import android.view.Display;
 import android.view.WindowManager;
 
 public final class WindowManagerUtils {
 
     private WindowManagerUtils() {
+    }
+
+    public static @Px int getStatusBarSize(@NonNull Resources res) {
+        int result = 0;
+        int resourceId = res.getIdentifier("status_bar_height", "dimen", "android");
+        if (resourceId > 0) {
+            result = res.getDimensionPixelSize(resourceId);
+        }
+        return result;
     }
 
     public static Point getNavigationBarSize(Context context) {
@@ -35,6 +48,8 @@ public final class WindowManagerUtils {
         Display display = windowManager.getDefaultDisplay();
         Point size = new Point();
         display.getSize(size);
+        Rect outSize = new Rect();
+        display.getRectSize(outSize);
         return size;
     }
 

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -161,6 +161,7 @@
     <string name="title_activity_ocr_calibration_error">Errore di calibrazione</string>
     <string name="recalibration_description">La ricalibrazione incrementa le performance di GoIV trovando dinamicamente le aree di scansione specifiche per il tuo telefono.</string>
     <string name="scan_optimization_outdated_warning">I tuoi dati di calibrazione sono obsoleti. Esegui una nuova ricalibrazione dello schermo per godere di tutte le ultime funzionalità!</string>
+    <string name="email_report_require_permission">"GoIV necessita dell'accesso alla memoria esterna per condividere lo screenshot di calibrazione con la tua app di posta."</string>
     <string name="discard_unsaved_changes">Ci sono modifiche non salvate. Vuoi veramente scartarle?</string>
     <string name="configuration_saved">Configurazione salvata!</string>
     <string name="configuration_saved_feature_disabled">Configurazione salvata!\nAbilita la funzionalità \"%1$s\" nelle impostazioni per attivare la nuova configurazione!</string>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -3,11 +3,6 @@
     <style name="AppTheme.NoActionBar">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
-        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
-        <item name="android:statusBarColor">@android:color/white</item>
-    </style>
-
-    <style name="AppTheme.NoActionBar.Blue">
         <item name="android:statusBarColor">@color/colorPrimaryDark</item>
     </style>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,6 +172,7 @@
     <string name="scan_optimization_notice_text">You have not run scan calibration. It\'s recommended to run this optimization on all devices.</string>
     <string name="scan_optimization_screen_ratio_warning">GoIV has detected that your screen is not standard. You\'ll most likely need to perform screen calibration for GoIV to work.</string>
     <string name="scan_optimization_outdated_warning">Your calibration data is outdated. Please run screen calibration again to enjoy the latest features!</string>
+    <string name="email_report_require_permission">"GoIV needs to access external storage to share the calibration screenshot with your email client app."</string>
     <string name="discard_unsaved_changes">There are unsaved changes.\nDo you really want to discard them?</string>
     <string name="configuration_saved">Configuration saved!</string>
     <string name="configuration_saved_feature_disabled">Configuration saved!\nPlease enable \"%1$s\" feature in setting to activate the new configuration!</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -79,8 +79,6 @@
         <item name="windowNoTitle">true</item>
     </style>
 
-    <style name="AppTheme.NoActionBar.Blue" /> <!-- Don't remove! -->
-
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar"/>
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light"/>


### PR DESCRIPTION
Black out status and navigation bars before running a calibration to avoid interference from any notification or system icon nor virtual key.

Also fix a crash on Android 6.0+ caused by missing WRITE_EXTERNAL_STORAGE permission when sending an email report to the developers.