### PR TITLE
Support for changing scan areas for Lucky Pokemon

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
@@ -1103,8 +1103,12 @@ public class OcrHelper {
         // If no power up cost was found, check by offsetting down by the height of the
         // "LUCKY POKEMON" string, which is slightly higher than the power up candy cost field
         if (!powerUpCandyCost.isPresent()) {
-            int tempLuckyOffset =
-                    (int) (ScanArea.calibratedFromSettings(POKEMON_POWER_UP_CANDY_COST, settings).height * 1.2);
+            int tempLuckyOffset = (int) (0.0247 * pokemonImage.getHeight() * 1.2); // Default value w/o calibration
+            ScanArea powerUpCandyArea = ScanArea.calibratedFromSettings(POKEMON_POWER_UP_CANDY_COST, settings);
+            if (powerUpCandyArea != null) {
+                tempLuckyOffset = (int) (powerUpCandyArea.height * 1.2);
+            }
+            
             powerUpCandyCost = getPokemonPowerUpCandyCostFromImg(pokemonImage,
                     ScanArea.calibratedFromSettings(POKEMON_POWER_UP_CANDY_COST, settings, tempLuckyOffset));
             if (powerUpCandyCost.isPresent()) {

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/ScanArea.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/ScanArea.java
@@ -30,10 +30,24 @@ public class ScanArea {
 
     @Nullable
     public static ScanArea calibratedFromSettings(String calibrationKey, GoIVSettings settings) {
+        return calibratedFromSettings(calibrationKey, settings, 0);
+    }
+
+    /**
+     * Create a screen area by reading a setting for a certain part. For example, loading the screen area where
+     * the pokemon HP might be.
+     *
+     * @param calibrationKey The key value used to find the saved user setting for the area, in the form of
+     *                       "x,y,x2,y2".
+     * @param luckyOffset Amount to offset the scan region downward in case this is a lucky pokemon
+     */
+
+    @Nullable
+    public static ScanArea calibratedFromSettings(String calibrationKey, GoIVSettings settings, int luckyOffset) {
         if (settings.hasManualScanCalibration()) {
             try {
                 String[] values = settings.getCalibrationValue(calibrationKey).split(",");
-                return new ScanArea(Integer.valueOf(values[0]), Integer.valueOf(values[1]),
+                return new ScanArea(Integer.valueOf(values[0]), Integer.valueOf(values[1]) + luckyOffset,
                         Integer.valueOf(values[2]), Integer.valueOf(values[3]));
             } catch (Exception e) {
                 return null;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -212,7 +212,7 @@
     <string name="ocr_error_pick_pixel_white">Unable to pick white marker pixel color\n</string>
     <string name="ocr_error_locate_pixel_green">Unable to locate green marker pixel\n</string>
     <string name="ocr_error_pick_pixel_green">Unable to pick green marker pixel color\n</string>
-    <string name="ocr_msg_verify">\nATTENTION! Please verify that:\n① The info screen is scrolled all the way up\n② The 3D model doesn\'t cover any important information\n③ Is not a final evolution! I suggest a Pidgey!</string>
+    <string name="ocr_msg_verify">\nATTENTION! Please verify that:\n① The info screen is scrolled all the way up\n② The 3D model doesn\'t cover any important information\n③ Is not a final evolution! I suggest a Pidgey!\n④ Is not lucky</string>
     <string name="ocr_calibration_saved">Calibration saved!\nRestart GoIV to apply the changes!</string>
     <string name="ocr_finding_name">Finding name area</string>
     <string name="ocr_finding_type">Finding type area</string>


### PR DESCRIPTION
Added an alternate version of the region scan computation which can offset vertically for lucky pokemon. Retained the existing signature for backward compatibility, as well as for use in fields unaffected by lucky status. When the first scannable area that would be affected by Lucky is encountered, if no result is returned, it will retry with the lucky offset; if this returns a value, the pokemon is assumed to be lucky, and further scans below the line will be similarly offset. Using an offset of 120% of the power up candy scan height, just as a "feels right" value. Needs testing against other devices. Works spot on for Pixel.