### PR TITLE
fix pokemon evolutions list in the input dialog

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -171,6 +171,7 @@ public class PokeInfoCalculator {
         final int[] formsCountIndex = res.getIntArray(R.array.formsCountIndex);
 
         int pokeListSize = names.length;
+        ArrayList<Pokemon> formVariantPokemons = new ArrayList<>();
         for (int i = 0; i < pokeListSize; i++) {
             Pokemon p = new Pokemon(names[i], displayNames[i], i, attack[i], defense[i], stamina[i], devolution[i],
                     evolutionCandyCost[i]);
@@ -216,7 +217,15 @@ public class PokeInfoCalculator {
                     if (!formPokemon.equals(formPokemonDisplayName)) {
                         pokemap.put(formPokemonDisplayName, formPokemon);
                     }
+                    formVariantPokemons.add(formPokemon);
                 }
+            }
+        }
+
+        // add evolutions to form variant pokemons instance if the normal form pokemon has its evolutions.
+        for (Pokemon formPokemon : formVariantPokemons) {
+            if (!pokedex.get(formPokemon.number).evolutions.isEmpty()) {
+                formPokemon.evolutions.addAll(pokedex.get(formPokemon.number).evolutions);
             }
         }
 


### PR DESCRIPTION
Hi GoIV pj team.

I've found there is a problem in the v5.0.8 (in my previous patch).
The problem is that a pokemon evolutions list is not correct in the input dialog if alolan forms included, like following.
![device-2018-06-28-153706](https://user-images.githubusercontent.com/17121615/42048745-1fa9c78e-7b3f-11e8-84b3-307a7c46d849.png)

I've detected the reason, and created a patch to fix this problem.
![device-2018-06-28-153601](https://user-images.githubusercontent.com/17121615/42048762-2c2f82e6-7b3f-11e8-96c8-bf971ab5652a.png)

Would you check this?