### PR TITLE
improvement for normalizing pokemon type

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -10,13 +10,15 @@ import android.support.annotation.Nullable;
 
 import com.kamron.pogoiv.GoIVSettings;
 import com.kamron.pogoiv.R;
+import com.kamron.pogoiv.utils.StringUtils;
 
-import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * Created by Johan Swanberg on 2016-08-18.
@@ -26,8 +28,8 @@ public class PokeInfoCalculator {
     private static PokeInfoCalculator instance;
 
     private ArrayList<Pokemon> pokedex = new ArrayList<>();
-    private String[] typeNamesArray;
     private String[] pokeNamesWithForm = {};
+    private Map<Pokemon.Type, String> normalizedTypeNames = new EnumMap<>(Pokemon.Type.class);
 
     /**
      * Pokemons that aren't evolutions of any other one.
@@ -68,7 +70,22 @@ public class PokeInfoCalculator {
      */
     private PokeInfoCalculator(@NonNull GoIVSettings settings, @NonNull Resources res) {
         populatePokemon(settings, res);
-        this.typeNamesArray = res.getStringArray(R.array.typeName);
+
+        // create and cache the full pokemon display name list
+        ArrayList<String> pokemonNamesArray = new ArrayList<>();
+        for (Pokemon poke : getPokedex()) {
+            for (Pokemon pokemonForm : getForms(poke)) {
+                pokemonNamesArray.add(pokemonForm.toString());
+            }
+        }
+
+        pokeNamesWithForm = pokemonNamesArray.toArray(new String[pokemonNamesArray.size()]);
+
+        // create and cache the normalized pokemon type locale name
+        for (int i = 0; i < res.getStringArray(R.array.typeName).length; i++) {
+            normalizedTypeNames.put(Pokemon.Type.values()[i],
+                    StringUtils.normalize(res.getStringArray(R.array.typeName)[i]));
+        }
     }
 
     public List<Pokemon> getPokedex() {
@@ -140,18 +157,6 @@ public class PokeInfoCalculator {
      * @return the full pokemon display names including forms as string array.
      */
     public String[] getPokemonNamesWithFormArray() {
-        if (pokeNamesWithForm.length != 0) {
-            return pokeNamesWithForm;
-        }
-
-        ArrayList<String> pokemonNamesArray = new ArrayList<>();
-        for (Pokemon poke : getPokedex()) {
-            for (Pokemon pokemonForm : getForms(poke)) {
-                pokemonNamesArray.add(pokemonForm.toString());
-            }
-        }
-
-        pokeNamesWithForm = pokemonNamesArray.toArray(new String[pokemonNamesArray.size()]);
         return pokeNamesWithForm;
     }
 
@@ -228,8 +233,6 @@ public class PokeInfoCalculator {
                 formPokemon.evolutions.addAll(pokedex.get(formPokemon.number).evolutions);
             }
         }
-
-        pokeNamesWithForm = getPokemonNamesWithFormArray();
     }
 
     /**
@@ -500,36 +503,11 @@ public class PokeInfoCalculator {
     }
 
     /**
-     * Returns the type name, such as fire or water, in the correct current locale name. However, special characters
-     * such as â, é etc are replaced with their normalized forms a, e etc. So they can be compared with what's
-     * scanned. (The ocr does not recognize special characters such as é).
-     * <p>
-     * Type numbers:
-     * <p>
-     * 0 normal <p>
-     * 1 fire<p>
-     * 2 water<p>
-     * 3 electric<p>
-     * 4 grass<p>
-     * 5 ice<p>
-     * 6 fighting<p>
-     * 7 poison<p>
-     * 8 ground<p>
-     * 9 flying<p>
-     * 10 psychic<p>
-     * 11 bug<p>
-     * 12 rock<p>
-     * 13 ghost<p>
-     * 14 dragon<p>
-     * 15 dark<p>
-     * 16 steel<p>
-     * 17 fairy<p>
+     * Returns the normalized type name for such as fire or water, in the correct current locale name.
      *
-     * @param typeNameNum The number for the type to get the correct name for.
+     * @param type The enum for the type to get the correct name for.
      */
-    public String getTypeName(int typeNameNum) {
-        String cleanedType = Normalizer.normalize(typeNamesArray[typeNameNum], Normalizer.Form.NFD);
-        cleanedType = cleanedType.replaceAll("[\\p{M}]", "");
-        return cleanedType;
+    public String getNormalizedType(Pokemon.Type type) {
+        return normalizedTypeNames.get(type);
     }
 }

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/Pokemon.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/Pokemon.java
@@ -37,6 +37,27 @@ public class Pokemon {
         }
     }
 
