### PR TITLE
Improves mid-evolution detection by removing misdetect

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/ocrhelper/OcrHelper.java
@@ -593,11 +593,17 @@ public class OcrHelper {
         refinedImage.getPixels(pixelArray, 0, refinedImage.getWidth(), 0, refinedImage.getHeight() / 2, refinedImage
                 .getWidth(), 1);
 
+        int numNonWhitePixels = 0;
         for (int pixel : pixelArray) {
             if (pixel != Color.rgb(255, 255, 255)) { // if pixel is not white
-                return false;
+                numNonWhitePixels++;
             }
         }
+        float percentNonWhite = (float) numNonWhitePixels / (float) pixelArray.length;
+        if (percentNonWhite > 0.013){
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
The 'allblank' method heuristic was too trigger happy, in some instances, a few black pixels would accidentally be left in the candy-image, which should still be ignored. This adds a percentage barrier.


I made this patch because a friend couldnt scan pokemon on her phone, and got to borrow her phone and debug to see what happened, which led me to discover this issue.