### PR TITLE
Fix form attributes for Unown and Spinda

### DIFF
--- a/app/src/main/res/values/forms.xml
+++ b/app/src/main/res/values/forms.xml
@@ -243,44 +243,44 @@
   <item>144</item> <!-- Normal Form -->
   <item>144</item> <!-- Alola Form -->
   <!--Unown-->
-  <item>-1</item> <!-- F Form -->
-  <item>-1</item> <!-- A Form -->
-  <item>-1</item> <!-- B Form -->
-  <item>-1</item> <!-- C Form -->
-  <item>-1</item> <!-- D Form -->
-  <item>-1</item> <!-- E Form -->
-  <item>-1</item> <!-- G Form -->
-  <item>-1</item> <!-- H Form -->
-  <item>-1</item> <!-- I Form -->
-  <item>-1</item> <!-- J Form -->
-  <item>-1</item> <!-- K Form -->
-  <item>-1</item> <!-- L Form -->
-  <item>-1</item> <!-- M Form -->
-  <item>-1</item> <!-- N Form -->
-  <item>-1</item> <!-- O Form -->
-  <item>-1</item> <!-- P Form -->
-  <item>-1</item> <!-- Q Form -->
-  <item>-1</item> <!-- R Form -->
-  <item>-1</item> <!-- S Form -->
-  <item>-1</item> <!-- T Form -->
-  <item>-1</item> <!-- U Form -->
-  <item>-1</item> <!-- V Form -->
-  <item>-1</item> <!-- W Form -->
-  <item>-1</item> <!-- X Form -->
-  <item>-1</item> <!-- Y Form -->
-  <item>-1</item> <!-- Z Form -->
-  <item>-1</item> <!-- Exclamation Point Form -->
-  <item>-1</item> <!-- Question Mark Form -->
+  <item>136</item> <!-- F Form -->
+  <item>136</item> <!-- A Form -->
+  <item>136</item> <!-- B Form -->
+  <item>136</item> <!-- C Form -->
+  <item>136</item> <!-- D Form -->
+  <item>136</item> <!-- E Form -->
+  <item>136</item> <!-- G Form -->
+  <item>136</item> <!-- H Form -->
+  <item>136</item> <!-- I Form -->
+  <item>136</item> <!-- J Form -->
+  <item>136</item> <!-- K Form -->
+  <item>136</item> <!-- L Form -->
+  <item>136</item> <!-- M Form -->
+  <item>136</item> <!-- N Form -->
+  <item>136</item> <!-- O Form -->
+  <item>136</item> <!-- P Form -->
+  <item>136</item> <!-- Q Form -->
+  <item>136</item> <!-- R Form -->
+  <item>136</item> <!-- S Form -->
+  <item>136</item> <!-- T Form -->
+  <item>136</item> <!-- U Form -->
+  <item>136</item> <!-- V Form -->
+  <item>136</item> <!-- W Form -->
+  <item>136</item> <!-- X Form -->
+  <item>136</item> <!-- Y Form -->
+  <item>136</item> <!-- Z Form -->
+  <item>136</item> <!-- Exclamation Point Form -->
+  <item>136</item> <!-- Question Mark Form -->
   <!--Spinda-->
-  <item>-1</item> <!-- 00 Form -->
-  <item>-1</item> <!-- 01 Form -->
-  <item>-1</item> <!-- 02 Form -->
-  <item>-1</item> <!-- 03 Form -->
-  <item>-1</item> <!-- 04 Form -->
-  <item>-1</item> <!-- 05 Form -->
-  <item>-1</item> <!-- 06 Form -->
-  <item>-1</item> <!-- 07 Form -->
-  <item>-1</item> <!-- 08 Form -->
+  <item>116</item> <!-- 00 Form -->
+  <item>116</item> <!-- 01 Form -->
+  <item>116</item> <!-- 02 Form -->
+  <item>116</item> <!-- 03 Form -->
+  <item>116</item> <!-- 04 Form -->
+  <item>116</item> <!-- 05 Form -->
+  <item>116</item> <!-- 06 Form -->
+  <item>116</item> <!-- 07 Form -->
+  <item>116</item> <!-- 08 Form -->
   <!--Castform-->
   <item>139</item> <!-- Normal Form -->
   <item>139</item> <!-- Sunny Form -->
