### PR TITLE
performance improvement and refactoring

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -273,7 +273,7 @@ public class Pokefly extends Service {
         LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(ACTION_UPDATE_UI));
 
         pokeInfoCalculator = PokeInfoCalculator.getInstance(this);
-        nameCorrector = new PokemonNameCorrector(pokeInfoCalculator);
+        nameCorrector = PokemonNameCorrector.getInstance(pokeInfoCalculator);
         displayMetrics = getResources().getDisplayMetrics();
         initOcr();
         windowManager = (WindowManager) getSystemService(WINDOW_SERVICE);

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -272,8 +272,8 @@ public class Pokefly extends Service {
 
         LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(ACTION_UPDATE_UI));
 
-        pokeInfoCalculator = PokeInfoCalculator.getInstance(this);
-        nameCorrector = PokemonNameCorrector.getInstance(this.getResources());
+        nameCorrector = PokemonNameCorrector.getInstance(this);
+        pokeInfoCalculator = PokeInfoCalculator.getInstance();
         displayMetrics = getResources().getDisplayMetrics();
         initOcr();
         windowManager = (WindowManager) getSystemService(WINDOW_SERVICE);

--- a/app/src/main/java/com/kamron/pogoiv/Pokefly.java
+++ b/app/src/main/java/com/kamron/pogoiv/Pokefly.java
@@ -273,7 +273,7 @@ public class Pokefly extends Service {
         LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(ACTION_UPDATE_UI));
 
         pokeInfoCalculator = PokeInfoCalculator.getInstance(this);
