### PR TITLE
update gradle build tools and gradle version used

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,7 +72,6 @@ android {
      * Update (both Gradle and local SDK) whenever possible
      */
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
 
     /**
      * Build configurations for APK

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/openCVLibrary330/build.gradle
+++ b/openCVLibrary330/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 19

--- a/openCVLibrary330/src/main/AndroidManifest.xml
+++ b/openCVLibrary330/src/main/AndroidManifest.xml
@@ -2,7 +2,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="org.opencv"
       android:versionCode="3300"
-      android:versionName="3.3.0">
-
-    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="21" />
-</manifest>
+      android:versionName="3.3.0" />


### PR DESCRIPTION
`3.2.1` requires gradle 4.6 or above and adds a bunch of build errors and warnings.

It has a default `buildToolsVersion` now so specifying one is no longer necessary. it also errors on sdk versions being specified in the manifest