@@ -397,44 +397,44 @@
   <item>186</item> <!-- Normal Form -->
   <item>186</item> <!-- Alola Form -->
   <!--Unown-->
-  <item>-1</item> <!-- F Form -->
-  <item>-1</item> <!-- A Form -->
-  <item>-1</item> <!-- B Form -->
-  <item>-1</item> <!-- C Form -->
-  <item>-1</item> <!-- D Form -->
-  <item>-1</item> <!-- E Form -->
-  <item>-1</item> <!-- G Form -->
-  <item>-1</item> <!-- H Form -->
-  <item>-1</item> <!-- I Form -->
-  <item>-1</item> <!-- J Form -->
-  <item>-1</item> <!-- K Form -->
-  <item>-1</item> <!-- L Form -->
-  <item>-1</item> <!-- M Form -->
-  <item>-1</item> <!-- N Form -->
-  <item>-1</item> <!-- O Form -->
-  <item>-1</item> <!-- P Form -->
-  <item>-1</item> <!-- Q Form -->
-  <item>-1</item> <!-- R Form -->
-  <item>-1</item> <!-- S Form -->
-  <item>-1</item> <!-- T Form -->
-  <item>-1</item> <!-- U Form -->
-  <item>-1</item> <!-- V Form -->
-  <item>-1</item> <!-- W Form -->
-  <item>-1</item> <!-- X Form -->
-  <item>-1</item> <!-- Y Form -->
-  <item>-1</item> <!-- Z Form -->
-  <item>-1</item> <!-- Exclamation Point Form -->
-  <item>-1</item> <!-- Question Mark Form -->
+  <item>91</item> <!-- F Form -->
+  <item>91</item> <!-- A Form -->
+  <item>91</item> <!-- B Form -->
+  <item>91</item> <!-- C Form -->
+  <item>91</item> <!-- D Form -->
+  <item>91</item> <!-- E Form -->
+  <item>91</item> <!-- G Form -->
+  <item>91</item> <!-- H Form -->
+  <item>91</item> <!-- I Form -->
+  <item>91</item> <!-- J Form -->
+  <item>91</item> <!-- K Form -->
+  <item>91</item> <!-- L Form -->
+  <item>91</item> <!-- M Form -->
+  <item>91</item> <!-- N Form -->
+  <item>91</item> <!-- O Form -->
+  <item>91</item> <!-- P Form -->
+  <item>91</item> <!-- Q Form -->
+  <item>91</item> <!-- R Form -->
+  <item>91</item> <!-- S Form -->
+  <item>91</item> <!-- T Form -->
+  <item>91</item> <!-- U Form -->
+  <item>91</item> <!-- V Form -->
+  <item>91</item> <!-- W Form -->
+  <item>91</item> <!-- X Form -->
+  <item>91</item> <!-- Y Form -->
+  <item>91</item> <!-- Z Form -->
+  <item>91</item> <!-- Exclamation Point Form -->
+  <item>91</item> <!-- Question Mark Form -->
   <!--Spinda-->
-  <item>-1</item> <!-- 00 Form -->
-  <item>-1</item> <!-- 01 Form -->
-  <item>-1</item> <!-- 02 Form -->
-  <item>-1</item> <!-- 03 Form -->
-  <item>-1</item> <!-- 04 Form -->
-  <item>-1</item> <!-- 05 Form -->
-  <item>-1</item> <!-- 06 Form -->
-  <item>-1</item> <!-- 07 Form -->
-  <item>-1</item> <!-- 08 Form -->
+  <item>116</item> <!-- 00 Form -->
+  <item>116</item> <!-- 01 Form -->
+  <item>116</item> <!-- 02 Form -->
+  <item>116</item> <!-- 03 Form -->
+  <item>116</item> <!-- 04 Form -->
+  <item>116</item> <!-- 05 Form -->
+  <item>116</item> <!-- 06 Form -->
+  <item>116</item> <!-- 07 Form -->
+  <item>116</item> <!-- 08 Form -->
   <!--Castform-->
   <item>139</item> <!-- Normal Form -->
   <item>139</item> <!-- Sunny Form -->
