### PR TITLE
MixedUnicodeToken: Returnvalue now matches token description in GoIV

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/clipboardlogic/tokens/MixedUnicodeToken.java
+++ b/app/src/main/java/com/kamron/pogoiv/clipboardlogic/tokens/MixedUnicodeToken.java
@@ -11,7 +11,7 @@ import com.kamron.pogoiv.scanlogic.ScanResult;
 /**
  * Copied from UnicodeToken created by Johan on 2016-09-25.
  * MixedUnicodeToken created by TripSixes on 2017-01-12
- * Represents the lowest possible IV combination with ⓪①②③④⑤⑥⑦⑧⑨⑩⑪⑫⑬⑭⑮, but also
+ * Represents the lowest possible IV values per stat with ⓪①②③④⑤⑥⑦⑧⑨⑩⑪⑫⑬⑭⑮, but also
  * mixes the filled and non-filled characters depending on if there are multiple or single of
  * a given IV Result list.
  */
@@ -100,9 +100,9 @@ public class MixedUnicodeToken extends ClipboardToken {
             return "";
         }
 
-        return attToUse[lowestIVCombination.att]
-                + defToUse[lowestIVCombination.def]
-                + staToUse[lowestIVCombination.sta];
+        return attToUse[lowestAttackStat]
+                + defToUse[lowestDefenseStat]
+                + staToUse[lowestStaminaStat];
     }
 
     @Override


### PR DESCRIPTION
This PR addresses https://github.com/farkam135/GoIV/issues/1016, which has also been discussed on Reddit: https://www.reddit.com/r/GoIV/comments/a0u2yo/problem_with_uivmixed07_display_of_calculated/

It fixes the returnvalue to be in line with the description in the app GoIV, which states that it returns the lowest value for each stat. Instead, it currently returns the lowest IV combination.