### PR TITLE
improvement for candy pokemon name

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
@@ -803,7 +803,7 @@ public class OcrHelper {
     }
 
     private static boolean isNidoranName(String pokemonName) {
-        return pokemonName.toLowerCase().contains(nidoUngendered);
+        return StringUtils.normalize(pokemonName).contains(StringUtils.normalize(nidoUngendered));
     }
 
     @NonNull

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
@@ -83,7 +83,7 @@ public class OcrHelper {
             tesseract.init(dataPath, "eng");
             tesseract.setPageSegMode(TessBaseAPI.PageSegMode.PSM_SINGLE_LINE);
             tesseract.setVariable(TessBaseAPI.VAR_CHAR_WHITELIST,
-                    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789/♀♂");
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789/-♀♂");
 
             nidoFemale = pokeInfoCalculator.get(28).name;
             nidoMale = pokeInfoCalculator.get(31).name;
@@ -846,7 +846,7 @@ public class OcrHelper {
         if (candyName == null) {
             candy = replaceColors(candy, true, 68, 105, 108, Color.WHITE, 200, true);
             tesseract.setImage(candy);
-            candyName = StringUtils.normalize(fixOcrNumsToLetters(tesseract.getUTF8Text().replaceAll("[\\s]", "")))
+            candyName = StringUtils.normalize(fixOcrNumsToLetters(tesseract.getUTF8Text().replaceAll("[\\s-]", "")))
                     .replace(StringUtils.normalize(pokeflyRef.get().getResources().getString(R.string.candy)), "");
             if (isNidoranName(candyName)) {
                 candyName = StringUtils.normalize(getNidoranGenderName(pokemonGender));

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
@@ -819,8 +819,16 @@ public class OcrHelper {
         if (candyName == null) {
             candy = replaceColors(candy, true, 68, 105, 108, Color.WHITE, 200, true);
             tesseract.setImage(candy);
-            candyName = StringUtils.normalize(fixOcrNumsToLetters(tesseract.getUTF8Text().replaceAll("[\\s-]", "")))
-                    .replace(StringUtils.normalize(pokeflyRef.get().getResources().getString(R.string.candy)), "");
+            String candyText = tesseract.getUTF8Text();
+            String candyWordLocale = pokeflyRef.get().getResources().getString(R.string.candy);
+
+            candyText = fixOcrNumsToLetters(candyText);
+
+            // remove characters not included in pokemon names or candy word. (ex. white space, -, etc)
+            candyText = candyText.replaceAll("[^\\w♂♀]", "");
+
+            candyText = StringUtils.normalize(candyText);
+            candyName = candyText.replace(StringUtils.normalize(candyWordLocale), "");
             if (isNidoranName(candyName)) {
                 candyName = StringUtils.normalize(getNidoranGenderName(pokemonGender));
             }

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
@@ -13,11 +13,13 @@ import com.google.common.base.Optional;
 import com.googlecode.tesseract.android.TessBaseAPI;
 import com.kamron.pogoiv.GoIVSettings;
 import com.kamron.pogoiv.Pokefly;
+import com.kamron.pogoiv.R;
 import com.kamron.pogoiv.scanlogic.Data;
 import com.kamron.pogoiv.scanlogic.PokeInfoCalculator;
 import com.kamron.pogoiv.scanlogic.Pokemon;
 import com.kamron.pogoiv.scanlogic.ScanData;
 import com.kamron.pogoiv.utils.LevelRange;
+import com.kamron.pogoiv.utils.StringUtils;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -822,6 +824,7 @@ public class OcrHelper {
 
     /**
      * Gets the candy name from a pokenon image.
+     * The candy name is returned as normalized text.
      *
      * @param pokemonImage the image of the whole screen
      * @return the candy name, or "" if nothing was found
@@ -843,10 +846,10 @@ public class OcrHelper {
         if (candyName == null) {
             candy = replaceColors(candy, true, 68, 105, 108, Color.WHITE, 200, true);
             tesseract.setImage(candy);
-            candyName = fixOcrNumsToLetters(
-                    removeFirstOrLastWord(tesseract.getUTF8Text().trim().replace("-", " "), candyWordFirst));
+            candyName = StringUtils.normalize(fixOcrNumsToLetters(tesseract.getUTF8Text().replaceAll("[\\s]", "")))
+                    .replace(StringUtils.normalize(pokeflyRef.get().getResources().getString(R.string.candy)), "");
             if (isNidoranName(candyName)) {
-                candyName = getNidoranGenderName(pokemonGender);
+                candyName = StringUtils.normalize(getNidoranGenderName(pokemonGender));
             }
             ocrCache.put(hash, candyName);
         }

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
@@ -58,7 +58,6 @@ public class OcrHelper {
     private static boolean isPokeSpamEnabled;
     private static LruCache<String, String> ocrCache;
     private static LruCache<String, String> appraisalCache;
-    private static boolean candyWordFirst;
 
 
     private static WeakReference<Pokefly> pokeflyRef;
@@ -92,8 +91,6 @@ public class OcrHelper {
             ocrCache = new LruCache<>(200);
             appraisalCache = new LruCache<>(200);
 
-            candyWordFirst = isCandyWordFirst();
-
             instance = new OcrHelper();
         }
 
@@ -119,14 +116,6 @@ public class OcrHelper {
         instance = null;
         ocrCache = null;
         appraisalCache = null;
-    }
-
-    private static boolean isCandyWordFirst() {
-        // Check if language makes the pokemon name in candy second; France/Spain/Italy/Portuguese
-        // have Bonbon/Caramelos/Caramelle/Doces pokeName
-        String language = Locale.getDefault().getLanguage();
-        HashSet<String> specialCandyOrderLangs = new HashSet<>(Arrays.asList("fr", "es", "it", "pt"));
-        return specialCandyOrderLangs.contains(language);
     }
 
     /**
@@ -804,22 +793,6 @@ public class OcrHelper {
 
     private static boolean isNidoranName(String pokemonName) {
         return StringUtils.normalize(pokemonName).contains(StringUtils.normalize(nidoUngendered));
-    }
-
-    @NonNull
-    private static String removeFirstOrLastWord(String src, boolean removeFirst) {
-        if (removeFirst) {
-            int fstSpace = src.indexOf(' ');
-            if (fstSpace != -1) {
-                return src.substring(fstSpace + 1);
-            }
-        } else {
-            int lstSpace = src.lastIndexOf(' ');
-            if (lstSpace != -1) {
-                return src.substring(0, lstSpace);
-            }
-        }
-        return src;
     }
 
     /**

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -39,6 +39,7 @@
     <string name="defense">Verteidigung</string>
     <string name="delete_screenshots_setting_summary">Lösche Screenshots vom GoIV automatisch</string>
     <string name="delete_screenshots_setting_title">lösche Screenshots</string>
+    <string name="candy">Bonbon</string>
     <string name="evolution">Entwicklung</string>
     <string name="iv_perfect" formatted="false">% Perfekt</string>
     <string name="launch_pokemon_go_setting_summary">Wechsel zu Pokémon Go, wenn die Starttaste geklickt wird</string>
@@ -93,5 +94,5 @@
     <string name="is3">…sehen lassen</string>
     <string name="is2">Hut ab!</string>
     <string name="is1">die besten …gesehen</string>
-	
+
 </resources>


### PR DESCRIPTION
The candy text phrase like "Pikachu Candy" does not have white space separator between the candy word and pokemon name, in the case of some locale languages.

For example, "Pikachu-Bonbon" in German, or "ピカチュウのアメ" in Japanese.

So it is better to detect candy pokemon name with using the localized candy word in the resource strings like "Candy", "Bonbon", "Caramelos", etc instead of white space character.

This PR improves to detect pokemons with their candy names, like pokemons nicknamed by users, especially in German locale.
