### PR TITLE
Fix evolution candy cost calculation

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -399,20 +399,15 @@ public class PokeInfoCalculator {
      * @return the combined candy cost for all required evolutions
      */
     public int getCandyCostForEvolution(Pokemon start, Pokemon end) {
-        Pokemon devolution = getDevolution(start);
-        Pokemon dedevolution = null;
-        if (devolution != null) { //devolution must exist for there to be a devolution of the devolution
-            dedevolution = getDevolution(devolution);
-        }
-
-        boolean isEndReallyAfterStart = (devolution == start)
-                || dedevolution == start; //end must be devolution or devolution of devolution of start
         int cost = 0;
-        if (isInSameEvolutionChain(start, end) && isEndReallyAfterStart) {
-            while (start != end) { //move backwards from end until you've reached start
-                end = getDevolution(end);
-                cost += end.candyEvolutionCost;
+        while (start != end) { //move backwards from end until you've reached start
+            end = getDevolution(end);
+            // Gone through all devolutions from the end but never passed by start -> start and end are not related
+            if (end == null)
+            {
+                return 0;
             }
+            cost += end.candyEvolutionCost;
         }
         return cost;
     }


### PR DESCRIPTION
When calculating the candy cost for evolutions, it checks that the start pokemon is really before the end pokemon. But with the split of `PokemonBase` and `Pokemon` a typo crept in, which actually checks the devolutions of the start pokemon.

This rewrites it into a simpler function, we already go through the devolutions anyway, so just have one loop which goes from the end pokemon to every devolution pokemon. If the start pokemon wasn't seen until there are no devolutions anymore, it either means that start and end are the wrong way around or that both aren't related.
