### PR TITLE
Update project to Android Studio 3.4.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,7 +72,6 @@ android {
      * Update (both Gradle and local SDK) whenever possible
      */
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
 
     /**
      * Build configurations for APK

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.4.1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sat Jun 08 08:31:36 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/openCVLibrary330/build.gradle
+++ b/openCVLibrary330/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 19


### PR DESCRIPTION
The GoIV Android Studio project is using outdated plugins and build tools.
Update them to maximize compatibility with latest Android releases.

PS:
Yes, the removal of the buildTool lines from the Gradle build files is intended since it is not neened in latest Android Studio releases, the build tools version is inferred from other project properties.