-        nameCorrector = PokemonNameCorrector.getInstance(pokeInfoCalculator);
+        nameCorrector = PokemonNameCorrector.getInstance(this.getResources());
         displayMetrics = getResources().getDisplayMetrics();
         initOcr();
         windowManager = (WindowManager) getSystemService(WINDOW_SERVICE);

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
@@ -71,7 +71,7 @@ public class IVPreviewPrinter {
             pokeflyRef = new WeakReference<>(pokefly);
             ivPreviewPrinterRef = new WeakReference<>(ivPreviewPrinter);
             ivButtonRef = new WeakReference<>(ivButton);
-            pokemonNameCorrector = PokemonNameCorrector.getInstance(pokefly.getResources());
+            pokemonNameCorrector = PokemonNameCorrector.getInstance(pokefly);
         }
 
         @Override

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
@@ -71,7 +71,7 @@ public class IVPreviewPrinter {
             pokeflyRef = new WeakReference<>(pokefly);
             ivPreviewPrinterRef = new WeakReference<>(ivPreviewPrinter);
             ivButtonRef = new WeakReference<>(ivButton);
-            pokemonNameCorrector = PokemonNameCorrector.getInstance(PokeInfoCalculator.getInstance());
+            pokemonNameCorrector = PokemonNameCorrector.getInstance(pokefly.getResources());
         }
 
         @Override

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/IVPreviewPrinter.java
@@ -71,7 +71,7 @@ public class IVPreviewPrinter {
             pokeflyRef = new WeakReference<>(pokefly);
             ivPreviewPrinterRef = new WeakReference<>(ivPreviewPrinter);
             ivButtonRef = new WeakReference<>(ivButton);
-            pokemonNameCorrector = new PokemonNameCorrector(PokeInfoCalculator.getInstance());
+            pokemonNameCorrector = PokemonNameCorrector.getInstance(PokeInfoCalculator.getInstance());
         }
 
         @Override

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/fractions/InputFraction.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/fractions/InputFraction.java
@@ -105,7 +105,7 @@ public class InputFraction extends Fraction {
 
         // Guess the species
         PokemonNameCorrector.PokeDist possiblePoke =
-                PokemonNameCorrector.getInstance(PokeInfoCalculator.getInstance()).getPossiblePokemon(Pokefly.scanData);
+                PokemonNameCorrector.getInstance(pokefly.getResources()).getPossiblePokemon(Pokefly.scanData);
 
         // set color based on similarity
         if (possiblePoke.dist == 0) {

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/fractions/InputFraction.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/fractions/InputFraction.java
@@ -27,10 +27,13 @@ import com.kamron.pogoiv.scanlogic.PokeInfoCalculator;
 import com.kamron.pogoiv.scanlogic.Pokemon;
 import com.kamron.pogoiv.scanlogic.PokemonNameCorrector;
 import com.kamron.pogoiv.utils.LevelRange;
+import com.kamron.pogoiv.utils.StringUtils;
 import com.kamron.pogoiv.utils.fractions.Fraction;
 import com.kamron.pogoiv.widgets.PokemonSpinnerAdapter;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -71,11 +74,16 @@ public class InputFraction extends Fraction {
 
     private Pokefly pokefly;
     private PokeInfoCalculator pokeInfoCalculator;
-
+    private final Map<String, Pokemon> normalizedPokemonNameMap;
 
     public InputFraction(@NonNull Pokefly pokefly) {
         this.pokefly = pokefly;
         this.pokeInfoCalculator = PokeInfoCalculator.getInstance();
+        Map<String, Pokemon> pokemap = new HashMap<>();
+        for (Pokemon pokemon : pokeInfoCalculator.getPokedex()) {
+            pokemap.put(StringUtils.normalize(pokemon.toString()), pokemon); // set display pokemon name as key
+        }
+        this.normalizedPokemonNameMap = pokemap;
     }
 
     @Override public int getLayoutResId() {
@@ -292,7 +300,7 @@ public class InputFraction extends Fraction {
             pokemon = pokeInputAdapter.getItem(pokeInputSpinner.getSelectedItemPosition());
         } else { //user typed manually
             String userInput = autoCompleteTextView1.getText().toString();
-            pokemon = pokeInfoCalculator.get(userInput);
+            pokemon = normalizedPokemonNameMap.get(StringUtils.normalize(userInput));
             if (pokemon == null) { //no such pokemon was found, show error toast and abort showing results
                 Toast.makeText(pokefly, userInput + pokefly.getString(R.string.wrong_pokemon_name_input),
                         Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/fractions/InputFraction.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/fractions/InputFraction.java
@@ -105,7 +105,7 @@ public class InputFraction extends Fraction {
 
         // Guess the species
         PokemonNameCorrector.PokeDist possiblePoke =
-                PokemonNameCorrector.getInstance(pokefly.getResources()).getPossiblePokemon(Pokefly.scanData);
+                PokemonNameCorrector.getInstance(pokefly).getPossiblePokemon(Pokefly.scanData);
 
         // set color based on similarity
         if (possiblePoke.dist == 0) {

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/fractions/InputFraction.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/fractions/InputFraction.java
@@ -97,7 +97,7 @@ public class InputFraction extends Fraction {
 
         // Guess the species
         PokemonNameCorrector.PokeDist possiblePoke =
-                new PokemonNameCorrector(PokeInfoCalculator.getInstance()).getPossiblePokemon(Pokefly.scanData);
+                PokemonNameCorrector.getInstance(PokeInfoCalculator.getInstance()).getPossiblePokemon(Pokefly.scanData);
 
         // set color based on similarity
         if (possiblePoke.dist == 0) {

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -14,7 +14,6 @@ import com.kamron.pogoiv.utils.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -29,7 +28,6 @@ public class PokeInfoCalculator {
 
     private ArrayList<Pokemon> pokedex = new ArrayList<>();
     private String[] pokeNamesWithForm = {};
-    private Map<Pokemon.Type, String> normalizedTypeNames = new EnumMap<>(Pokemon.Type.class);
 
     /**
      * Pokemons who's name appears as a type of candy.
@@ -72,12 +70,6 @@ public class PokeInfoCalculator {
         }
 
         pokeNamesWithForm = pokemonNamesArray.toArray(new String[pokemonNamesArray.size()]);
-
-        // create and cache the normalized pokemon type locale name
-        for (int i = 0; i < res.getStringArray(R.array.typeName).length; i++) {
-            normalizedTypeNames.put(Pokemon.Type.values()[i],
-                    StringUtils.normalize(res.getStringArray(R.array.typeName)[i]));
-        }
     }
 
     public List<Pokemon> getPokedex() {
@@ -482,14 +474,5 @@ public class PokeInfoCalculator {
         int lowHp = (int) Math.max(
                 Math.floor((selectedPokemon.baseStamina + scanResult.getIVStaminaLow()) * lvlScalar), 10);
         return Math.round((highHp + lowHp) / 2f);
-    }
-
-    /**
-     * Returns the normalized type name for such as fire or water, in the correct current locale name.
-     *
-     * @param type The enum for the type to get the correct name for.
-     */
-    public String getNormalizedType(Pokemon.Type type) {
-        return normalizedTypeNames.get(type);
     }
 }

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -43,9 +43,6 @@ public class PokeInfoCalculator {
      */
     private HashMap<String, Pokemon> candyPokemons = new HashMap<>();
 
-    private HashMap<String, Pokemon> pokemap = new HashMap<>();
-
-
     public static synchronized @NonNull PokeInfoCalculator getInstance(@NonNull Context context) {
         if (instance == null) {
             instance = new PokeInfoCalculator(GoIVSettings.getInstance(context), context.getResources());
@@ -118,10 +115,6 @@ public class PokeInfoCalculator {
         return null;
     }
 
-    public Pokemon get(String name) {
-        return pokemap.get(StringUtils.normalize(name));
-    }
-
     public static String[] getPokemonNamesArray(Resources res) {
         if (res.getBoolean(R.bool.use_default_pokemonsname_as_ocrstring)) {
             // If flag ON, force to use English strings as pokemon name for OCR.
@@ -181,10 +174,6 @@ public class PokeInfoCalculator {
             Pokemon p = new Pokemon(names[i], displayNames[i], i, attack[i], defense[i], stamina[i], devolution[i],
                     evolutionCandyCost[i]);
             pokedex.add(p);
-            pokemap.put(StringUtils.normalize(names[i]), p);
-            if (!names[i].equals(displayNames[i])) {
-                pokemap.put(StringUtils.normalize(displayNames[i]), p);
-            }
         }
 
         for (int i = 0; i < pokeListSize; i++) {
@@ -219,10 +208,6 @@ public class PokeInfoCalculator {
                             devolution[i],
                             evolutionCandyCost[i]);
                     pokedex.get(i).forms.add(formPokemon);
-                    pokemap.put(StringUtils.normalize(formPokemonName), formPokemon);
-                    if (!formPokemon.equals(formPokemonDisplayName)) {
-                        pokemap.put(StringUtils.normalize(formPokemonDisplayName), formPokemon);
-                    }
                     formVariantPokemons.add(formPokemon);
                 }
             }

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -32,11 +32,6 @@ public class PokeInfoCalculator {
     private Map<Pokemon.Type, String> normalizedTypeNames = new EnumMap<>(Pokemon.Type.class);
 
     /**
-     * Pokemons that aren't evolutions of any other one.
-     */
-    private ArrayList<Pokemon> basePokemons = new ArrayList<>();
-
-    /**
      * Pokemons who's name appears as a type of candy.
      * For most, this is the basePokemon (ie: Pidgey candies)
      * For some, this is an original Gen1 Pokemon (ie: Magmar candies, instead of Magby candies)
@@ -87,10 +82,6 @@ public class PokeInfoCalculator {
 
     public List<Pokemon> getPokedex() {
         return Collections.unmodifiableList(pokedex);
-    }
-
-    public List<Pokemon> getBasePokemons() {
-        return Collections.unmodifiableList(basePokemons);
     }
 
     /**
@@ -183,7 +174,6 @@ public class PokeInfoCalculator {
             } else {
                 Pokemon candyPokemon = pokedex.get(candyNamesArray[i]);
                 candyPokemons.put(StringUtils.normalize(candyPokemon.name), candyPokemon);
-                basePokemons.add(pokedex.get(i));
             }
 
             //Check for different pokemon forms, such as alolan forms, and add them to the formsCount.

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -33,7 +33,7 @@ public class PokeInfoCalculator {
      */
     private ArrayList<Pokemon> candyPokemons = new ArrayList<>();
 
-    public static synchronized @NonNull PokeInfoCalculator getInstance(@NonNull Context context) {
+    protected static synchronized @NonNull PokeInfoCalculator getInstance(@NonNull Context context) {
         if (instance == null) {
             instance = new PokeInfoCalculator(GoIVSettings.getInstance(context), context.getResources());
         }

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -10,14 +10,11 @@ import android.support.annotation.Nullable;
 
 import com.kamron.pogoiv.GoIVSettings;
 import com.kamron.pogoiv.R;
-import com.kamron.pogoiv.utils.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 /**
  * Created by Johan Swanberg on 2016-08-18.
@@ -34,7 +31,7 @@ public class PokeInfoCalculator {
      * For most, this is the basePokemon (ie: Pidgey candies)
      * For some, this is an original Gen1 Pokemon (ie: Magmar candies, instead of Magby candies)
      */
-    private HashMap<String, Pokemon> candyPokemons = new HashMap<>();
+    private ArrayList<Pokemon> candyPokemons = new ArrayList<>();
 
     public static synchronized @NonNull PokeInfoCalculator getInstance(@NonNull Context context) {
         if (instance == null) {
@@ -79,10 +76,10 @@ public class PokeInfoCalculator {
     /**
      * Returns the full collection of possible candy pokemon that exist in Pokemon Go.
      *
-     * @return Map of all candy pokemons with normalized pokemon names as their keys.
+     * @return Map of all candy pokemons.
      */
-    public Map<String, Pokemon> getNormalizedCandyPokemons() {
-        return Collections.unmodifiableMap(candyPokemons);
+    public List<Pokemon> getCandyPokemons() {
+        return Collections.unmodifiableList(candyPokemons);
     }
 
     /**
@@ -165,7 +162,7 @@ public class PokeInfoCalculator {
                 devo.evolutions.add(pokedex.get(i));
             } else {
                 Pokemon candyPokemon = pokedex.get(candyNamesArray[i]);
-                candyPokemons.put(StringUtils.normalize(candyPokemon.name), candyPokemon);
+                candyPokemons.add(candyPokemon);
             }
 
             //Check for different pokemon forms, such as alolan forms, and add them to the formsCount.

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -74,9 +74,9 @@ public class PokeInfoCalculator {
     }
 
     /**
-     * Returns the full collection of possible candy pokemon that exist in Pokemon Go.
+     * Returns the full list of pokemons possible candy name.
      *
-     * @return Map of all candy pokemons.
+     * @return List of all candy pokemons that exist in Pokemon Go.
      */
     public List<Pokemon> getCandyPokemons() {
         return Collections.unmodifiableList(candyPokemons);

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -41,7 +41,7 @@ public class PokeInfoCalculator {
      * For most, this is the basePokemon (ie: Pidgey candies)
      * For some, this is an original Gen1 Pokemon (ie: Magmar candies, instead of Magby candies)
      */
-    private ArrayList<Pokemon> candyPokemons = new ArrayList<>();
+    private HashMap<String, Pokemon> candyPokemons = new HashMap<>();
 
     private HashMap<String, Pokemon> pokemap = new HashMap<>();
 
@@ -97,12 +97,12 @@ public class PokeInfoCalculator {
     }
 
     /**
-     * Returns the full list of possible candy names.
+     * Returns the full collection of possible candy pokemon that exist in Pokemon Go.
      *
-     * @return List of all candy names that exist in Pokemon Go
+     * @return Map of all candy pokemons with normalized pokemon names as their keys.
      */
-    public List<Pokemon> getCandyPokemons() {
-        return Collections.unmodifiableList(candyPokemons);
+    public Map<String, Pokemon> getNormalizedCandyPokemons() {
+        return Collections.unmodifiableMap(candyPokemons);
     }
 
     /**
@@ -192,7 +192,8 @@ public class PokeInfoCalculator {
                 Pokemon devo = pokedex.get(devolution[i]);
                 devo.evolutions.add(pokedex.get(i));
             } else {
-                candyPokemons.add(pokedex.get(candyNamesArray[i]));
+                Pokemon candyPokemon = pokedex.get(candyNamesArray[i]);
+                candyPokemons.put(StringUtils.normalize(candyPokemon.name), candyPokemon);
                 basePokemons.add(pokedex.get(i));
             }
 

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -161,8 +161,7 @@ public class PokeInfoCalculator {
                 Pokemon devo = pokedex.get(devolution[i]);
                 devo.evolutions.add(pokedex.get(i));
             } else {
-                Pokemon candyPokemon = pokedex.get(candyNamesArray[i]);
-                candyPokemons.add(candyPokemon);
+                candyPokemons.add(pokedex.get(candyNamesArray[i]));
             }
 
             //Check for different pokemon forms, such as alolan forms, and add them to the formsCount.

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
@@ -121,9 +121,9 @@ public class PokemonNameCorrector {
             eeveelutionCorrection.put(normalizePokemonType(Type.PSYCHIC), 195); //Espeon pokedex#
             eeveelutionCorrection.put(normalizePokemonType(Type.DARK),196); //Umbreon pokedex#
             // Preparing for the future....
-            // eeveelutionCorrection.put(pokeInfoCalculator.normalizePokemonType(Type.GRASS), 469); //Leafeon pokedex#
-            // eeveelutionCorrection.put(pokeInfoCalculator.normalizePokemonType(Type.ICE), 470); //Glaceon pokedex#
-            // eeveelutionCorrection.put(pokeInfoCalculator.normalizePokemonType(Type.FAIRY), 699); //Sylveon pokedex#
+            // eeveelutionCorrection.put(normalizePokemonType(Type.GRASS), 469); //Leafeon pokedex#
+            // eeveelutionCorrection.put(normalizePokemonType(Type.ICE), 470); //Glaceon pokedex#
+            // eeveelutionCorrection.put(normalizePokemonType(Type.FAIRY), 699); //Sylveon pokedex#
             if (eeveelutionCorrection.containsKey(scanData.getNormalizedPokemonType())) {
                 int eeveelutionPokedexId = eeveelutionCorrection.get(scanData.getNormalizedPokemonType());
                 guess = new PokeDist(pokeInfoCalculator.get(eeveelutionPokedexId), 0);

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
@@ -137,7 +137,7 @@ public class PokemonNameCorrector {
         //5.  get the pokemon with the closest name within the evolution line guessed from the candy (or candy and
         // cost calculation).
         if (guess.pokemon == null && bestGuessEvolutionLine != null) {
-            guess = getNicknameGuess(scanData.getPokemonName(), bestGuessEvolutionLine);
+            guess = guessBestPokemonByName(scanData.getPokemonName(), bestGuessEvolutionLine);
         }
 
 
@@ -152,7 +152,7 @@ public class PokemonNameCorrector {
 
         //7. All else failed: make a wild guess based only on closest name match
         if (guess.pokemon == null) {
-            guess = getNicknameGuess(scanData.getPokemonName(), pokeInfoCalculator.getPokedex());
+            guess = guessBestPokemonByName(scanData.getPokemonName(), pokeInfoCalculator.getPokedex());
         }
 
 
@@ -329,20 +329,19 @@ public class PokemonNameCorrector {
     }
 
     /**
-     * A method which returns the best guess at which pokemon it is according to similarity with the nickname
+     * A method which returns the best guess at which pokemon it is according to similarity with the name
      * in the given pokemon list.
      *
-     * @param poketext the nickname to compare with
-     * @param pokemons the pokemon list to search the nickname into.
+     * @param name the input name to compare with
+     * @param pokemons the pokemon list to search the input name into.
      * @return a pokedist representing the search result.
      */
-
-    private PokeDist getNicknameGuess(String poketext, List<Pokemon> pokemons) {
+    private PokeDist guessBestPokemonByName(String name, List<Pokemon> pokemons) {
         //if there's no perfect match, get the pokemon that best matches the nickname within the best guess evo-line
         Pokemon bestMatchPokemon = null;
         int lowestDist = Integer.MAX_VALUE;
         for (Pokemon trypoke : pokemons) {
-            int dist = Data.levenshteinDistance(trypoke.name, poketext);
+            int dist = Data.levenshteinDistance(trypoke.name, name);
             if (dist < lowestDist) {
                 bestMatchPokemon = trypoke;
                 lowestDist = dist;
@@ -351,12 +350,20 @@ public class PokemonNameCorrector {
         return new PokeDist(bestMatchPokemon, lowestDist);
     }
 
-    private PokeDist getNicknameGuess(String poketext, Map<String, Pokemon> pokemons) {
+    /**
+     * A method which returns the best guess at which pokemon it is according to similarity with the name
+     * in the given pokemons collection.
+     *
+     * @param normalizedName the normalized input name to compare with
+     * @param pokemons the pokemons collection with normalized their names as keys to search the normalized name into.
+     * @return a pokedist representing the search result.
+     */
+    private PokeDist guessBestPokemonByNormalizedName(String normalizedName, Map<String, Pokemon> pokemons) {
         //if there's no perfect match, get the pokemon that best matches the nickname within the best guess evo-line
         Pokemon bestMatchPokemon = null;
         int lowestDist = Integer.MAX_VALUE;
         for (Map.Entry<String, Pokemon> trypoke : pokemons.entrySet()) {
-            int dist = Data.levenshteinDistance(trypoke.getKey(), poketext);
+            int dist = Data.levenshteinDistance(trypoke.getKey(), normalizedName);
             if (dist < lowestDist) {
                 bestMatchPokemon = trypoke.getValue();
                 lowestDist = dist;
@@ -374,7 +381,7 @@ public class PokemonNameCorrector {
      */
     private ArrayList<Pokemon> getBestGuessForEvolutionLine(String input) {
         //candy name will only ever match the base evolution, so search in getBasePokemons().
-        PokeDist bestMatch = getNicknameGuess(input, pokeInfoCalculator.getNormalizedCandyPokemons());
+        PokeDist bestMatch = guessBestPokemonByNormalizedName(input, pokeInfoCalculator.getNormalizedCandyPokemons());
         return pokeInfoCalculator.getEvolutionLine(bestMatch.pokemon);
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
@@ -10,6 +10,7 @@ import com.kamron.pogoiv.utils.StringUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import lombok.AllArgsConstructor;
 
@@ -350,6 +351,20 @@ public class PokemonNameCorrector {
         return new PokeDist(bestMatchPokemon, lowestDist);
     }
 
+    private PokeDist getNicknameGuess(String poketext, Map<String, Pokemon> pokemons) {
+        //if there's no perfect match, get the pokemon that best matches the nickname within the best guess evo-line
+        Pokemon bestMatchPokemon = null;
+        int lowestDist = Integer.MAX_VALUE;
+        for (Map.Entry<String, Pokemon> trypoke : pokemons.entrySet()) {
+            int dist = Data.levenshteinDistance(trypoke.getKey(), poketext);
+            if (dist < lowestDist) {
+                bestMatchPokemon = trypoke.getValue();
+                lowestDist = dist;
+            }
+        }
+        return new PokeDist(bestMatchPokemon, lowestDist);
+    }
+
     /**
      * Get the evolution line which closest matches the string. The string is supposed to be the base evolution of a
      * line.
@@ -359,7 +374,7 @@ public class PokemonNameCorrector {
      */
     private ArrayList<Pokemon> getBestGuessForEvolutionLine(String input) {
         //candy name will only ever match the base evolution, so search in getBasePokemons().
-        PokeDist bestMatch = getNicknameGuess(input, pokeInfoCalculator.getCandyPokemons());
+        PokeDist bestMatch = getNicknameGuess(input, pokeInfoCalculator.getNormalizedCandyPokemons());
         return pokeInfoCalculator.getEvolutionLine(bestMatch.pokemon);
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
@@ -89,9 +89,8 @@ public class PokemonNameCorrector {
             //         pokeInfoCalculator.get(470).name); //Glaceon
             // eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.FAIRY),
             //         pokeInfoCalculator.get(699).name); //Sylveon
-            String normalizedPokemonType = StringUtils.normalize(scanData.getPokemonType());
-            if (eeveelutionCorrection.containsKey(normalizedPokemonType)) {
-                String name = eeveelutionCorrection.get(normalizedPokemonType);
+            if (eeveelutionCorrection.containsKey(scanData.getNormalizedPokemonType())) {
+                String name = eeveelutionCorrection.get(scanData.getNormalizedPokemonType());
                 guess = new PokeDist(pokeInfoCalculator.get(name), 0);
             }
         }
@@ -101,7 +100,7 @@ public class PokemonNameCorrector {
                 scanData.getCandyName()).contains(StringUtils.normalize(pokeInfoCalculator.get(182).name))
                 && (scanData.getEvolutionCandyCost().get() != -1)) { //its not an azumarill
             //if the scanned data contains the type water, it must be a marill, as azuril is normal type.
-            if (StringUtils.normalize(scanData.getPokemonType()).contains(
+            if (scanData.getNormalizedPokemonType().contains(
                     pokeInfoCalculator.getNormalizedType(Type.WATER))) {
                 guess = new PokeDist(pokeInfoCalculator.get(182), 0);
             } else {
@@ -166,126 +165,126 @@ public class PokemonNameCorrector {
             switch (guess.pokemon.number) {
                 case (102): // Exeggutor (dex 103)
                     // check types including dragon
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.DRAGON))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (18): // Rattata
                     // check types including dark
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.DARK))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (19): // Raticate
                     // check types including dark
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.DARK))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (25): // Raichu
                     // check types including psychic
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.PSYCHIC))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (26): // Sandshrew
                     // check types including ice
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.ICE))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (27): // Sandslash
                     // check types including ice
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.ICE))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (36): // Vulpix
                     // check types including ice
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.ICE))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (37): // Ninetales
                     // check types including ice
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.ICE))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (49): // Diglett
                     // check types including steel
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.STEEL))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (50): // Dugtrio
                     // check types including steel
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.STEEL))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (51): // Meowth
                     // check types including dark
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.DARK))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (52): // Persian
                     // check types including dark
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.DARK))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (73): // Geodude
                     // check types including electric
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.ELECTRIC))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (74): // Graveler
                     // check types including electric
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.ELECTRIC))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (75): // Golem
                     // check types including electric
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.ELECTRIC))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (87): // Grimer
                     // check types including dark
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.DARK))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (88): // Muk
                     // check types including dark
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.DARK))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }
                     break;
                 case (104): // Marowak
                     // check types including fire
-                    if (StringUtils.normalize(scanData.getPokemonType()).contains(
+                    if (scanData.getNormalizedPokemonType().contains(
                             pokeInfoCalculator.getNormalizedType(Type.FIRE))) {
                         return new PokeDist(pokeInfoCalculator.get(guess.pokemon.number).forms.get(0), 0);
                     }

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
@@ -37,6 +37,7 @@ public class PokemonNameCorrector {
     private PokemonNameCorrector(Resources res) {
         this.pokeInfoCalculator = PokeInfoCalculator.getInstance();
 
+        // create and cache the pokedex pokemons collection with normalized their names as keys
         Map<String, Pokemon> pokemap = new HashMap<>();
         for (Pokemon pokemon : pokeInfoCalculator.getPokedex()) {
             pokemap.put(StringUtils.normalize(pokemon.name), pokemon);

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
@@ -345,6 +345,7 @@ public class PokemonNameCorrector {
             if (dist < lowestDist) {
                 bestMatchPokemon = trypoke;
                 lowestDist = dist;
+                if (dist == 0) break;
             }
         }
         return new PokeDist(bestMatchPokemon, lowestDist);
@@ -367,6 +368,7 @@ public class PokemonNameCorrector {
             if (dist < lowestDist) {
                 bestMatchPokemon = trypoke.getValue();
                 lowestDist = dist;
+                if (dist == 0) break;
             }
         }
         return new PokeDist(bestMatchPokemon, lowestDist);

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
@@ -1,6 +1,7 @@
 package com.kamron.pogoiv.scanlogic;
 
 
+import android.content.Context;
 import android.content.res.Resources;
 import android.support.annotation.NonNull;
 
@@ -34,8 +35,8 @@ public class PokemonNameCorrector {
     private static String nidoMale;
     private static String nidoUngendered;
 
-    private PokemonNameCorrector(Resources res) {
-        this.pokeInfoCalculator = PokeInfoCalculator.getInstance();
+    private PokemonNameCorrector(Context context) {
+        this.pokeInfoCalculator = PokeInfoCalculator.getInstance(context);
 
         // create and cache the pokedex pokemons collection with normalized their names as keys
         Map<String, Pokemon> pokemap = new HashMap<>();
@@ -43,7 +44,7 @@ public class PokemonNameCorrector {
             pokemap.put(StringUtils.normalize(pokemon.name), pokemon);
         }
         this.normalizedPokemonNameMap = pokemap;
-        this.res = res;
+        this.res = context.getResources();
 
         nidoFemale = StringUtils.normalize(pokeInfoCalculator.get(28).name);
         nidoMale = StringUtils.normalize(pokeInfoCalculator.get(31).name);
@@ -63,9 +64,9 @@ public class PokemonNameCorrector {
         }
     }
 
-    public static PokemonNameCorrector getInstance(Resources res) {
+    public static PokemonNameCorrector getInstance(Context context) {
         if (instance == null) {
-            instance = new PokemonNameCorrector(res);
+            instance = new PokemonNameCorrector(context);
         }
 
         return instance;

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
@@ -27,6 +27,7 @@ public class PokemonNameCorrector {
     private static PokemonNameCorrector instance;
     private final PokeInfoCalculator pokeInfoCalculator;
     private final Map<String, Pokemon> normalizedPokemonNameMap;
+    private final Map<String, Pokemon> normalizedCandyPokemons;
     private final Map<Pokemon.Type, String> normalizedTypeNames;
     private Resources res;
     private static String nidoFemale;
@@ -49,10 +50,15 @@ public class PokemonNameCorrector {
 
         // create and cache the normalized pokemon type locale name
         this.normalizedTypeNames = new EnumMap<>(Pokemon.Type.class);
-
         for (int i = 0; i < res.getStringArray(R.array.typeName).length; i++) {
             this.normalizedTypeNames.put(Pokemon.Type.values()[i],
                     StringUtils.normalize(res.getStringArray(R.array.typeName)[i]));
+        }
+
+        // create and cache the candy pokemons collection with normalized their names as keys
+        this.normalizedCandyPokemons = new HashMap<>();
+        for (Pokemon pokemon : pokeInfoCalculator.getCandyPokemons()) {
+            this.normalizedCandyPokemons.put(StringUtils.normalize(pokemon.name), pokemon);
         }
     }
 
@@ -426,7 +432,7 @@ public class PokemonNameCorrector {
      * @return an evolution line which the string best matches the base evolution pokemon name
      */
     private ArrayList<Pokemon> getBestGuessForEvolutionLine(String input) {
-        PokeDist bestMatch = guessBestPokemonByNormalizedName(input, pokeInfoCalculator.getNormalizedCandyPokemons());
+        PokeDist bestMatch = guessBestPokemonByNormalizedName(input, normalizedCandyPokemons);
         return pokeInfoCalculator.getEvolutionLine(bestMatch.pokemon);
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
@@ -22,10 +22,11 @@ import static com.kamron.pogoiv.scanlogic.Pokemon.Type;
  * Created by pgiarrusso on 5/9/2016.
  */
 public class PokemonNameCorrector {
+    private static PokemonNameCorrector instance;
     private final PokeInfoCalculator pokeInfoCalculator;
     private final Map<String, Pokemon> normalizedPokemonNameMap;
 
-    public PokemonNameCorrector(PokeInfoCalculator pokeInfoCalculator) {
+    private PokemonNameCorrector(PokeInfoCalculator pokeInfoCalculator) {
         this.pokeInfoCalculator = pokeInfoCalculator;
 
         Map<String, Pokemon> pokemap = new HashMap<>();
@@ -33,6 +34,14 @@ public class PokemonNameCorrector {
             pokemap.put(StringUtils.normalize(pokemon.name), pokemon);
         }
         this.normalizedPokemonNameMap = pokemap;
+    }
+
+    public static PokemonNameCorrector getInstance(PokeInfoCalculator pokeInfoCalculator) {
+        if (instance == null) {
+            instance = new PokemonNameCorrector(pokeInfoCalculator);
+        }
+
+        return instance;
     }
 
     /**

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
@@ -88,27 +88,19 @@ public class PokemonNameCorrector {
         //3.  check correction for abnormal pokemon using Pokemon Type (such as eevees evolutions, azuril.)
         if (guess.pokemon == null
                 && normalizedCandyName.contains(StringUtils.normalize(pokeInfoCalculator.get(132).name))) {
-            HashMap<String, String> eeveelutionCorrection = new HashMap<>();
-            eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.WATER),
-                    pokeInfoCalculator.get(133).name); //Vaporeon
-            eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.ELECTRIC),
-                    pokeInfoCalculator.get(134).name); //Jolteon
-            eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.FIRE),
-                    pokeInfoCalculator.get(135).name); //Flareon
-            eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.PSYCHIC),
-                    pokeInfoCalculator.get(195).name); //Espeon
-            eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.DARK),
-                    pokeInfoCalculator.get(196).name); //Umbreon
+            HashMap<String, Integer> eeveelutionCorrection = new HashMap<>();
+            eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.WATER), 133); //Vaporeon pokedex#
+            eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.ELECTRIC), 134); //Jolteon pokedex#
+            eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.FIRE), 135); //Flareon pokedex#
+            eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.PSYCHIC), 195); //Espeon pokedex#
+            eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.DARK),196); //Umbreon pokedex#
             // Preparing for the future....
-            // eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.GRASS),
-            //         pokeInfoCalculator.get(469).name); //Leafeon
-            // eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.ICE),
-            //         pokeInfoCalculator.get(470).name); //Glaceon
-            // eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.FAIRY),
-            //         pokeInfoCalculator.get(699).name); //Sylveon
+            // eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.GRASS), 469); //Leafeon pokedex#
+            // eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.ICE), 470); //Glaceon pokedex#
+            // eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.FAIRY), 699); //Sylveon pokedex#
             if (eeveelutionCorrection.containsKey(scanData.getNormalizedPokemonType())) {
-                String name = eeveelutionCorrection.get(scanData.getNormalizedPokemonType());
-                guess = new PokeDist(pokeInfoCalculator.get(name), 0);
+                int eeveelutionPokedexId = eeveelutionCorrection.get(scanData.getNormalizedPokemonType());
+                guess = new PokeDist(pokeInfoCalculator.get(eeveelutionPokedexId), 0);
             }
         }
 

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
@@ -9,7 +9,6 @@ import com.kamron.pogoiv.utils.StringUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import lombok.AllArgsConstructor;
@@ -107,12 +106,11 @@ public class PokemonNameCorrector {
         //3.1 Azuril and marill have the same evolution cost, but different types.
         if (normalizedCandyName.contains(StringUtils.normalize(pokeInfoCalculator.get(182).name))
                 && (scanData.getEvolutionCandyCost().get() != -1)) { //its not an azumarill
-            //if the scanned data contains the type water, it must be a marill, as azuril is normal type.
-            if (scanData.getNormalizedPokemonType().contains(
-                    pokeInfoCalculator.getNormalizedType(Type.WATER))) {
-                guess = new PokeDist(pokeInfoCalculator.get(182), 0);
+            //if the scanned data contains the type water, it must be a marill, as azurill is normal type.
+            if (scanData.getNormalizedPokemonType().contains(pokeInfoCalculator.getNormalizedType(Type.WATER))) {
+                guess = new PokeDist(pokeInfoCalculator.get(182), 0); //marill
             } else {
-                guess = new PokeDist(pokeInfoCalculator.get(297), 0);
+                guess = new PokeDist(pokeInfoCalculator.get(297), 0); //azurill
             }
         }
 
@@ -171,8 +169,7 @@ public class PokemonNameCorrector {
         return guess;
     }
 
-    private PokeDist checkAlolanVariant(PokeDist guess,
-                                        ScanData scanData) {
+    private PokeDist checkAlolanVariant(PokeDist guess, ScanData scanData) {
         try {
             switch (guess.pokemon.number) {
                 case (102): // Exeggutor (dex 103)
@@ -370,7 +367,6 @@ public class PokemonNameCorrector {
      * @return an evolution line which the string best matches the base evolution pokemon name
      */
     private ArrayList<Pokemon> getBestGuessForEvolutionLine(String input) {
-        //candy name will only ever match the base evolution, so search in getBasePokemons().
         PokeDist bestMatch = guessBestPokemonByNormalizedName(input, pokeInfoCalculator.getNormalizedCandyPokemons());
         return pokeInfoCalculator.getEvolutionLine(bestMatch.pokemon);
     }

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
@@ -44,8 +44,8 @@ public class PokemonNameCorrector {
         this.normalizedPokemonNameMap = pokemap;
         this.res = res;
 
-        nidoFemale = pokeInfoCalculator.get(28).name;
-        nidoMale = pokeInfoCalculator.get(31).name;
+        nidoFemale = StringUtils.normalize(pokeInfoCalculator.get(28).name);
+        nidoMale = StringUtils.normalize(pokeInfoCalculator.get(31).name);
         nidoUngendered = nidoFemale.replace("♀", "").toLowerCase();
 
         // create and cache the normalized pokemon type locale name
@@ -201,8 +201,8 @@ public class PokemonNameCorrector {
 
         // remove characters not included in pokemon names or candy word. (ex. white space, -, etc)
         normalizedPokemonName = normalizedPokemonName.replaceAll("[^\\w♂♀]", "");
-        if (isNidoranName(normalizedPokemonName)) {
-            normalizedPokemonName = StringUtils.normalize(getNidoranGenderName(scanData.getPokemonGender()));
+        if (normalizedPokemonName.contains(nidoUngendered)) {
+            normalizedPokemonName = getNidoranGenderName(scanData.getPokemonGender());
         }
 
         return normalizedPokemonName;
@@ -216,16 +216,11 @@ public class PokemonNameCorrector {
         // remove characters not included in pokemon names or candy word. (ex. white space, -, etc)
         normalizedCandyText = normalizedCandyText.replaceAll("[^\\w♂♀]", "");
         normalizedCandyName = normalizedCandyText.replace(StringUtils.normalize(candyWordLocale), "");
-        if (isNidoranName(normalizedCandyName)) {
-            normalizedCandyName = StringUtils.normalize(getNidoranGenderName(scanData.getPokemonGender()));
+        if (normalizedCandyName.contains(nidoUngendered)) {
+            normalizedCandyName = getNidoranGenderName(scanData.getPokemonGender());
         }
 
         return normalizedCandyName;
-    }
-
-
-    private static boolean isNidoranName(String pokemonName) {
-        return StringUtils.normalize(pokemonName).contains(StringUtils.normalize(nidoUngendered));
     }
 
     /**

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
@@ -341,7 +341,7 @@ public class PokemonNameCorrector {
         Pokemon bestMatchPokemon = null;
         int lowestDist = Integer.MAX_VALUE;
         for (Pokemon trypoke : pokemons) {
-            int dist = Data.levenshteinDistance(StringUtils.normalize(trypoke.name), StringUtils.normalize(poketext));
+            int dist = Data.levenshteinDistance(trypoke.name, poketext);
             if (dist < lowestDist) {
                 bestMatchPokemon = trypoke;
                 lowestDist = dist;

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
@@ -43,6 +43,7 @@ public class PokemonNameCorrector {
      * @return a Pokedist with the best guess of the pokemon
      */
     public PokeDist getPossiblePokemon(@NonNull ScanData scanData) {
+        String normalizedCandyName = scanData.getNormalizedCandyName();
         ArrayList<Pokemon> bestGuessEvolutionLine = null;
         PokeDist guess;
 
@@ -51,7 +52,7 @@ public class PokemonNameCorrector {
 
         //2. See if we can get a perfect match with candy name & upgrade cost
         if (guess.pokemon == null) {
-            bestGuessEvolutionLine = getBestGuessForEvolutionLine(scanData.getCandyName());
+            bestGuessEvolutionLine = getBestGuessForEvolutionLine(normalizedCandyName);
 
             ArrayList<Pokemon> candyNameEvolutionCostGuess =
                     getCandyNameEvolutionCostGuess(bestGuessEvolutionLine, scanData.getEvolutionCandyCost());
@@ -69,8 +70,7 @@ public class PokemonNameCorrector {
 
         //3.  check correction for abnormal pokemon using Pokemon Type (such as eevees evolutions, azuril.)
         if (guess.pokemon == null
-                && StringUtils.normalize(
-                        scanData.getCandyName()).contains(StringUtils.normalize(pokeInfoCalculator.get(132).name))) {
+                && normalizedCandyName.contains(StringUtils.normalize(pokeInfoCalculator.get(132).name))) {
             HashMap<String, String> eeveelutionCorrection = new HashMap<>();
             eeveelutionCorrection.put(pokeInfoCalculator.getNormalizedType(Type.WATER),
                     pokeInfoCalculator.get(133).name); //Vaporeon
@@ -96,8 +96,7 @@ public class PokemonNameCorrector {
         }
 
         //3.1 Azuril and marill have the same evolution cost, but different types.
-        if (StringUtils.normalize(
-                scanData.getCandyName()).contains(StringUtils.normalize(pokeInfoCalculator.get(182).name))
+        if (normalizedCandyName.contains(StringUtils.normalize(pokeInfoCalculator.get(182).name))
                 && (scanData.getEvolutionCandyCost().get() != -1)) { //its not an azumarill
             //if the scanned data contains the type water, it must be a marill, as azuril is normal type.
             if (scanData.getNormalizedPokemonType().contains(

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanData.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanData.java
@@ -5,6 +5,7 @@ import android.support.annotation.Nullable;
 
 import com.google.common.base.Optional;
 import com.kamron.pogoiv.utils.LevelRange;
+import com.kamron.pogoiv.utils.StringUtils;
 
 /**
  * A ScanData represents the result of an OCR scan.
@@ -16,6 +17,7 @@ public class ScanData {
     private LevelRange estimatedPokemonLevelRange;
     private String pokemonName;
     private final String pokemonType;
+    private final String normalizedPokemonType;
     private final Pokemon.Gender pokemonGender;
     private final String candyName;
     private Optional<Integer> pokemonHP;
@@ -37,6 +39,7 @@ public class ScanData {
         this.estimatedPokemonLevelRange = estimatedPokemonLevel;
         this.pokemonName = pokemonName;
         this.pokemonType = pokemonType;
+        this.normalizedPokemonType = StringUtils.normalize(pokemonType);
         this.pokemonGender = pokemonGender;
         this.candyName = candyName;
         this.pokemonHP = pokemonHP;
@@ -69,6 +72,10 @@ public class ScanData {
 
     public String getPokemonType() {
         return pokemonType;
+    }
+
+    public String getNormalizedPokemonType() {
+        return normalizedPokemonType;
     }
 
     public Pokemon.Gender getPokemonGender() {

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanData.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanData.java
@@ -16,10 +16,12 @@ import com.kamron.pogoiv.utils.StringUtils;
 public class ScanData {
     private LevelRange estimatedPokemonLevelRange;
     private String pokemonName;
+    private String normalizedPokemonName;
     private final String pokemonType;
     private final String normalizedPokemonType;
     private final Pokemon.Gender pokemonGender;
     private final String candyName;
+    private final String normalizedCandyName;
     private Optional<Integer> pokemonHP;
     private Optional<Integer> pokemonCP;
     private Optional<Integer> pokemonCandyAmount;
@@ -38,10 +40,12 @@ public class ScanData {
                     String moveFast, String moveCharge, boolean isLucky, String uniqueID) {
         this.estimatedPokemonLevelRange = estimatedPokemonLevel;
         this.pokemonName = pokemonName;
+        this.normalizedPokemonName = StringUtils.normalize(pokemonName);
         this.pokemonType = pokemonType;
         this.normalizedPokemonType = StringUtils.normalize(pokemonType);
         this.pokemonGender = pokemonGender;
         this.candyName = candyName;
+        this.normalizedCandyName = StringUtils.normalize(candyName);
         this.pokemonHP = pokemonHP;
         this.pokemonCP = pokemonCP;
         this.pokemonCandyAmount = pokemonCandyAmount;
@@ -66,8 +70,13 @@ public class ScanData {
         return pokemonName;
     }
 
+    public String getNormalizedPokemonName() {
+        return normalizedPokemonName;
+    }
+
     public void setPokemonName(@NonNull String pokemonName) {
         this.pokemonName = pokemonName;
+        this.normalizedPokemonName = StringUtils.normalize(pokemonName);
     }
 
     public String getPokemonType() {
@@ -84,6 +93,10 @@ public class ScanData {
 
     public String getCandyName() {
         return candyName;
+    }
+
+    public String getNormalizedCandyName() {
+        return normalizedCandyName;
     }
 
     public Optional<Integer> getPokemonHP() {

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanData.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/ScanData.java
@@ -58,6 +58,41 @@ public class ScanData {
         this.uniqueID = uniqueID;
     }
 
+    @Override public String toString() {
+        // temporary format for checking OCR result and debugging IV calculations.
+        return String.format("ScanData\n"
+                        + "name:%s\n"
+                        + "type:%s\n"
+                        + "gender:%s\n"
+                        + "cp:%d\n"
+                        + "hp:%d\n"
+                        + "lucky:%B\n\n"
+
+                        + "candy_name:%s\n"
+                        + "candy_amount:%d\n"
+                        + "evolution_candy:%d\n"
+                        + "powerup_candy:%d\n"
+                        + "powerup_stardust:%d\n\n"
+
+                        + "move_fast:%s\n"
+                        + "move_charge:%s\n",
+                pokemonName,
+                pokemonType,
+                pokemonGender,
+                pokemonCP.or(-1),
+                pokemonHP.or(-1),
+                isLucky,
+
+                candyName,
+                pokemonCandyAmount.or(-1),
+                evolutionCandyCost.or(-1),
+                powerUpCandyCost.or(-1),
+                powerUpStardustCost.or(-1),
+
+                moveFast,
+                moveCharge);
+    }
+
     public LevelRange getEstimatedPokemonLevel() {
         return estimatedPokemonLevelRange;
     }


### PR DESCRIPTION
this PR improves performance at the points of followings:

* PokemonNameCorrector caches at first normalized text needed to improve detecting pokemons.
* PokemonNameCorrector stops guessing when it finds the best match pokemon.
https://github.com/udnp/GoIV_JP/blob/cbcb57dd3fbfb3e6f80dbc6d31a60786e0d1c18a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java#L418
```java
            if (dist < lowestDist) {
                bestMatchPokemon = trypoke.getValue();
                lowestDist = dist;
                if (dist == 0) break;
            }
```

refactoring points:
* normalizing for OCR scanned text are gathered into ScanData class.
* normalizing for pokemon info text are gathered into PokemonNameCorrector class.