+    public enum Type {
+        NORMAL,
+        FIRE,
+        WATER,
+        GRASS,
+        ELECTRIC,
+        ICE,
+        FIGHTING,
+        POISON,
+        GROUND,
+        FLYING,
+        PSYCHIC,
+        BUG,
+        ROCK,
+        GHOST,
+        DRAGON,
+        DARK,
+        STEEL,
+        FAIRY,
+    }
+
     /**
      * Evolutions of this Pokemon, sorted in alphabetical order.
      * Try to avoid assumptions that only hold for Gen. I Pokemon: evolutions can have smaller

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
@@ -5,11 +5,15 @@ import android.support.annotation.NonNull;
 
 import com.google.common.base.Optional;
 
+import com.kamron.pogoiv.utils.StringUtils;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
 import lombok.AllArgsConstructor;
+
+import static com.kamron.pogoiv.scanlogic.Pokemon.Type;
 
 /**
  * Component for user-trainable autocorrection of pokemon names.
@@ -66,25 +70,26 @@ public class PokemonNameCorrector {
         if (guess.pokemon == null
                 && scanData.getCandyName().toLowerCase().contains(pokeInfoCalculator.get(132).name.toLowerCase())) {
             HashMap<String, String> eeveelutionCorrection = new HashMap<>();
-            eeveelutionCorrection.put(pokeInfoCalculator.getTypeName(2), //WATER
+            eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.WATER),
                     pokeInfoCalculator.get(133).name); //Vaporeon
-            eeveelutionCorrection.put(pokeInfoCalculator.getTypeName(3), //ELECTRIC
+            eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.ELECTRIC),
                     pokeInfoCalculator.get(134).name); //Jolteon
-            eeveelutionCorrection.put(pokeInfoCalculator.getTypeName(1), //FIRE
+            eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.FIRE),
                     pokeInfoCalculator.get(135).name); //Flareon
-            eeveelutionCorrection.put(pokeInfoCalculator.getTypeName(10), //PSYCHIC
+            eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.PSYCHIC),
                     pokeInfoCalculator.get(195).name); //Espeon
-            eeveelutionCorrection.put(pokeInfoCalculator.getTypeName(15), //DARK
+            eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.DARK),
                     pokeInfoCalculator.get(196).name); //Umbreon
             // Preparing for the future....
-            // eeveelutionCorrection.put(pokeInfoCalculator.getTypeName(4), //GRASS
+            // eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.GRASS),
             //         pokeInfoCalculator.get(469).name); //Leafeon
-            // eeveelutionCorrection.put(pokeInfoCalculator.getTypeName(5), //ICE
+            // eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.ICE),
             //         pokeInfoCalculator.get(470).name); //Glaceon
-            // eeveelutionCorrection.put(pokeInfoCalculator.getTypeName(17), //FAIRY
+            // eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.FAIRY),
             //         pokeInfoCalculator.get(699).name); //Sylveon
-            if (eeveelutionCorrection.containsKey(scanData.getPokemonType())) {
-                String name = eeveelutionCorrection.get(scanData.getPokemonType());
+            String normalizedPokemonType = StringUtils.normalize(scanData.getPokemonType());
+            if (eeveelutionCorrection.containsKey(normalizedPokemonType)) {
+                String name = eeveelutionCorrection.get(normalizedPokemonType);
                 guess = new PokeDist(pokeInfoCalculator.get(name), 0);
             }
         }
@@ -93,7 +98,8 @@ public class PokemonNameCorrector {
         if (scanData.getCandyName().toLowerCase().contains(pokeInfoCalculator.get(182).name.toLowerCase())
                 && (scanData.getEvolutionCandyCost().get() != -1)) { //its not an azumarill
             //if the scanned data contains the type water, it must be a marill, as azuril is normal type.
-            if (scanData.getPokemonType().contains(pokeInfoCalculator.getTypeName(2))) {
+            if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    pokeInfoCalculator.getNormalizedType(Type.WATER))) {
                 guess = new PokeDist(pokeInfoCalculator.get(182), 0);
             } else {
                 guess = new PokeDist(pokeInfoCalculator.get(297), 0);
@@ -157,127 +163,127 @@ public class PokemonNameCorrector {
             switch (guess.pokemon.number) {
                 case (102): // Exeggutor (dex 103)
                     // check types including dragon
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(14).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.DRAGON))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (18): // Rattata
                     // check types including dark
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(15).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.DARK))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (19): // Raticate
                     // check types including dark
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(15).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.DARK))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (25): // Raichu
                     // check types including psychic
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(10).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.PSYCHIC))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (26): // Sandshrew
                     // check types including ice
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(5).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.ICE))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (27): // Sandslash
                     // check types including ice
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(5).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.ICE))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (36): // Vulpix
                     // check types including ice
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(5).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.ICE))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (37): // Ninetales
                     // check types including ice
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(5).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.ICE))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (49): // Diglett
                     // check types including steel
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(16).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.STEEL))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (50): // Dugtrio
                     // check types including steel
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(16).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.STEEL))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (51): // Meowth
                     // check types including dark
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(15).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.DARK))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (52): // Persian
                     // check types including dark
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(15).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.DARK))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (73): // Geodude
                     // check types including electric
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(3).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.ELECTRIC))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (74): // Graveler
                     // check types including electric
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(3).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.ELECTRIC))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (75): // Golem
                     // check types including electric
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(3).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.ELECTRIC))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (87): // Grimer
                     // check types including dark
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(15).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.DARK))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (88): // Muk
                     // check types including dark
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(15).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.DARK))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (104): // Marowak
                     // check types including fire
-                    if (scanData.getPokemonType().toLowerCase().contains(
-                            pokeInfoCalculator.getTypeName(1).toLowerCase())) {
+                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                            pokeInfoCalculator.getNormalizedType(Type.FIRE))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanData.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanData.java
@@ -6,8 +6,6 @@ import android.support.annotation.Nullable;
 import com.google.common.base.Optional;
 import com.kamron.pogoiv.utils.LevelRange;
 
-import java.text.Normalizer;
-
 /**
  * A ScanData represents the result of an OCR scan.
  * Created by pgiarrusso on 3/9/2016.
@@ -68,12 +66,7 @@ public class ScanData {
     }
 
     public String getPokemonType() {
-        //first ensure that there's no special characters such as é, á or â, and convert them to e, a , a.
-        //These kinds of characters should not be possible to scan, but we're clearing them out for
-        //future proofing.
-        String seperatedType = Normalizer.normalize(pokemonType, Normalizer.Form.NFD);
-        seperatedType = seperatedType.replaceAll("[\\p{M}]", "");
-        return seperatedType;
+        return pokemonType;
     }
 
     public Pokemon.Gender getPokemonGender() {

--- a/app/src/main/java/com/kamron/pogoiv/utils/StringUtils.java
+++ b/app/src/main/java/com/kamron/pogoiv/utils/StringUtils.java
@@ -4,9 +4,20 @@ import java.text.Normalizer;
 import java.util.Locale;
 
 public class StringUtils {
-/**
- * Returns the normalized string for simplifying words to detect pokemons.
- */
+
+    /**
+     * Returns the normalized string for simplifying characters to detect pokemons.
+     *
+     * Actually scanned character result quality is often not enough in some reasons like following:
+     *  - device screen resolution
+     *  - font properties(size, forms and ligature)
+     *  - letter complexity in some locales
+     *
+     * This method provides normalized string to simplify characters.
+     * For examples, special characters such as â, é, ば etc are replaced with their normalized forms a, e, は etc.
+     * So they can be compared more simply.
+     *
+     */
     public static String normalize(String s) {
         s = s.toLowerCase();
         s = Normalizer.normalize(s, Normalizer.Form.NFD);
@@ -16,6 +27,7 @@ public class StringUtils {
         //String lang = Locale.getDefault().getLanguage();
         //
         //if (Locale.getDefault().getLanguage().contains("ja")) {
+        //  ...
         //}
 
         return s;

--- a/app/src/main/java/com/kamron/pogoiv/utils/StringUtils.java
+++ b/app/src/main/java/com/kamron/pogoiv/utils/StringUtils.java
@@ -1,0 +1,23 @@
+package com.kamron.pogoiv.utils;
+
+import java.text.Normalizer;
+import java.util.Locale;
+
+public class StringUtils {
+/**
+ * Returns the normalized string for simplifying words to detect pokemons.
+ */
+    public static String normalize(String s) {
+        s = s.toLowerCase();
+        s = Normalizer.normalize(s, Normalizer.Form.NFD);
+        s = s.replaceAll("[\\p{M}]", "");
+
+        /* append more normalizers below for each locales, if needed */
+        //String lang = Locale.getDefault().getLanguage();
+        //
+        //if (Locale.getDefault().getLanguage().contains("ja")) {
+        //}
+
+        return s;
+    }
+}

--- a/app/src/main/res/values-de/pokemons.xml
+++ b/app/src/main/res/values-de/pokemons.xml
@@ -394,8 +394,8 @@
         <!--  0   normal --> <item>NORMAL</item>
         <!--  1     fire --> <item>FEUER</item>
         <!--  2    water --> <item>WASSER</item>
-        <!--  3 electric --> <item>ELEKTRO</item>
-        <!--  4    grass --> <item>PFLANZE</item>
+        <!--  3    grass --> <item>PFLANZE</item>
+        <!--  4 electric --> <item>ELEKTRO</item>
         <!--  5      ice --> <item>EIS</item>
         <!--  6 fighting --> <item>KAMPF</item>
         <!--  7   poison --> <item>GIFT</item>

--- a/app/src/main/res/values-es/pokemons.xml
+++ b/app/src/main/res/values-es/pokemons.xml
@@ -4,8 +4,8 @@
         <!--  0   normal --> <item>NORMAL</item>
         <!--  1     fire --> <item>FUEGO</item>
         <!--  2    water --> <item>AGUA</item>
-        <!--  3 electric --> <item>ELÉCTRICO</item>
-        <!--  4    grass --> <item>PLANTA</item>
+        <!--  3    grass --> <item>PLANTA</item>
+        <!--  4 electric --> <item>ELÉCTRICO</item>
         <!--  5      ice --> <item>HIELO</item>
         <!--  6 fighting --> <item>LUCHA</item>
         <!--  7   poison --> <item>VENENO</item>

--- a/app/src/main/res/values-fr/pokemons.xml
+++ b/app/src/main/res/values-fr/pokemons.xml
@@ -394,8 +394,8 @@
         <!--  0   normal --> <item>NORMAL</item>
         <!--  1     fire --> <item>FEU</item>
         <!--  2    water --> <item>EAU</item>
-        <!--  3 electric --> <item>ÉLECTRIK</item>
-        <!--  4    grass --> <item>PLANTE</item>
+        <!--  3    grass --> <item>PLANTE</item>
+        <!--  4 electric --> <item>ÉLECTRIK</item>
         <!--  5      ice --> <item>GLACE</item>
         <!--  6 fighting --> <item>COMBAT</item>
         <!--  7   poison --> <item>POISON</item>

--- a/app/src/main/res/values-it/pokemons.xml
+++ b/app/src/main/res/values-it/pokemons.xml
@@ -4,8 +4,8 @@
         <!--  0   normal --> <item>NORMALE</item>
         <!--  1     fire --> <item>FUOCO</item>
         <!--  2    water --> <item>ACQUA</item>
-        <!--  3 electric --> <item>ELETTRO</item>
-        <!--  4    grass --> <item>ERBA</item>
+        <!--  3    grass --> <item>ERBA</item>
+        <!--  4 electric --> <item>ELETTRO</item>
         <!--  5      ice --> <item>GHIACCIO</item>
         <!--  6 fighting --> <item>LOTTA</item>
         <!--  7   poison --> <item>VELENO</item>

--- a/app/src/main/res/values/pokemons.xml
+++ b/app/src/main/res/values/pokemons.xml
@@ -395,8 +395,8 @@
         <!--  0   normal --> <item>NORMAL</item>
         <!--  1     fire --> <item>FIRE</item>
         <!--  2    water --> <item>WATER</item>
-        <!--  3 electric --> <item>ELECTRIC</item>
-        <!--  4    grass --> <item>GRASS</item>
+        <!--  3    grass --> <item>GRASS</item>
+        <!--  4 electric --> <item>ELECTRIC</item>
         <!--  5      ice --> <item>ICE</item>
         <!--  6 fighting --> <item>FIGHTING</item>
         <!--  7   poison --> <item>POISON</item>


### PR DESCRIPTION
This PRs points are

* normalized pokemon type strings are cached in PokeInfoCalculator instance at first.
* enum Pokemon.Type values are used instead of hard numbers

Next steps, this StringUtils#normalize() is used for pokemon names and candy word, to improve pokemon detection in German and French.