### PR TITLE
detection for pokemons Meltan and Melmetal (quick hardcoded patch)

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -150,6 +150,14 @@ public class PokeInfoCalculator {
 
         int pokeListSize = names.length;
         ArrayList<Pokemon> formVariantPokemons = new ArrayList<>();
+
+        // quick hardcoded patch for Meltan and Melmetal
+        // Tentatively use pokedex list size unless discontinuous pokedex numbers.
+        candyNamesArray[pokeListSize - 2] = pokeListSize - 2;
+        candyNamesArray[pokeListSize - 1] = pokeListSize - 2;
+        devolution[pokeListSize - 1] = pokeListSize - 2;
+        // END patch for Meltan and Melmetal
+
         for (int i = 0; i < pokeListSize; i++) {
             Pokemon p = new Pokemon(names[i], displayNames[i], i, attack[i], defense[i], stamina[i], devolution[i],
                     evolutionCandyCost[i]);

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -152,7 +152,8 @@ public class PokeInfoCalculator {
         ArrayList<Pokemon> formVariantPokemons = new ArrayList<>();
 
         // quick hardcoded patch for Meltan and Melmetal
-        // Tentatively use pokedex list size unless discontinuous pokedex numbers.
+        // Tentatively use pokedex list size until supporting discontinuous pokedex numbers,
+        // like as #493 Arceus, #808 Meltan, #809 Melmetal.
         candyNamesArray[pokeListSize - 2] = pokeListSize - 2;
         candyNamesArray[pokeListSize - 1] = pokeListSize - 2;
         devolution[pokeListSize - 1] = pokeListSize - 2;

--- a/app/src/main/res/values-de/pokemons.xml
+++ b/app/src/main/res/values-de/pokemons.xml
@@ -498,6 +498,8 @@
         <item>Darkrai</item>
         <item>Shaymin</item>
         <item>Arceus</item>
+        <item>Meltan</item>
+        <item>Melmetal</item>
     </string-array>
     <string-array name="typeName">
         <!--  0   normal -->

--- a/app/src/main/res/values-fr/pokemons.xml
+++ b/app/src/main/res/values-fr/pokemons.xml
@@ -498,6 +498,8 @@
         <item>  Darkrai</item>
         <item>  Shaymin</item>
         <item>  Arceus</item>
+        <item>Meltan</item>
+        <item>Melmetal</item>
     </string-array>
     <string-array name="typeName">
         <!--  0   normal -->

--- a/app/src/main/res/values-zh-rTW/pokemons.xml
+++ b/app/src/main/res/values-zh-rTW/pokemons.xml
@@ -496,6 +496,7 @@
         <item>达克莱伊</item>
         <item>谢米</item>
         <item>阿尔宙斯</item>
-
+        <item>Meltan</item>
+        <item>Melmetal</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-zh-rTW/pokemons.xml
+++ b/app/src/main/res/values-zh-rTW/pokemons.xml
@@ -496,7 +496,7 @@
         <item>达克莱伊</item>
         <item>谢米</item>
         <item>阿尔宙斯</item>
-        <item>Meltan</item>
-        <item>Melmetal</item>
+        <item>美錄坦</item>
+        <item>美錄梅塔</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/pokemons.xml
+++ b/app/src/main/res/values/pokemons.xml
@@ -497,6 +497,8 @@
         <item>Darkrai</item>
         <item>Shaymin</item>
         <item>Arceus</item>
+        <item>Meltan</item>
+        <item>Melmetal</item>
     </string-array>
     <string-array name="typeName">
         <!--  0   normal --> <item>NORMAL</item>


### PR DESCRIPTION
This is a quick hardcoded patch.
but dose not need to change `integers.xml` and its generator.

tested with a pokemon renamed as Meltan,
because I still don't have these new pokemons.

![pr-meltan](https://user-images.githubusercontent.com/17121615/48629606-6842b500-e9fd-11e8-95dd-2f8cfc2b975b.png)
