### PR TITLE
fixed the issue that needed non-ascii charactors are removed

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -529,7 +529,7 @@ public class PokeInfoCalculator {
      */
     public String getTypeName(int typeNameNum) {
         String cleanedType = Normalizer.normalize(typeNamesArray[typeNameNum], Normalizer.Form.NFD);
-        cleanedType = cleanedType.replaceAll("[^\\p{ASCII}]", "");
+        cleanedType = cleanedType.replaceAll("[\\p{M}]", "");
         return cleanedType;
     }
 }

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanData.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanData.java
@@ -72,7 +72,7 @@ public class ScanData {
         //These kinds of characters should not be possible to scan, but we're clearing them out for
         //future proofing.
         String seperatedType = Normalizer.normalize(pokemonType, Normalizer.Form.NFD);
-        seperatedType = seperatedType.replaceAll("[^\\p{ASCII}]", "");
+        seperatedType = seperatedType.replaceAll("[\\p{M}]", "");
         return seperatedType;
     }
 


### PR DESCRIPTION
This PR is a minor improvement for Latin characters (but critical fix for the other characters...)
because in non Latin characters the needed characters  to detect Pokemon name are removed.

It should be better that the "combining characters" are removed instead of non ascii characters.

https://en.wikipedia.org/wiki/Combining_character