### PR TITLE
Prevent exception when the candy cost is absent

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonNameCorrector.java
@@ -134,7 +134,7 @@ public class PokemonNameCorrector {
 
         //3.1 Azuril and marill have the same evolution cost, but different types.
         if (normalizedCandyName.contains(StringUtils.normalize(pokeInfoCalculator.get(182).name))
-                && (scanData.getEvolutionCandyCost().get() != -1)) { //its not an azumarill
+                && (scanData.getEvolutionCandyCost().or(-1) != -1)) { //its not an azumarill
             //if the scanned data contains the type water, it must be a marill, as azurill is normal type.
             if (scanData.getNormalizedPokemonType().contains(normalizePokemonType(Type.WATER))) {
                 guess = new PokeDist(pokeInfoCalculator.getForm(182), 0); //marill


### PR DESCRIPTION
If the evolution candy cost is absent, it throughs an exception if it is
read the first time. And that could happen if a Marill family pokemon
was scanned. In that case it should assume that the cost isn't present.

Fixes: #1043