### PR TITLE
Fix appraisal measurement and other improvements

### DIFF
--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/AppraisalManager.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/AppraisalManager.java
@@ -143,6 +143,7 @@ public class AppraisalManager {
 
         void post() {
             barData = null;
+            retries = 0;
             handler.removeCallbacks(this);
             handler.postDelayed(this, initialDelay);
         }
@@ -210,6 +211,7 @@ public class AppraisalManager {
                 }
 
                 if (change && retries < SCANRETRIES) {
+                    retries++;
                     handler.postDelayed(this, RETRYDELAY);
                 } else {
                     int[] width = new int[this.barData.length];

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/AppraisalManager.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/AppraisalManager.java
@@ -67,12 +67,11 @@ public class AppraisalManager {
         // Although, it's entirely possible for the user to touch the area below (or above) GoIV an unlimited number
         // of times without actually ever starting the appraisal process
 
-        if (numTouches == 2) { // Second touch is usually the "Appraise" menu item.
+        if ((numTouches > 2) && (!autoAppraisalDone)) {
             // Signal to the user that we're now looking for the first appraisal phase.
             for (OnAppraisalEventListener eventListener : eventListeners) {
                 eventListener.highlightActiveUserInterface();
             }
-        } else if ((numTouches > 2) && (!autoAppraisalDone)) {
             // Scan Appraisal text after the configured delay.
             autoScreenScanner.post();
         }
@@ -104,9 +103,10 @@ public class AppraisalManager {
             stamina = combination.sta;
             staminaValid = true;
             autoAppraisalDone = true;
-            for (OnAppraisalEventListener eventListener : eventListeners) {
-                eventListener.refreshSelection();
-            }
+        }
+        // Refresh the selection
+        for (OnAppraisalEventListener eventListener : eventListeners) {
+            eventListener.refreshSelection();
         }
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/fractions/AppraisalFraction.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/fractions/AppraisalFraction.java
@@ -97,8 +97,17 @@ public class AppraisalFraction extends MovableFraction implements AppraisalManag
             @Override
             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
                 if (!insideUpdate) {
+                    if (appraisalManager.attack != atkSeek.getProgress()) {
+                        appraisalManager.attackValid = true;
+                    }
                     appraisalManager.attack = atkSeek.getProgress();
+                    if (appraisalManager.defense != defSeek.getProgress()) {
+                        appraisalManager.defenseValid = true;
+                    }
                     appraisalManager.defense = defSeek.getProgress();
+                    if (appraisalManager.stamina != staSeek.getProgress()) {
+                        appraisalManager.staminaValid = true;
+                    }
                     appraisalManager.stamina = staSeek.getProgress();
                     updateValueTexts();
                 }
@@ -186,9 +195,6 @@ public class AppraisalFraction extends MovableFraction implements AppraisalManag
 
     @OnCheckedChanged({R.id.atkEnabled, R.id.defEnabled, R.id.staEnabled})
     public void onEnabled() {
-        atkSeek.setEnabled(atkEnabled.isChecked());
-        defSeek.setEnabled(defEnabled.isChecked());
-        staSeek.setEnabled(staEnabled.isChecked());
         if (!insideUpdate) {
             appraisalManager.attackValid = atkEnabled.isChecked();
             appraisalManager.defenseValid = defEnabled.isChecked();

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/fractions/AppraisalFraction.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/fractions/AppraisalFraction.java
@@ -199,6 +199,7 @@ public class AppraisalFraction extends MovableFraction implements AppraisalManag
             appraisalManager.attackValid = atkEnabled.isChecked();
             appraisalManager.defenseValid = defEnabled.isChecked();
             appraisalManager.staminaValid = staEnabled.isChecked();
+            updateIVPreviewInButton();
         }
     }
 

--- a/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/fractions/AppraisalFraction.java
+++ b/app/src/main/java/com/kamron/pogoiv/pokeflycomponents/fractions/AppraisalFraction.java
@@ -100,9 +100,8 @@ public class AppraisalFraction extends MovableFraction implements AppraisalManag
                     appraisalManager.attack = atkSeek.getProgress();
                     appraisalManager.defense = defSeek.getProgress();
                     appraisalManager.stamina = staSeek.getProgress();
-                    updateIVPreviewInButton();
+                    updateValueTexts();
                 }
-                updateValueTexts();
             }
 
             @Override
@@ -201,25 +200,30 @@ public class AppraisalFraction extends MovableFraction implements AppraisalManag
     public void refreshSelection() {
         setSpinnerSelection();
         spinnerLayout.setBackground(null);
-        updateIVPreviewInButton();
     }
 
+    /**
+     * Updates the checkboxes, labels and IV preview in the button.
+     */
     private void updateValueTexts() {
         atkValue.setText(String.valueOf(appraisalManager.attack));
         defValue.setText(String.valueOf(appraisalManager.defense));
         staValue.setText(String.valueOf(appraisalManager.stamina));
+        atkEnabled.setChecked(appraisalManager.attackValid);
+        defEnabled.setChecked(appraisalManager.defenseValid);
+        staEnabled.setChecked(appraisalManager.staminaValid);
+        updateIVPreviewInButton();
     }
 
+    /**
+     * Sets the progress bars and calls {@code updateValueTexts()}, mainly used to update it from the outside.
+     */
     private void setSpinnerSelection() {
         insideUpdate = true;
         updateValueTexts();
         atkSeek.setProgress(appraisalManager.attack);
         defSeek.setProgress(appraisalManager.defense);
         staSeek.setProgress(appraisalManager.stamina);
-        atkEnabled.setChecked(appraisalManager.attackValid);
-        defEnabled.setChecked(appraisalManager.defenseValid);
-        staEnabled.setChecked(appraisalManager.staminaValid);
-        onEnabled();
         insideUpdate = false;
     }
 

--- a/app/src/main/res/layout/fraction_appraisal.xml
+++ b/app/src/main/res/layout/fraction_appraisal.xml
@@ -81,29 +81,21 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:id="@+id/atkEnabled"
+            android:text="@string/atk"
             app:layout_constraintStart_toStartOf="parent"
             android:layout_marginStart="4dp"
             android:layout_marginTop="4dp"
             app:layout_constraintTop_toTopOf="parent"/>
-        <TextView
-            android:text="@string/atk"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/atkHeader"
-            app:layout_constraintBottom_toBottomOf="@+id/atkEnabled"
-            app:layout_constraintTop_toTopOf="@+id/atkEnabled"
-            app:layout_constraintStart_toEndOf="@+id/atkEnabled"
-            android:layout_marginStart="8dp"/>
         <SeekBar
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:id="@+id/atkSeek"
             android:layout_weight="1"
             android:layout_marginEnd="8dp"
-            app:layout_constraintStart_toEndOf="@+id/atkHeader"
+            app:layout_constraintStart_toEndOf="@+id/atkEnabled"
             android:layout_marginStart="8dp"
-            app:layout_constraintBottom_toBottomOf="@+id/atkHeader"
-            app:layout_constraintTop_toTopOf="@+id/atkHeader"
+            app:layout_constraintBottom_toBottomOf="@+id/atkEnabled"
+            app:layout_constraintTop_toTopOf="@+id/atkEnabled"
             android:max="15"
             app:layout_constraintEnd_toStartOf="@+id/atkValue"/>
         <TextView
@@ -120,17 +112,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:id="@+id/defEnabled"
+            android:text="@string/def"
             app:layout_constraintTop_toBottomOf="@+id/atkEnabled"
             app:layout_constraintStart_toStartOf="@+id/atkEnabled"/>
-        <TextView
-            android:text="@string/def"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/defHeader"
-            app:layout_constraintStart_toEndOf="@+id/defEnabled"
-            android:layout_marginStart="8dp"
-            app:layout_constraintBottom_toBottomOf="@+id/defEnabled"
-            app:layout_constraintTop_toTopOf="@+id/defEnabled"/>
         <SeekBar
             android:layout_width="0dp"
             android:layout_height="match_parent"
@@ -138,8 +122,8 @@
             android:layout_weight="1"
             android:layout_marginEnd="8dp"
             app:layout_constraintStart_toStartOf="@+id/atkSeek"
-            app:layout_constraintBottom_toBottomOf="@+id/defHeader"
-            app:layout_constraintTop_toTopOf="@+id/defHeader"
+            app:layout_constraintBottom_toBottomOf="@+id/defEnabled"
+            app:layout_constraintTop_toTopOf="@+id/defEnabled"
             android:max="15"
             app:layout_constraintEnd_toStartOf="@+id/defValue"/>
         <TextView
@@ -154,19 +138,11 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:id="@+id/staEnabled"
+            android:text="@string/sta"
             app:layout_constraintStart_toStartOf="@+id/defEnabled"
             app:layout_constraintTop_toBottomOf="@+id/defEnabled"
             android:layout_marginBottom="4dp"
             app:layout_constraintBottom_toBottomOf="parent"/>
-        <TextView
-            android:text="@string/sta"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/staHeader"
-            app:layout_constraintStart_toEndOf="@+id/staEnabled"
-            android:layout_marginStart="8dp"
-            app:layout_constraintBottom_toBottomOf="@+id/staEnabled"
-            app:layout_constraintTop_toTopOf="@+id/staEnabled"/>
         <SeekBar
             android:layout_width="0dp"
             android:layout_height="match_parent"
@@ -174,8 +150,8 @@
             android:layout_weight="1"
             app:layout_constraintStart_toStartOf="@+id/defSeek"
             android:layout_marginEnd="8dp"
-            app:layout_constraintTop_toTopOf="@+id/staHeader"
-            app:layout_constraintBottom_toBottomOf="@+id/staHeader"
+            app:layout_constraintTop_toTopOf="@+id/staEnabled"
+            app:layout_constraintBottom_toBottomOf="@+id/staEnabled"
             android:max="15"
             app:layout_constraintEnd_toStartOf="@+id/staValue"/>
         <TextView


### PR DESCRIPTION
Primarily it does fix the issue that the size of the appraisal box is not fixed to the relations of the screen. So it now does measure the box by scanning the white lines.

Additionally this also contains a few improvements like:

- Don't disable the seekbars
- Check the checkbox when using the seekbars
- Only highlight it while actually scanning
- Actually count the number of retries, so that it could actually "cancel" an appraisal