### PR TITLE
change repository definition order so 'common' resolves from google before jcenter is checked

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
@@ -12,8 +12,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 


### PR DESCRIPTION
When I pull master and try to build I get this gradle error: 
```
Failed to resolve: common
Open File
```
Changing the order that the repositories are specified lets it check google first for that dependency and find it. Curious who else sees this; I don't have anything in my local caches (which it would check first). 