### PR TITLE
remove the android min and target sdk attributes from the manifest in the CV library

### DIFF
--- a/openCVLibrary330/src/main/AndroidManifest.xml
+++ b/openCVLibrary330/src/main/AndroidManifest.xml
@@ -2,7 +2,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="org.opencv"
       android:versionCode="3300"
-      android:versionName="3.3.0">
-
-    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="21" />
-</manifest>
+      android:versionName="3.3.0" />


### PR DESCRIPTION
Splitting out part of https://github.com/farkam135/GoIV/pull/1000/files

There aren't doing anything here and are actually different to the values specified in the `build.gradle` file for this project [see here!](https://github.com/harkin/GoIV/blob/5a2206ab270bdf3810f288853c4e74ed9b525881/openCVLibrary330/build.gradle#L8-L9)

At some point in the compilation the values from the `build.gradle` get inserted into the manifest. Here's the debug manifest generated during a build for me:

```
<?xml version="1.0" encoding="utf-8"?>
<manifest xmlns:android="http://schemas.android.com/apk/res/android"
    package="org.opencv"
    android:versionCode="3300"
    android:versionName="3.3.0" >

    <uses-sdk
        android:minSdkVersion="19"
        android:targetSdkVersion="27" />

</manifest>
```