@@ -551,44 +551,44 @@
   <item>155</item> <!-- Normal Form -->
   <item>155</item> <!-- Alola Form -->
   <!--Unown-->
-  <item>-1</item> <!-- F Form -->
-  <item>-1</item> <!-- A Form -->
-  <item>-1</item> <!-- B Form -->
-  <item>-1</item> <!-- C Form -->
-  <item>-1</item> <!-- D Form -->
-  <item>-1</item> <!-- E Form -->
-  <item>-1</item> <!-- G Form -->
-  <item>-1</item> <!-- H Form -->
-  <item>-1</item> <!-- I Form -->
-  <item>-1</item> <!-- J Form -->
-  <item>-1</item> <!-- K Form -->
-  <item>-1</item> <!-- L Form -->
-  <item>-1</item> <!-- M Form -->
-  <item>-1</item> <!-- N Form -->
-  <item>-1</item> <!-- O Form -->
-  <item>-1</item> <!-- P Form -->
-  <item>-1</item> <!-- Q Form -->
-  <item>-1</item> <!-- R Form -->
-  <item>-1</item> <!-- S Form -->
-  <item>-1</item> <!-- T Form -->
-  <item>-1</item> <!-- U Form -->
-  <item>-1</item> <!-- V Form -->
-  <item>-1</item> <!-- W Form -->
-  <item>-1</item> <!-- X Form -->
-  <item>-1</item> <!-- Y Form -->
-  <item>-1</item> <!-- Z Form -->
-  <item>-1</item> <!-- Exclamation Point Form -->
-  <item>-1</item> <!-- Question Mark Form -->
+  <item>134</item> <!-- F Form -->
+  <item>134</item> <!-- A Form -->
+  <item>134</item> <!-- B Form -->
+  <item>134</item> <!-- C Form -->
+  <item>134</item> <!-- D Form -->
+  <item>134</item> <!-- E Form -->
+  <item>134</item> <!-- G Form -->
+  <item>134</item> <!-- H Form -->
+  <item>134</item> <!-- I Form -->
+  <item>134</item> <!-- J Form -->
+  <item>134</item> <!-- K Form -->
+  <item>134</item> <!-- L Form -->
+  <item>134</item> <!-- M Form -->
+  <item>134</item> <!-- N Form -->
+  <item>134</item> <!-- O Form -->
+  <item>134</item> <!-- P Form -->
+  <item>134</item> <!-- Q Form -->
+  <item>134</item> <!-- R Form -->
+  <item>134</item> <!-- S Form -->
+  <item>134</item> <!-- T Form -->
+  <item>134</item> <!-- U Form -->
+  <item>134</item> <!-- V Form -->
+  <item>134</item> <!-- W Form -->
+  <item>134</item> <!-- X Form -->
+  <item>134</item> <!-- Y Form -->
+  <item>134</item> <!-- Z Form -->
+  <item>134</item> <!-- Exclamation Point Form -->
+  <item>134</item> <!-- Question Mark Form -->
   <!--Spinda-->
-  <item>-1</item> <!-- 00 Form -->
-  <item>-1</item> <!-- 01 Form -->
-  <item>-1</item> <!-- 02 Form -->
-  <item>-1</item> <!-- 03 Form -->
-  <item>-1</item> <!-- 04 Form -->
-  <item>-1</item> <!-- 05 Form -->
-  <item>-1</item> <!-- 06 Form -->
-  <item>-1</item> <!-- 07 Form -->
-  <item>-1</item> <!-- 08 Form -->
+  <item>155</item> <!-- 00 Form -->
+  <item>155</item> <!-- 01 Form -->
+  <item>155</item> <!-- 02 Form -->
+  <item>155</item> <!-- 03 Form -->
+  <item>155</item> <!-- 04 Form -->
+  <item>155</item> <!-- 05 Form -->
+  <item>155</item> <!-- 06 Form -->
+  <item>155</item> <!-- 07 Form -->
+  <item>155</item> <!-- 08 Form -->
   <!--Castform-->
   <item>172</item> <!-- Normal Form -->
   <item>172</item> <!-- Sunny Form -->


### PR DESCRIPTION
With the change to PokemonBase and Pokemon, pokemons with forms only use the form attributes, which were wrong for those two pokemon.